### PR TITLE
fix of BrotliCompress example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let mut writer = brotli::Compressor::new(&mut io::stdout(), 4096 /* buffer size 
 ### With the Stream Copy abstraction
 
 ```rust
-match brotli::BrotliCompress(&mut io::stdin(), &mut io::stdout(), quality as u32, lg_window_size as u32) {
+match brotli::BrotliCompress(&mut io::stdin(), &mut io::stdout(), &brotli_encoder_params) {
     Ok(_) => {},
     Err(e) => panic!("Error {:?}", e),
 }


### PR DESCRIPTION
I noticed one of my applications wasn't compiling any longer after updating from brotli 1.0.8 to 2.3. I'm using the stream copy abstraction, and as such came back to the example in the README. Since the compiler told me that it now expects three instead of the four parameters given, the README seemed out of date. After I found the necessary fixes to my code to make in the source-code, I found it necessary to inform other developers of the change through the README.

While the example could still benefit from a more detailed explanation, at least now it is not incorrect.