### PR TITLE
style: reformat Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/brotli/"
 homepage = "https://github.com/dropbox/rust-brotli"
 repository = "https://github.com/dropbox/rust-brotli"
 keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
+categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
 
@@ -15,32 +16,31 @@ autobins = false
 doc = false
 name = "brotli"
 
-
-
 [[bin]]
 doc = false
 name = "catbrotli"
 
 [profile.release]
-lto=true
-incremental=false
+lto = true
+incremental = false
 
 [dependencies]
-"alloc-no-stdlib" = {version="2.0"}
-"brotli-decompressor" = {version="~2.5", default-features=false}
-"alloc-stdlib" = {version="~0.2", optional=true}
-# Uncomment once this packed_simd "packed_simd_2" = {version="0.3", optional=true}
-"sha2" = {version="~0.10", optional=true}
+"alloc-no-stdlib" = { version = "2.0" }
+"alloc-stdlib" = { version = "~0.2", optional = true }
+"brotli-decompressor" = { version = "~2.5", default-features = false }
+"sha2" = { version = "~0.10", optional = true }
+# Uncomment once this packed_simd
+# "packed_simd_2" = {version="0.3", optional=true}
 
 [features]
-default=["std", "ffi-api"]
-validation=["sha2"]
+default = ["std", "ffi-api"]
+benchmark = ["brotli-decompressor/benchmark"]
+disable-timer = ["brotli-decompressor/disable-timer"]
+external-literal-probability = []
+ffi-api = []
+pass-through-ffi-panics = []
 seccomp = ["brotli-decompressor/seccomp"]
 std = ["alloc-stdlib", "brotli-decompressor/std"]
-external-literal-probability = []
-disable-timer = ["brotli-decompressor/disable-timer"]
-benchmark = ["brotli-decompressor/benchmark"]
+validation = ["sha2"]
 vector_scratch_space = []
-#simd = ["packed_simd_2/into_bits"]
-pass-through-ffi-panics = []
-ffi-api = []
+# simd = ["packed_simd_2/into_bits"]

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -8,25 +8,26 @@ documentation = "https://github.com/dropbox/rust-brotli/blob/master/README.md"
 homepage = "https://github.com/dropbox/rust-brotli"
 repository = "https://github.com/dropbox/rust-brotli"
 keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
+categories = ["compression", "no-std", "external-ffi-bindings"]
 readme = "README.md"
 autobins = false
 
 [lib]
-path="src/lib.rs"
-crate-type=["cdylib", "staticlib", "rlib"]
+path = "src/lib.rs"
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [profile.release]
-lto=true
+lto = true
 
 [dependencies]
-"brotli" = {version="~3.3", default-features=false, features=["ffi-api"]}
+"brotli" = { version = "~3.3", default-features = false, features = ["ffi-api"] }
 
 [features]
-validation=["brotli/validation"]
-default=["std"]
-seccomp = ["brotli/seccomp"]
-std = ["brotli/std"]
-disable-timer = ["brotli/disable-timer"]
+default = ["std"]
 benchmark = ["brotli/benchmark"]
-vector_scratch_space = ["brotli/vector_scratch_space"]
+disable-timer = ["brotli/disable-timer"]
+seccomp = ["brotli/seccomp"]
 simd = ["brotli/simd"]
+std = ["brotli/std"]
+validation = ["brotli/validation"]
+vector_scratch_space = ["brotli/vector_scratch_space"]


### PR DESCRIPTION
Cleanup spacing and sorted dependencies in both Cargo.toml.  This is a precursor to upgrading to 2021 edition and many other linting changes