### PR TITLE
chore: .gitignore should exclude lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-target
+.DS_Store
+.idea/
+.vscode/
+Cargo.lock
+target/


### PR DESCRIPTION
Cargo.lock is neither checked in, nor ignored. This excludes it (usually lock is not needed for the libraries). It also excludes common IDEs and silly macOS files.