### PR TITLE
Fix warnings related to premature use of #[must_use] on functions

### DIFF
--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -13,7 +13,6 @@ use core;
 static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17i32) as (usize);
 
 // returns number of commands inserted
-#[must_use]
 fn EmitInsertLen(insertlen: u32, mut commands: &mut &mut [u32]) -> usize {
   if insertlen < 6u32 {
     (*commands)[0] = insertlen;
@@ -44,7 +43,7 @@ fn EmitInsertLen(insertlen: u32, mut commands: &mut &mut [u32]) -> usize {
   core::mem::replace(commands, &mut remainder[1..]);
   1
 }
-#[must_use]
+
 fn EmitDistance(distance: u32, mut commands: &mut &mut [u32]) -> usize {
   let d: u32 = distance.wrapping_add(3u32);
   let nbits: u32 = Log2FloorNonZero(d as (u64)).wrapping_sub(1u32);
@@ -59,7 +58,6 @@ fn EmitDistance(distance: u32, mut commands: &mut &mut [u32]) -> usize {
   1
 }
 
-#[must_use]
 fn EmitCopyLenLastDistance(copylen: usize, mut commands: &mut &mut [u32]) -> usize {
   if copylen < 12usize {
     (*commands)[0] = copylen.wrapping_add(20usize) as (u32);
@@ -119,7 +117,6 @@ fn HashBytesAtOffset(v: u64, offset: i32, shift: usize) -> u32 {
   }
 }
 
-#[must_use]
 fn EmitCopyLen(copylen: usize, mut commands: &mut &mut [u32]) -> usize {
   if copylen < 10usize {
     (*commands)[0] = copylen.wrapping_add(38usize) as (u32);


### PR DESCRIPTION
```
warning: `#[must_use]` on functions is experimental (see issue #43302)
  --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-1.0.8/src/enc/compress_fragment_two_pass.rs:16:1
   |
16 | #[must_use]
   | ^^^^^^^^^^^
   |
   = help: add #![feature(fn_must_use)] to the crate attributes to enable

warning: `#[must_use]` on functions is experimental (see issue #43302)
  --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-1.0.8/src/enc/compress_fragment_two_pass.rs:47:1
   |
47 | #[must_use]
   | ^^^^^^^^^^^
   |
   = help: add #![feature(fn_must_use)] to the crate attributes to enable

warning: `#[must_use]` on functions is experimental (see issue #43302)
  --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-1.0.8/src/enc/compress_fragment_two_pass.rs:62:1
   |
62 | #[must_use]
   | ^^^^^^^^^^^
   |
   = help: add #![feature(fn_must_use)] to the crate attributes to enable

warning: `#[must_use]` on functions is experimental (see issue #43302)
   --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/brotli-1.0.8/src/enc/compress_fragment_two_pass.rs:122:1
    |
122 | #[must_use]
    | ^^^^^^^^^^^
    |
    = help: add #![feature(fn_must_use)] to the crate attributes to enable
```