### PR TITLE
The -l parsing code is duplicated, remove the one that isn't reachable

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -663,10 +663,6 @@ fn main() {
           buffer_size = argument.trim_matches('-').trim_matches('b').trim_matches('s').trim_matches('=').parse::<usize>().unwrap();
           continue;
       }
-      if argument.starts_with("-l") && !double_dash {
-          params.lgblock = argument.trim_matches('-').trim_matches('l').parse::<i32>().unwrap();
-          continue;
-      }
       if argument.starts_with("-findprior") && !double_dash {
           params.prior_bitmask_detection = 1;
           continue;


### PR DESCRIPTION
This section: https://github.com/dropbox/rust-brotli/blob/master/src/bin/brotli.rs#L638

And this section: https://github.com/dropbox/rust-brotli/blob/master/src/bin/brotli.rs#L666

Are identical (with the exception that one of them uses 2 spaces as indentation, and the other uses 4).

This PR removes the later one.