### PR TITLE
Fix q9 compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brotli"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["Daniel Reiter Horn <danielrh@dropbox.com>", "The Brotli Authors"]
 description = "A brotli compressor and decompressor that with an interface avoiding the rust stdlib. This makes it suitable for embedded devices and kernels. It is designed with a pluggable allocator so that the standard lib's allocator may be employed. The default build also includes a stdlib allocator and stream interface. Disable this with --features=no-stdlib. All included code is safe."
 license = "BSD-3-Clause/MIT"

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -21,7 +21,7 @@ fn main() {
                     if let io::ErrorKind::Interrupted = e.kind() {
                         continue;
                     }
-                    panic!(e);
+                    panic!("{}", e);
                 }
                 Ok(size) => {
                     if size == 0 {
@@ -30,13 +30,13 @@ fn main() {
                                 if let io::ErrorKind::Interrupted = e.kind() {
                                     continue;
                                 }
-                                panic!(e)
+                                panic!("{}", e)
                             }
                             Ok(_) => break,
                         }
                     }
                     match writer.write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
+                        Err(e) => panic!("{}", e),
                         Ok(_) => {},
                     }
                 }

--- a/examples/decompress.rs
+++ b/examples/decompress.rs
@@ -20,14 +20,14 @@ fn main() {
                     if let io::ErrorKind::Interrupted = e.kind() {
                         continue;
                     }
-                    panic!(e);
+                    panic!("{}", e);
                 }
                 Ok(size) => {
                     if size == 0 {
                         break;
                     }
                     match io::stdout().write_all(&buf[..size]) {
-                        Err(e) => panic!(e),
+                        Err(e) => panic!("{}", e),
                         Ok(_) => {},
                     }
                 }

