### PR TITLE
Switch from packed_simd to packed_simd_2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ incremental=false
 "alloc-no-stdlib" = {version="2.0"}
 "brotli-decompressor" = {version="~2.3", default-features=false}
 "alloc-stdlib" = {version="~0.2", optional=true}
-"packed_simd" = {version="0.3", optional=true}
+"packed_simd_2" = {version="0.3", optional=true}
 "sha2" = {version="~0.8", optional=true}
 
 [features]
@@ -41,6 +41,6 @@ external-literal-probability = []
 disable-timer = ["brotli-decompressor/disable-timer"]
 benchmark = ["brotli-decompressor/benchmark"]
 vector_scratch_space = []
-simd = ["packed_simd/into_bits"]
+simd = ["packed_simd_2/into_bits"]
 pass-through-ffi-panics = []
 ffi-api = []

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -5,7 +5,7 @@ use super::super::alloc::SliceWrapper;
 
 use super::util::{brotli_max_uint32_t, FastLog2, floatX, FastLog2u16};
 #[cfg(feature="simd")]
-use packed_simd::IntoBits;
+use packed_simd_2::IntoBits;
 use super::vectorization::{v256,v256i, Mem256i, sum8, cast_f32_to_i32, cast_i32_to_f32, log2i};
 
 static kCopyBase: [u32; 24] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 22, 30, 38, 54, 70,

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -13,7 +13,7 @@ use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut, Allocator};
 use super::util::{FastLog2, brotli_max_uint8_t, brotli_min_size_t};
 #[cfg(feature="simd")]
-use packed_simd::IntoBits;
+use packed_simd_2::IntoBits;
 use core;
 static kMaxLiteralHistograms: usize = 100usize;
 

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -43,7 +43,7 @@ pub mod multithreading;
 pub mod fixed_queue;
 pub mod worker_pool;
 #[cfg(feature="simd")]
-use packed_simd::{i16x16, f32x8, i32x8};
+use packed_simd_2::{i16x16, f32x8, i32x8};
 #[cfg(feature="simd")]
 pub type s16 = i16x16;
 #[cfg(feature="simd")]

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -9,7 +9,7 @@ use super::util::{floatX, FastLog2u16};
 use super::find_stride;
 use super::{s16, v8};
 #[cfg(feature="simd")]
-use packed_simd::IntoBits;
+use packed_simd_2::IntoBits;
 // the high nibble, followed by the low nibbles
 pub const CONTEXT_MAP_PRIOR_SIZE: usize = 256 * 17;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #[cfg(feature="std")]
 extern crate std;
 #[cfg(feature="simd")]
-extern crate packed_simd;
+extern crate packed_simd_2;
 #[cfg(feature="std")]
 extern crate alloc_stdlib;
 #[allow(unused_imports)]


### PR DESCRIPTION
packed_simd is no longer maintained and does not compile.