### PR TITLE
Fix partial flush on flush_or_close()

### DIFF
--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -2,7 +2,8 @@
 use core;
 use super::encode::{BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
                     BrotliEncoderParameter, BrotliEncoderSetParameter, BrotliEncoderOperation,
-                    BrotliEncoderStateStruct, BrotliEncoderCompressStream, BrotliEncoderIsFinished};
+                    BrotliEncoderStateStruct, BrotliEncoderCompressStream, BrotliEncoderIsFinished,
+                    BrotliEncoderHasMoreOutput};
 use super::backward_references::BrotliEncoderParams;
 use brotli_decompressor::CustomWrite;
 use super::interface;
@@ -207,6 +208,9 @@ CompressorWriterCustomIo<ErrType, W, BufferType, Alloc>
               return Err(self.error_if_invalid_data.take().unwrap());
            }
            if let BrotliEncoderOperation::BROTLI_OPERATION_FLUSH = op {
+              if BrotliEncoderHasMoreOutput(&mut self.state) != 0 {
+                 continue;
+              }
               return Ok(());
            }
            if BrotliEncoderIsFinished(&mut self.state) != 0 {


### PR DESCRIPTION
`BROTLI_OPERATION_FLUSH` must be re-tried until no more data is available as input and internal buffers are empty (this can take more than one call). Otherwise, the writer is left in a "flushing" state which will make further writes fail.

The documentation on how to use `BROTLI_OPERATION_FLUSH` (https://brotli.org/encode.html#aed2 , https://brotli.org/encode.html#a512) mentions the compressor should be called until it has no available input data and `BrotliEncoderHasMoreOutput()` returns false:

```
	Under some circumstances (e.g. lack of output stream capacity) this operation would require several calls to BrotliEncoderCompressStream
	[...]
	Warning
	When flushing and finishing, op should not change until operation is complete; input stream should not be swapped, reduced or extended as well.
```

The current implementation calls `BrotliEncoderCompressStream()` once and always returns Ok(), which may leave the compressor in `BROTLI_OPERATION_FLUSH` state and make future write operations return an Err() (and allow the caller to modify the input stream, leaving room for unexpected compression results).

This patch should fix #73 