--- a/src/bin/catbrotli.rs
+++ b/src/bin/catbrotli.rs
@@ -89,7 +89,7 @@ fn main() {
         loop {
             ioffset = 0;
             match read_no_interrupt(&mut input_file, &mut ibuffer[..]) {
-                Err(e) => panic!(e),
+                Err(e) => panic!("{}", e),
                 Ok(cur_read) => {
                     if cur_read == 0 {
                         break;
@@ -142,7 +142,7 @@ fn main() {
                 break;
             }
             failure => {
-                panic!(failure)
+                panic!("{:?}", failure)
             }
         }
     }

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -143,12 +143,12 @@ fn decompress_internal<InputType, OutputType, Run: Runner>(r: &mut InputType,
             Err(e) => {
               match e.kind() {
                 io::ErrorKind::Interrupted => continue,
-                _ => panic!(e),
+                _ => panic!("{}", e),
               }
             }
             Ok(size) => {
               if size == 0 {
-                panic!(io::Error::new(io::ErrorKind::UnexpectedEof, "Read EOF"));
+                panic!("{:?}", io::Error::new(io::ErrorKind::UnexpectedEof, "Read EOF"));
               }
               available_in = size;
             }

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -385,7 +385,7 @@ fn test_random_then_unicode_9() {
     roundtrip_helper(RANDOM_THEN_UNICODE, 9, 22, false);
 }
 #[cfg(feature="std")]
-const random_then_unicode_compressed_size_9_5 : usize = 136563;
+const random_then_unicode_compressed_size_9_5 : usize = 136542;
 #[cfg(feature="std")]
 const random_then_unicode_compressed_size_9_5x : usize = 136045;
 

--- a/src/bin/test_broccoli.rs
+++ b/src/bin/test_broccoli.rs
@@ -40,7 +40,7 @@ fn concat(files:&mut [UnlimitedBuffer],
           loop {
             ioffset = 0;
             match input.read(&mut ibuffer[..]) {
-              Err(e) => panic!(e),
+              Err(e) => panic!("{}", e),
               Ok(cur_read) => {
                 if cur_read == 0 {
                   break;
@@ -62,7 +62,7 @@ fn concat(files:&mut [UnlimitedBuffer],
                       panic!("Unexpected state: Success when streaming before finish");
                     },
                     failure => {
-                      panic!(failure);
+                      panic!("{:?}", failure);
                     },
                   }
                 }
@@ -94,7 +94,7 @@ fn concat(files:&mut [UnlimitedBuffer],
           break;
         }
         failure => {
-          panic!(failure)
+          panic!("{:?}", failure)
         }
       }
     }

--- a/src/bin/test_custom_dict.rs
+++ b/src/bin/test_custom_dict.rs
@@ -113,11 +113,11 @@ fn test_custom_dict_for_multithreading() {
     for brotli in brs.iter_mut() {
         brotli.reset_read();
         bro_cat_li.new_brotli_file();
-        let mut input = brotli;
+        let input = brotli;
         loop {
             let mut ioffset = 0usize;
             match input.read(&mut ibuffer[..]) {
-                Err(e) => panic!(e),
+                Err(e) => panic!("{:?}", e),
                 Ok(cur_read) => {
                     if cur_read == 0 {
                         break;
@@ -139,7 +139,7 @@ fn test_custom_dict_for_multithreading() {
                                 panic!("Unexpected state: Success when streaming before finish");
                             },
                             failure => {
-                                panic!(failure);
+                                panic!("{:?}", failure);
                             },
                         }
                     }
@@ -169,7 +169,7 @@ fn test_custom_dict_for_multithreading() {
                 break;
             }
             failure => {
-                panic!(failure)
+                panic!("{}", failure as i32)
             }
         }
     }

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -32,7 +32,9 @@ struct HexSlice<'a>(&'a [u8]);
 impl<'a> fmt::Display for HexSlice<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0 {
-            try!(write!(f, "{:02X}", byte));
+            if let Err(e) = write!(f, "{:02X}", byte) {
+                return Err(e);
+            }
         }
         Ok(())
     }
@@ -83,7 +85,9 @@ struct SliceU8Ref<'a>(pub &'a[u8]);
 impl<'a> fmt::LowerHex for SliceU8Ref<'a> {
     fn fmt(&self, fmtr: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for item in self.0 {
-            try!( fmtr.write_fmt(format_args!("{:02x}", item)));
+            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -2,7 +2,6 @@ use core;
 
 #[repr(C)]
 #[derive(Debug,Clone,Copy, PartialEq)]
-#[no_mangle]
 pub enum BroCatliResult {
   Success = 0,
   NeedsMoreInput = 1,

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -566,6 +566,22 @@ impl H9Opts {
    }
 }
 
+pub struct H9<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> {
+    pub num_:<Alloc as Allocator<u16>>::AllocatedMemory,//[u16;1 << H9_BUCKET_BITS],
+    pub buckets_:<Alloc as Allocator<u32>>::AllocatedMemory,//[u32; H9_BLOCK_SIZE << H9_BUCKET_BITS],
+    pub dict_search_stats_:Struct1,
+    pub h9_opts: H9Opts,
+}
+
+impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> PartialEq<H9<Alloc>> for H9<Alloc> {
+    fn eq(&self, other: &H9<Alloc>) -> bool {
+        self.dict_search_stats_ == other.dict_search_stats_
+            && self.num_.slice() == other.num_.slice()
+            && self.buckets_.slice() == other.buckets_.slice()
+            && self.h9_opts == other.h9_opts
+    }
+}
+
 fn adv_prepare_distance_cache(distance_cache: &mut [i32], num_distances: i32) {
         if num_distances > 4i32 {
             let last_distance: i32 = distance_cache[(0usize)];
@@ -637,6 +653,205 @@ const kDistanceShortCodeCost : [u32;16] = [
   BROTLI_SCORE_BASE - 125,
   BROTLI_SCORE_BASE - 125
 ];
+
+fn BackwardReferenceScoreH9(copy_length: usize,
+                            backward_reference_offset: usize,
+                            h9_opts: H9Opts) -> u64 {
+    (u64::from(BROTLI_SCORE_BASE).wrapping_add((h9_opts.literal_byte_score as u64).wrapping_mul(copy_length as u64)).wrapping_sub(
+        (BROTLI_DISTANCE_BIT_PENALTY as u64).wrapping_mul(Log2FloorNonZero(backward_reference_offset as u64) as u64))) >> 2
+}
+
+fn BackwardReferenceScoreUsingLastDistanceH9(
+    copy_length : usize, distance_short_code : usize,
+    h9_opts: H9Opts) -> u64 {
+  ((h9_opts.literal_byte_score as u64).wrapping_mul(copy_length as u64).wrapping_add(
+      u64::from(kDistanceShortCodeCost[distance_short_code]))) >> 2
+}
+
+impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Alloc> {
+  #[inline(always)]
+    fn Opts(&self) -> H9Opts {
+       self.h9_opts
+    }
+  #[inline(always)]
+    fn GetHasherCommon(&mut self) -> &mut Struct1 {
+        return &mut self.dict_search_stats_;
+    }
+  #[inline(always)]
+    fn HashBytes(&self, data: &[u8]) -> usize {
+        let h: u32 = BROTLI_UNALIGNED_LOAD32(data).wrapping_mul(kHashMul32);
+        let thirty_two : usize = 32;
+        (h >> (thirty_two.wrapping_sub(H9_BUCKET_BITS))) as usize
+    }
+  #[inline(always)]
+    fn HashTypeLength(&self) -> usize {
+        4
+    }
+  #[inline(always)]
+    fn StoreLookahead(&self) -> usize {
+        4
+    }
+    fn PrepareDistanceCache(&self, distance_cache: &mut [i32]) {
+        let num_distances = H9_NUM_LAST_DISTANCES_TO_CHECK as i32;
+        adv_prepare_distance_cache(distance_cache, num_distances);
+    }
+    fn FindLongestMatch(&mut self,
+                        dictionary: Option<&BrotliDictionary>,
+                        dictionary_hash: &[u16],
+                        data: &[u8],
+                        ring_buffer_mask: usize,
+                        distance_cache: &[i32],
+                        cur_ix: usize,
+                        max_length: usize,
+                        max_backward: usize,
+                        gap: usize,
+                        max_distance: usize,
+                        out: &mut HasherSearchResult)
+                        -> bool {
+        let best_len_in: usize = (*out).len;
+        let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
+        let mut best_score: u64 = (*out).score;
+        let mut best_len: usize = best_len_in;
+        let mut is_match_found: i32 = 0i32;
+        (*out).len_x_code = 0usize;
+        for i in 0..H9_NUM_LAST_DISTANCES_TO_CHECK {
+            let idx = kDistanceCacheIndex[i] as usize;
+            let backward = (distance_cache[idx] as usize).wrapping_add(kDistanceCacheOffset[i] as usize);
+            let mut prev_ix = cur_ix.wrapping_sub(backward);
+            if prev_ix >= cur_ix {
+                continue;
+            }
+            if backward > max_backward {
+                continue;
+            }
+            prev_ix &= ring_buffer_mask;
+            if cur_ix_masked.wrapping_add(best_len) > ring_buffer_mask ||
+                prev_ix.wrapping_add(best_len) > ring_buffer_mask ||
+                data[cur_ix_masked.wrapping_add(best_len)] != data[prev_ix.wrapping_add(best_len)] {
+                continue;
+            }
+            {
+                let len: usize = FindMatchLengthWithLimit(&data[(prev_ix as (usize))..],
+                                                          &data[(cur_ix_masked as (usize))..],
+                                                          max_length);
+                if len >= 3 || (len == 2 && i < 2) {
+                    let score = BackwardReferenceScoreUsingLastDistanceH9(len, i, self.h9_opts);
+                    if best_score < score {
+                        best_score = score;
+                        best_len = len;
+                        out.len = best_len;
+                        out.distance = backward;
+                        out.score = best_score;
+                        is_match_found = 1i32;
+                    }
+                }
+            }
+        }
+        if max_length >= 4 && cur_ix_masked.wrapping_add(best_len) <= ring_buffer_mask {
+            let key = self.HashBytes(&data.split_at(cur_ix_masked).1);
+            let bucket = &mut self.buckets_.slice_mut().split_at_mut(key << H9_BLOCK_BITS).1.split_at_mut(H9_BLOCK_SIZE).0;
+            assert!(bucket.len() > H9_BLOCK_MASK);
+            assert_eq!(bucket.len(), H9_BLOCK_MASK + 1);
+            let self_num_key = &mut self.num_.slice_mut()[key];
+            let down = if *self_num_key > H9_BLOCK_SIZE as u16 {
+                (*self_num_key as usize) - H9_BLOCK_SIZE
+            } else {0usize};
+            let mut i: usize = *self_num_key as usize;
+            let mut prev_best_val = data[cur_ix_masked.wrapping_add(best_len)];
+            while i > down {
+                i -= 1;
+                let mut prev_ix = bucket[i & H9_BLOCK_MASK] as usize;
+                let backward = cur_ix.wrapping_sub(prev_ix) as usize;
+                if (backward > max_backward) {
+                    break;
+                }
+                prev_ix &= ring_buffer_mask;
+                if (prev_ix.wrapping_add(best_len) > ring_buffer_mask ||
+                    prev_best_val != data[prev_ix.wrapping_add(best_len) as usize]) {
+                    continue;
+                }
+                {
+                    let len = FindMatchLengthWithLimit(&data.split_at(prev_ix).1,
+                                                       &data.split_at((cur_ix_masked as usize)).1,
+                                                       max_length);
+                    if (len >= 4) {
+                        /* Comparing for >= 3 does not change the semantics, but just saves
+                        for a few unnecessary binary logarithms in backward reference
+                        score, since we are not interested in such short matches. */
+                        let score = BackwardReferenceScoreH9(len, backward, self.h9_opts);
+                        if (best_score < score) {
+                            best_score = score;
+                            best_len = len;
+                            out.len = best_len;
+                            out.distance = backward;
+                            out.score = best_score;
+                            is_match_found = 1;
+                            if cur_ix_masked.wrapping_add(best_len) > ring_buffer_mask {
+                                break
+                            }
+                            prev_best_val = data[cur_ix_masked.wrapping_add(best_len) as usize];
+                        }
+                    }
+                }
+            }
+            bucket[*self_num_key as usize & H9_BLOCK_MASK] = cur_ix as u32;
+            *self_num_key = self_num_key.wrapping_add(1);
+        }
+        if is_match_found == 0 && dictionary.is_some() {
+            let (_, cur_data) = data.split_at(cur_ix_masked as usize);
+            is_match_found = SearchInStaticDictionary(dictionary.unwrap(),
+                                                      dictionary_hash,
+                                                      self,
+                                                      cur_data,
+                                                      max_length,
+                                                      max_backward.wrapping_add(gap),
+                                                      max_distance,
+                                                      out,
+                                                      0i32);
+        }
+        is_match_found != 0
+    }
+
+    fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
+        let (_, data_window) = data.split_at((ix & mask) as (usize));
+        let key: u32 = self.HashBytes(data_window) as u32;
+        let self_num_key = &mut self.num_.slice_mut()[key as usize];
+        let minor_ix: usize = (*self_num_key as usize & H9_BLOCK_MASK);
+        self.buckets_.slice_mut()[minor_ix.wrapping_add((key as usize) << H9_BLOCK_BITS)] = ix as u32;
+        *self_num_key = self_num_key.wrapping_add(1);
+    }
+    fn StoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
+        for i in ix_start..ix_end {
+            self.Store(data, mask, i);
+        }
+    }
+    fn BulkStoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
+        for i in ix_start..ix_end {
+            self.Store(data, mask, i);
+        }
+    }
+    fn Prepare(&mut self, _one_shot: bool, _input_size:usize, _data:&[u8]) ->HowPrepared {
+        if self.GetHasherCommon().is_prepared_ != 0 {
+            return HowPrepared::ALREADY_PREPARED;
+        }
+        for item in self.num_.slice_mut().iter_mut() {
+            *item =0;
+        }
+        self.GetHasherCommon().is_prepared_ = 1;
+        HowPrepared::NEWLY_PREPARED
+    }
+    fn StitchToPreviousBlock(&mut self,
+                             num_bytes: usize,
+                             position: usize,
+                             ringbuffer: &[u8],
+                             ringbuffer_mask: usize) {
+        StitchToPreviousBlockInternal(self,
+                                      num_bytes,
+                                      position,
+                                      ringbuffer,
+                                      ringbuffer_mask)
+    }
+}
 
 pub trait AdvHashSpecialization : PartialEq<Self>{
   #[inline(always)]
@@ -754,54 +969,6 @@ impl AdvHashSpecialization for HQ7Sub {
   #[inline(always)]
   fn block_mask(&self) -> u32 {
     (1 << 6) - 1
-  }
-  #[inline(always)]
-  fn get_hash_mask(&self) -> u64 {
-    //return 0xffffffffffffffffu64;
-    return 0xffffffffu64; // make it 32 bit
-  }
-  #[inline(always)]
-  fn get_k_hash_mul(&self) -> u64 {
-    return kHashMul32 as u64;
-  }
-  #[inline(always)]
-  fn load_and_mix_word(&self, data: &[u8]) -> u64 {
-    return (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul()) & self.get_hash_mask();
-  }
-  #[inline(always)]
-  fn set_hash_mask(&mut self, _params_hash_len: i32) {}
-  fn HashTypeLength(&self) -> usize {
-    4
-  }
-  #[inline(always)]
-  fn StoreLookahead(&self) -> usize {
-    4
-  }
-}
-
-
-#[derive(Clone, PartialEq)]
-pub struct H9Sub {}
-impl AdvHashSpecialization for H9Sub {
-  #[inline(always)]
-  fn hash_shift(&self) -> i32 {
-    32i32 - 15 // 32 - bucket_bits
-  }
-  #[inline(always)]
-  fn bucket_size(&self) -> u32 {
-    1 << 15
-  }
-  #[inline(always)]
-  fn block_bits(&self) -> i32 {
-    8
-  }
-  #[inline(always)]
-  fn block_size(&self) -> u32 {
-    1 << 8
-  }
-  #[inline(always)]
-  fn block_mask(&self) -> u32 {
-    (1 << 8) - 1
   }
   #[inline(always)]
   fn get_hash_mask(&self) -> u64 {
@@ -1357,8 +1524,9 @@ impl<Specialization: AdvHashSpecialization + Clone, Alloc: alloc::Allocator<u16>
     let mut i: usize;
     (*out).len = 0usize;
     (*out).len_x_code = 0usize;
+    i = 0usize;
     let cur_data = data.split_at(cur_ix_masked).1;
-    for i in 0..self.GetHasherCommon.params.num_last_distances_to_check as (usize) {
+    while i < self.GetHasherCommon.params.num_last_distances_to_check as (usize) {
       'continue45: loop {
         {
           let backward: usize = distance_cache[(i as (usize))] as (usize);
@@ -1377,7 +1545,7 @@ impl<Specialization: AdvHashSpecialization + Clone, Alloc: alloc::Allocator<u16>
           let prev_data = data.split_at(prev_ix).1;
           
           let len: usize = FindMatchLengthWithLimit(&prev_data,
-                                                    cur_data,
+                                                    &cur_data,
                                                     max_length);
           if len >= 3usize || len == 2usize && (i < 2usize) {
             let mut score: u64 = BackwardReferenceScoreUsingLastDistance(len, opts);
@@ -1398,6 +1566,7 @@ impl<Specialization: AdvHashSpecialization + Clone, Alloc: alloc::Allocator<u16>
         }
         break;
       }
+      i = i.wrapping_add(1 as (usize));
     }
     {
       let key: u32 = self.HashBytes(cur_data) as u32;
@@ -1694,6 +1863,20 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
       ret
   }    
 }
+impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc> for H9<Alloc> {
+  fn clone_with_alloc(&self, m: &mut Alloc) -> Self {
+      let mut num = <Alloc as Allocator<u16>>::alloc_cell(m, self.num_.len());
+      num.slice_mut().clone_from_slice(self.num_.slice());
+      let mut buckets = <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.len());
+      buckets.slice_mut().clone_from_slice(self.buckets_.slice());
+      H9::<Alloc> {
+          num_:num,
+          buckets_:buckets,
+          dict_search_stats_: self.dict_search_stats_.clone(),
+          h9_opts: self.h9_opts.clone(),
+      }
+  }
+}
 impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>,
      Special: AdvHashSpecialization+Sized+Clone,> CloneWithAlloc<Alloc> for AdvHasher<Special, Alloc> {
   fn clone_with_alloc(&self, m: &mut Alloc) -> Self {
@@ -1721,7 +1904,7 @@ pub enum UnionHasher<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> {
   H5q7(AdvHasher<HQ7Sub, Alloc>),
   H5q5(AdvHasher<HQ5Sub, Alloc>),
   H6(AdvHasher<H6Sub, Alloc>),
-  H9(AdvHasher<H9Sub, Alloc>),
+  H9(H9<Alloc>),
   H10(H10<Alloc, H10Buckets<Alloc>, H10DefaultParams>),
 }
 impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> PartialEq<UnionHasher<Alloc>> for UnionHasher<Alloc> {
@@ -1933,8 +2116,8 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> UnionHasher<Alloc> {
         <Alloc as Allocator<u32>>::free_cell(alloc, core::mem::replace(&mut hasher.buckets, <Alloc as Allocator<u32>>::AllocatedMemory::default()));
       }
       &mut UnionHasher::H9(ref mut hasher) => {
-        <Alloc as Allocator<u16>>::free_cell(alloc,core::mem::replace(&mut hasher.num, <Alloc as Allocator<u16>>::AllocatedMemory::default()));
-        <Alloc as Allocator<u32>>::free_cell(alloc, core::mem::replace(&mut hasher.buckets, <Alloc as Allocator<u32>>::AllocatedMemory::default()));
+        <Alloc as Allocator<u16>>::free_cell(alloc,core::mem::replace(&mut hasher.num_, <Alloc as Allocator<u16>>::AllocatedMemory::default()));
+        <Alloc as Allocator<u32>>::free_cell(alloc, core::mem::replace(&mut hasher.buckets_, <Alloc as Allocator<u32>>::AllocatedMemory::default()));
       }
       &mut UnionHasher::H10(ref mut hasher) => {
         hasher.free(alloc);

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -854,27 +854,16 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
 }
 
 pub trait AdvHashSpecialization : PartialEq<Self>{
-  #[inline(always)]
   fn get_hash_mask(&self) -> u64;
-  #[inline(always)]
   fn set_hash_mask(&mut self, params_hash_len: i32);
-  #[inline(always)]
   fn get_k_hash_mul(&self) -> u64;
-  #[inline(always)]
   fn HashTypeLength(&self) -> usize;
-  #[inline(always)]
   fn StoreLookahead(&self) -> usize;
-    #[inline(always)]
   fn load_and_mix_word(&self, data: &[u8]) -> u64;
-    #[inline(always)]
   fn hash_shift(&self) -> i32;
-    #[inline(always)]
   fn bucket_size(&self) -> u32;
-    #[inline(always)]
   fn block_mask(&self) -> u32;
-    #[inline(always)]
   fn block_size(&self) -> u32;
-  #[inline(always)]
   fn block_bits(&self) -> i32;
 }
 pub struct AdvHasher<Specialization: AdvHashSpecialization + Sized + Clone,

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -197,7 +197,7 @@ fn CostComputation<T:SliceWrapper<Mem256i> >(depth_histo: &mut [u32;BROTLI_CODE_
       let cur = cumulative_sum[(j&8) >> 3].extract(j & 7);
       let delta = cur - prev;
       prev = cur;
-      let mut cur = &mut depth_histo[j];
+      let cur = &mut depth_histo[j];
       *cur = (*cur as i32 + delta) as u32; // depth_histo[j] += delta
       if delta != 0 {
          max_depth = j;

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -317,7 +317,7 @@ fn FindBlocks<HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> + CostAcce
   }
   for (byte_ix, data_byte_ix) in data[..length].iter().enumerate() {
     {
-      let mut block_id_ptr = &mut block_id[byte_ix];
+      let block_id_ptr = &mut block_id[byte_ix];
       let ix: usize = byte_ix.wrapping_mul(bitmaplen);
       let insert_cost_ix: usize = u64::from(data_byte_ix.clone())
         .wrapping_mul(num_histograms as u64) as usize;

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -40,7 +40,7 @@ fn EmitInsertLen(insertlen: u32, commands: &mut &mut [u32]) -> usize {
     (*commands)[0] = 23u32 | extra << 8i32;
   }
   let remainder = core::mem::replace(commands, &mut []);
-  core::mem::replace(commands, &mut remainder[1..]);
+  let _ = core::mem::replace(commands, &mut remainder[1..]);
   1
 }
 
@@ -54,7 +54,7 @@ fn EmitDistance(distance: u32, commands: &mut &mut [u32]) -> usize {
   let extra: u32 = d.wrapping_sub(offset);
   (*commands)[0] = distcode | extra << 8i32;
   let remainder = core::mem::replace(commands, &mut []);
-  core::mem::replace(commands, &mut remainder[1..]);
+  let _ = core::mem::replace(commands, &mut remainder[1..]);
   1
 }
 
@@ -62,7 +62,7 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
   if copylen < 12usize {
     (*commands)[0] = copylen.wrapping_add(20usize) as (u32);
     let remainder = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder[1..]);
+    let _ = core::mem::replace(commands, &mut remainder[1..]);
     1
   } else if copylen < 72usize {
     let tail: usize = copylen.wrapping_sub(8usize);
@@ -72,7 +72,7 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
     let extra: usize = tail.wrapping_sub(prefix << nbits);
     (*commands)[0] = (code | extra << 8i32) as (u32);
     let remainder = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder[1..]);
+    let _ = core::mem::replace(commands, &mut remainder[1..]);
     1
   } else if copylen < 136usize {
     let tail: usize = copylen.wrapping_sub(8usize);
@@ -80,10 +80,10 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
     let extra: usize = tail & 31usize;
     (*commands)[0] = (code | extra << 8i32) as (u32);
     let remainder = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder[1..]);
+    let _ = core::mem::replace(commands, &mut remainder[1..]);
     (*commands)[0] = 64u32;
     let remainder2 = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder2[1..]);
+    let _ = core::mem::replace(commands, &mut remainder2[1..]);
     2
   } else if copylen < 2120usize {
     let tail: usize = copylen.wrapping_sub(72usize);
@@ -92,19 +92,19 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
     let extra: usize = tail.wrapping_sub(1usize << nbits);
     (*commands)[0] = (code | extra << 8i32) as (u32);
     let remainder = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder[1..]);
+    let _ = core::mem::replace(commands, &mut remainder[1..]);
     (*commands)[0] = 64u32;
     let remainder2 = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder2[1..]);
+    let _ = core::mem::replace(commands, &mut remainder2[1..]);
     2
   } else {
     let extra: usize = copylen.wrapping_sub(2120usize);
     (*commands)[0] = (63usize | extra << 8i32) as (u32);
     let remainder = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder[1..]);
+    let _ = core::mem::replace(commands, &mut remainder[1..]);
     (*commands)[0] = 64u32;
     let remainder2 = core::mem::replace(commands, &mut []);
-    core::mem::replace(commands, &mut remainder2[1..]);
+    let _ = core::mem::replace(commands, &mut remainder2[1..]);
     2
   }
 }
@@ -138,7 +138,7 @@ fn EmitCopyLen(copylen: usize, commands: &mut &mut [u32]) -> usize {
     (*commands)[0] = (63usize | extra << 8i32) as (u32);
   }
   let remainder = core::mem::replace(commands, &mut []);
-  core::mem::replace(commands, &mut remainder[1..]);
+  let _ = core::mem::replace(commands, &mut remainder[1..]);
   1
 }
 fn Hash(p: &[u8], shift: usize, length:usize) -> u32 {
@@ -268,11 +268,11 @@ fn CreateCommands(input_index: usize,
                                                              insert as usize))]);
         *num_literals += insert as usize;
         let new_literals = core::mem::replace(literals, &mut []);
-        core::mem::replace(literals, &mut new_literals[(insert as usize)..]);
+        let _ = core::mem::replace(literals, &mut new_literals[(insert as usize)..]);
         if distance == last_distance {
           (*commands)[0] = 64u32;
           let remainder = core::mem::replace(commands, &mut []);
-          core::mem::replace(commands, &mut remainder[1..]);
+          let _ = core::mem::replace(commands, &mut remainder[1..]);
           *num_commands += 1;
         } else {
           *num_commands += EmitDistance(distance as (u32), commands);

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -5,7 +5,7 @@ use super::constants::{BROTLI_WINDOW_GAP, BROTLI_CONTEXT_LUT, BROTLI_CONTEXT,
 use super::backward_references::{BrotliCreateBackwardReferences, Struct1, UnionHasher,
                                  BrotliEncoderParams, BrotliEncoderMode, BrotliHasherParams, H2Sub,
                                  H3Sub, H4Sub, H5Sub, H6Sub, H54Sub, HQ5Sub, HQ7Sub, AdvHasher, BasicHasher, H9Sub,
-                                 H9_BUCKET_BITS, H9_BLOCK_BITS, H9_NUM_LAST_DISTANCES_TO_CHECK,
+                                 H9_BUCKET_BITS, H9_BLOCK_SIZE, H9_BLOCK_BITS, H9_NUM_LAST_DISTANCES_TO_CHECK,
                                  AnyHasher, HowPrepared, StoreLookaheadThenStore, AdvHashSpecialization};
 use alloc::Allocator;
 pub use super::parameters::BrotliEncoderParameter;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -758,7 +758,7 @@ fn RingBufferInitBuffer<AllocU8: alloc::Allocator<u8>>(m: &mut AllocU8,
     new_data.slice_mut()[..lim].clone_from_slice(&(*rb).data_mo.slice()[..lim]);
     m.free_cell(core::mem::replace(&mut (*rb).data_mo, AllocU8::AllocatedMemory::default()));
   }
-  core::mem::replace(&mut (*rb).data_mo, new_data);
+  let _ = core::mem::replace(&mut (*rb).data_mo, new_data);
   (*rb).cur_size_ = buflen;
   (*rb).buffer_index = 2usize;
   (*rb).data_mo.slice_mut()[((*rb).buffer_index.wrapping_sub(2usize))] = 0;
@@ -1532,7 +1532,7 @@ pub fn BrotliEncoderCompress<Alloc: BrotliAlloc,
       *encoded_size = total_out.unwrap();
       BrotliEncoderDestroyInstance(s);
     }
-    core::mem::replace(m8, s_orig.m8);
+    let _ = core::mem::replace(m8, s_orig.m8);
     if result == 0 || max_out_size != 0 && (*encoded_size > max_out_size) {
         is_fallback = 1i32;
     } else {

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -4,7 +4,7 @@ use super::constants::{BROTLI_WINDOW_GAP, BROTLI_CONTEXT_LUT, BROTLI_CONTEXT,
                        BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS, BROTLI_MAX_NPOSTFIX, BROTLI_MAX_NDIRECT};
 use super::backward_references::{BrotliCreateBackwardReferences, Struct1, UnionHasher,
                                  BrotliEncoderParams, BrotliEncoderMode, BrotliHasherParams, H2Sub,
-                                 H3Sub, H4Sub, H5Sub, H6Sub, H54Sub, HQ5Sub, HQ7Sub, AdvHasher, BasicHasher, H9Sub,
+                                 H3Sub, H4Sub, H5Sub, H6Sub, H54Sub, HQ5Sub, HQ7Sub, AdvHasher, BasicHasher, H9,
                                  H9_BUCKET_BITS, H9_BLOCK_SIZE, H9_BLOCK_BITS, H9_NUM_LAST_DISTANCES_TO_CHECK,
                                  AnyHasher, HowPrepared, StoreLookaheadThenStore, AdvHashSpecialization};
 use alloc::Allocator;
@@ -981,8 +981,18 @@ fn InitializeH54<AllocU32:alloc::Allocator<u32>>(m32: &mut AllocU32, params : &B
 }
 
 fn InitializeH9<Alloc:alloc::Allocator<u16> + alloc::Allocator<u32>>(m16: &mut Alloc,
-                                                                     params : &BrotliEncoderParams) -> UnionHasher<Alloc> {
-  InitializeH5(m16, params)
+                                                                     params : &BrotliEncoderParams) -> H9<Alloc> {
+    H9 {
+        dict_search_stats_:Struct1{
+            params:params.hasher,
+            is_prepared_:1,
+            dict_num_lookups:0,
+            dict_num_matches:0,
+        },
+        num_:<Alloc as Allocator<u16>>::alloc_cell(m16, 1<<H9_BUCKET_BITS),
+        buckets_:<Alloc as Allocator<u32>>::alloc_cell(m16, H9_BLOCK_SIZE<<H9_BUCKET_BITS),
+        h9_opts: super::backward_references::H9Opts::new(&params.hasher),
+    }
 }
 
 fn InitializeH5<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>
@@ -1020,20 +1030,6 @@ fn InitializeH5<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>
         dict_num_matches: 0,
       },
       specialization: HQ7Sub {}
-    })
-  }
-  if params.hasher.block_bits == (H9Sub{}).block_bits() && (1<<params.hasher.bucket_bits) == (H9Sub{}).bucket_size() {
-    return UnionHasher::H9(AdvHasher {
-      buckets: buckets,
-      h9_opts: super::backward_references::H9Opts::new(&params.hasher),
-      num: num,
-      GetHasherCommon: Struct1 {
-        params: params.hasher,
-        is_prepared_: 1,
-        dict_num_lookups: 0,
-        dict_num_matches: 0,
-      },
-      specialization: H9Sub {}
     })
   }
   UnionHasher::H5(AdvHasher {
@@ -1103,7 +1099,7 @@ fn BrotliMakeHasher<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>
     return InitializeH6(m, params);
   }
   if hasher_type == 9i32 {
-    return InitializeH9(m, params);
+    return UnionHasher::H9(InitializeH9(m, params));
   }
   /*
     if hasher_type == 40i32 {

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -556,7 +556,7 @@ impl<AllocU32:alloc::Allocator<u32> > EntropyTally<AllocU32> {
     }
     fn identify_best_population_and_update_cache(&mut self) -> u8 {
         let mut old_bit_entropy : [floatY; NUM_STRIDES] = [0.0; NUM_STRIDES];
-        for (mut obe, be) in old_bit_entropy.iter_mut().zip(self.pop.iter_mut()) {
+        for (obe, be) in old_bit_entropy.iter_mut().zip(self.pop.iter_mut()) {
             *obe = be.cached_bit_entropy;
             if *obe != 0.0 {
                 be.cached_bit_entropy = HuffmanCost(be.bucket_populations.slice());

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -98,13 +98,9 @@ impl Default for HistogramDistance {
 pub trait CostAccessors {
   type i32vec : Sized + SliceWrapper<Mem256i>+SliceWrapperMut<Mem256i>;
   fn make_nnz_storage() -> Self::i32vec;
-  #[inline(always)]
   fn total_count(&self) -> usize;
-  #[inline(always)]
   fn bit_cost(&self) -> super::util::floatX;
-  #[inline(always)]
   fn set_bit_cost(&mut self, cost: super::util::floatX);
-  #[inline(always)]
   fn set_total_count(&mut self, count: usize);
 }
 impl SliceWrapper<u32> for HistogramLiteral {
@@ -438,7 +434,7 @@ pub fn HistogramAddHistogram<HistogramType:SliceWrapperMut<u32> + SliceWrapper<u
   let h1 = v.slice();
   let n = min(h0.len(), h1.len());
   for i in 0..n {
-    let mut h0val = &mut h0[i];
+    let h0val = &mut h0[i];
     let val = h0val.wrapping_add(h1[i]);
     *h0val = val;
   }

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -90,10 +90,14 @@ impl<'a> core::ops::Index<usize> for InputPair<'a> {
 impl<'a> core::fmt::LowerHex for InputPair<'a> {
     fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         for item in self.0.data {
-            try!( fmtr.write_fmt(format_args!("{:02x}", item)));
+            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
+                return Err(e)
+            }
         }
         for item in self.1.data {
-            try!( fmtr.write_fmt(format_args!("{:02x}", item)));
+            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/src/enc/parameters.rs
+++ b/src/enc/parameters.rs
@@ -1,4 +1,3 @@
-#[no_mangle]
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[repr(C)]
 pub enum BrotliEncoderParameter {

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -24,7 +24,7 @@ use super::backward_references::{BrotliEncoderParams, UnionHasher, CloneWithAllo
 pub type PoisonedThreadError = ();
 
 #[cfg(feature="std")]
-pub type LowLevelThreadError = std::boxed::Box<any::Any + Send + 'static>;
+pub type LowLevelThreadError = std::boxed::Box<dyn any::Any + Send + 'static>;
 #[cfg(not(feature="std"))]
 pub type LowLevelThreadError = ();
 

--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -12,7 +12,6 @@ pub type BroccoliResult = BroCatliResult;
 // a tool to concatenate brotli files together
 
 #[repr(C)]
-#[no_mangle]
 pub struct BroccoliState {
     more_data: *mut c_void,
     current_data: [u8;120],

--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -5,7 +5,6 @@ use std::{panic,thread, io};
 #[cfg(feature="std")]
 use std::io::Write;
 
-#[no_mangle]
 use core;
 use brotli_decompressor::ffi::alloc_util;
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
@@ -23,7 +22,6 @@ use ::enc::encode::BrotliEncoderStateStruct;
 use super::alloc_util::BrotliSubclassableAllocator;
 
 #[repr(C)]
-#[no_mangle]
 pub enum BrotliEncoderOperation {
   BROTLI_OPERATION_PROCESS = 0,
   BROTLI_OPERATION_FLUSH = 1,
@@ -32,7 +30,6 @@ pub enum BrotliEncoderOperation {
 }
 
 #[repr(C)]
-#[no_mangle]
 pub enum BrotliEncoderMode {
   BROTLI_MODE_GENERIC = 0,
   BROTLI_MODE_TEXT = 1,
@@ -44,7 +41,6 @@ pub enum BrotliEncoderMode {
 }
 
 #[repr(C)]
-#[no_mangle]
 pub struct BrotliEncoderState {
   pub custom_allocator: CAllocator,
   pub compressor: BrotliEncoderStateStruct<BrotliSubclassableAllocator>,

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -4,7 +4,6 @@ use std::{panic,thread, io};
 #[cfg(feature="std")]
 use std::io::Write;
 mod test;
-#[no_mangle]
 use core;
 #[allow(unused_imports)]
 use brotli_decompressor;
@@ -189,7 +188,6 @@ pub unsafe extern fn BrotliEncoderCompressMulti(
   }
 }
 
-#[no_mangle]
 #[repr(C)]
 pub struct BrotliEncoderWorkPool {
   custom_allocator: CAllocator,

--- a/src/ffi/multicompress/test.rs
+++ b/src/ffi/multicompress/test.rs
@@ -39,7 +39,7 @@ fn test_compress_workpool() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{}", ret2 as i32),
   }
   assert_eq!(rt_size, input.len());
   assert_eq!(&rt_buffer[..rt_size], &input[..]);
@@ -82,7 +82,7 @@ fn test_compress_empty_workpool() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{}", ret2 as i32),
   }
   assert_eq!(rt_size, input.len());
   assert_eq!(&rt_buffer[..rt_size], &input[..]);
@@ -122,7 +122,7 @@ fn test_compress_empty_multi_raw() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{}", ret2 as i32),
   }
   assert_eq!(rt_size, input.len());
   assert_eq!(&rt_buffer[..rt_size], &input[..]);
@@ -160,7 +160,7 @@ fn test_compress_null_multi_raw() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{}", ret2 as i32),
   }
   assert_eq!(rt_size, 0);
 }
@@ -202,7 +202,7 @@ fn test_compress_empty_multi_raw_one_thread() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{}", ret2 as i32),
   }
   assert_eq!(rt_size, input.len());
   assert_eq!(&rt_buffer[..rt_size], &input[..]);
@@ -242,7 +242,7 @@ fn test_compress_empty_multi_catable() {
   match ret2 {
     super::super::decompressor::ffi::interface::BrotliDecoderResult::BROTLI_DECODER_RESULT_SUCCESS => {
     },
-    _ => panic!(ret2),
+    _ => panic!("{:?}", ret2 as i32),
   }
   assert_eq!(rt_size, input.len());
   assert_eq!(&rt_buffer[..rt_size], &input[..]);


### PR DESCRIPTION
a recent refactor has reduced compression ratios for q9. This reverts the change and updates the system to remove warnings on new rust versions