### PR TITLE
Cargo.toml: pointing to the extracted doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.1.8"
 authors = ["Daniel Reiter Horn <danielrh@dropbox.com>", "The Brotli Authors"]
 description = "A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe."
 license = "BSD-3-Clause/MIT"
-documentation = "https://github.com/dropbox/rust-brotli/blob/master/README.md"
+documentation = "https://docs.rs/brotli/"
 homepage = "https://github.com/dropbox/rust-brotli"
 repository = "https://github.com/dropbox/rust-brotli"
 keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]


### PR DESCRIPTION
Pointing twice to `README.md` doesn't seem necessary.

Of course, this means that the extracted doc needs to be documented :)