### PR TITLE
Add function with_params to CompressorReader and CompressorWriter. Fix #22.

### DIFF
--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -7,6 +7,7 @@ use super::hash_to_binary_tree::ZopfliNode;
 use super::encode::{BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
                     BrotliEncoderParameter, BrotliEncoderSetParameter, BrotliEncoderOperation,
                     BrotliEncoderStateStruct, BrotliEncoderCompressStream, BrotliEncoderIsFinished};
+use super::backward_references::BrotliEncoderParams;
 use super::entropy_encode::HuffmanTree;
 use super::histogram::{ContextType, HistogramLiteral, HistogramCommand, HistogramDistance};
 use super::interface;
@@ -213,6 +214,12 @@ impl<R: Read> CompressorReader<R> {
                                                            alloc_zn,
                                                            q,
                                                            lgwin))
+  }
+
+  pub fn with_params(r: R, buffer_size: usize, params: &BrotliEncoderParams) -> Self {
+    let mut reader = Self::new(r, buffer_size, params.quality as u32, params.lgwin as u32);
+    (reader.0).0.state.params = params.clone();
+    reader
   }
 
   pub fn get_ref(&self) -> &R {

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -8,6 +8,7 @@ use super::hash_to_binary_tree::ZopfliNode;
 use super::encode::{BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
                     BrotliEncoderParameter, BrotliEncoderSetParameter, BrotliEncoderOperation,
                     BrotliEncoderStateStruct, BrotliEncoderCompressStream, BrotliEncoderIsFinished};
+use super::backward_references::BrotliEncoderParams;
 use super::entropy_encode::HuffmanTree;
 use super::histogram::{ContextType, HistogramLiteral, HistogramCommand, HistogramDistance};
 use brotli_decompressor::CustomWrite;
@@ -218,6 +219,12 @@ impl<W: Write> CompressorWriter<W> {
                                                            lgwin))
   }
 
+  pub fn with_params(w: W, buffer_size: usize, params: &BrotliEncoderParams) -> Self {
+    let mut writer = Self::new(w, buffer_size, params.quality as u32, params.lgwin as u32);
+    (writer.0).0.state.params = params.clone();
+    writer
+  }
+
   pub fn get_ref(&self) -> &W {
     self.0.get_ref()
   }
@@ -408,9 +415,9 @@ CompressorWriterCustomIo<ErrType, W, BufferType, AllocU8, AllocU16, AllocI32, Al
            if BrotliEncoderIsFinished(&mut self.state) != 0 {
               return Ok(());
            }
-        }        
+        }
     }
-    
+
     pub fn get_ref(&self) -> &W {
       &self.output
     }


### PR DESCRIPTION
This pull request adds a function `with_params` to `CompressionReader` and `CompressionWriter` in order to be able to choose more parameters than quality and lgwin when using these structs, like when using `BrotliCompress`.

Fix #22.

Regards.