### PR TITLE
chore: add GitHub CI and justfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,45 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - run: just ci-test
+
+  msrv:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Read crate metadata
+        id: metadata
+        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.metadata.outputs.rust-version }}
+          components: clippy,rustfmt
+      - run: just ci-test-msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions: write-all
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
 categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
+rust-version = "1.56.0"
 
 [[bin]]
 doc = false

--- a/justfile
+++ b/justfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env just --justfile
+
+@_default:
+    just --list --unsorted
+
+# Clean all build artifacts
+clean:
+    cargo clean
+
+# Build everything
+build:
+    RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples
+
+# Run cargo fmt and cargo clippy
+lint: fmt clippy
+
+# Run cargo fmt with optional params
+fmt *ARGS:
+    cargo fmt --all -- {{ ARGS }}
+
+# Run cargo clippy
+clippy:
+    cargo clippy -- -D warnings
+    cargo clippy --workspace --all-targets --bins --tests --lib --benches --examples -- -D warnings
+
+# Build and open code documentation
+docs:
+    cargo doc --no-deps --open
+
+# Test documentation
+test-doc:
+    cargo test --doc
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+# Test using cargo test with optional params
+test *ARGS:
+    cargo test {{ ARGS }}
+
+# Report current versions of rustc, cargo, and other utils
+sys-info:
+    rustc --version
+    cargo --version
+    {{ just_executable() }} --version
+
+# All tests to run for CI
+ci-test: sys-info (fmt "--check") build test test-doc
+# TODO: clippy
+
+# All stable tests to run for CI with the earliest supported Rust version. Assumes the Rust version is already set by rustup.
+ci-test-msrv: sys-info build test


### PR DESCRIPTION
* Add MSRV to Cargo.toml.  This value will go up as the code is cleaned up.  It was computed using `cargo msrv`
* Add justfile with several common recipes
* Use GitHub CI to test everything using latest and MSRV Rust version. CI uses justfile so that it can be tested both in CI and locally.
* Add dependabot configuration and auto-accept

To see what it would look like, I created a PR against my own fork:  https://github.com/nyurik/rust-brotli/pull/1/checks