### PR TITLE
Add GitHub CI automation, MSRV, and `just` recipes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,45 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - run: just ci-test
+
+  msrv:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Read crate metadata
+        id: metadata
+        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.metadata.outputs.rust-version }}
+          components: clippy,rustfmt
+      - run: just ci-test-msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Read rust-version from Cargo.toml
         id: metadata
-        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+        run: |
+          MSRV="$(just read-msrv)"
+          echo "rust-version=$MSRV" >> $GITHUB_OUTPUT
+          echo "Detected MSRV $MSRV"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
     types: [ published ]
   workflow_dispatch:
 
-  release:
-    types: [ published ]
-  workflow_dispatch:
-
 env:
   CARGO_TERM_COLOR: always
 
@@ -22,6 +18,7 @@ defaults:
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@v2
@@ -49,5 +46,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.metadata.outputs.rust-version }}
-          components: clippy,rustfmt
       - run: just ci-test-msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-      - name: Build
-        run: cargo build --verbose
-      - run: just ci-test
+      - name: Run `just ci-test` to lint, build, and test everything
+        run: just ci-test
       - name: Check if changes break public API and need a new version. Use `just semver-checks` to run locally.
         uses: obi1kenobi/cargo-semver-checks-action@v2
   msrv:
@@ -47,4 +46,5 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.metadata.outputs.rust-version }}
-      - run: just ci-test-msrv
+      - name: Run `just ci-test-msrv` to build and test everything with the MSRV
+        run: just ci-test-msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@v2
-        with: { tool: just }
+        with: { tool: "just" }
       - uses: actions/checkout@v4
-      - name: Build
-        run: cargo build --verbose
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Build
+        run: cargo build --verbose
       - run: just ci-test
-
+      - name: Check if changes break public API and need a new version. Use `just semver-checks` to run locally.
+        uses: obi1kenobi/cargo-semver-checks-action@v2
   msrv:
     name: Test MSRV
     runs-on: ubuntu-latest
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
-      - name: Read crate metadata
+      - name: Read rust-version from Cargo.toml
         id: metadata
         run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions: write-all
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
 categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
+rust-version = "1.56.0"
 
 [[bin]]
 doc = false

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,0 +1,12 @@
+# These are the targets that are built by make
+# Ideally they should go into some output subdirectory
+multiexample
+fuzz
+fuzz_d
+multiexample_d
+decompressor
+catbrotli
+decompressor_d
+catbrotli_d
+brotli_tool
+brotli_tool_d

--- a/justfile
+++ b/justfile
@@ -42,9 +42,12 @@ sys-info:
     cargo --version
     {{ just_executable() }} --version
 
-# All tests to run for CI
+# All tests to run for CI (TODO: add clippy)
 ci-test: sys-info (fmt "--check") build test test-doc
-# TODO: clippy
 
 # All stable tests to run for CI with the earliest supported Rust version. Assumes the Rust version is already set by rustup.
 ci-test-msrv: sys-info build test
+
+# Test if changes are backwards compatible (patch), or need a new minor/major version
+semver-checks:
+    cargo semver-checks

--- a/justfile
+++ b/justfile
@@ -56,6 +56,10 @@ sys-info:
     cargo --version
     {{ just_executable() }} --version
 
+# Get MSRV (Minimum Supported Rust Version) for the brotli crate
+read-msrv:
+    cargo metadata --no-deps --format-version 1 | jq -r -e '.packages[] | select(.name == "brotli").rust_version'
+
 # All tests to run for CI (TODO: add clippy)
 ci-test: sys-info (fmt "--check") build test test-doc
 

--- a/justfile
+++ b/justfile
@@ -8,33 +8,47 @@ clean:
     cargo clean
 
 # Build everything
-build:
+build: build-brotli build-ffi
+
+# Build the main crate
+build-brotli:
     RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples
 
-# Run cargo fmt and cargo clippy
-lint: fmt clippy
+# Build the brotli-ffi crate (in ./c dir)
+build-ffi:
+    # TODO change to this:   RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples --manifest-path c/Cargo.toml
+    cargo build --workspace --all-targets --bins --tests --lib --benches --examples --manifest-path c/Cargo.toml
+    # For now, use original make file for building/testing the FFI crate
+    cd c && make
 
 # Run cargo fmt with optional params
 fmt *ARGS:
     cargo fmt --all -- {{ ARGS }}
+    cd c && cargo fmt --all -- {{ ARGS }}
 
 # Run cargo clippy
 clippy:
     cargo clippy -- -D warnings
     cargo clippy --workspace --all-targets --bins --tests --lib --benches --examples -- -D warnings
+    cd c && cargo clippy -- -D warnings
+    cd c && cargo clippy --workspace --all-targets --bins --tests --lib --benches --examples -- -D warnings
 
 # Build and open code documentation
 docs:
     cargo doc --no-deps --open
+    cd c && cargo doc --no-deps --open
 
 # Test documentation
 test-doc:
     cargo test --doc
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+    cd c && cargo test --doc
+    cd c && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
 # Test using cargo test with optional params
 test *ARGS:
     cargo test {{ ARGS }}
+    cd c && cargo test {{ ARGS }}
 
 # Report current versions of rustc, cargo, and other utils
 sys-info:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,50 @@
+#!/usr/bin/env just --justfile
+
+@_default:
+    just --list --unsorted
+
+# Clean all build artifacts
+clean:
+    cargo clean
+
+# Build everything
+build:
+    RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples
+
+# Run cargo fmt and cargo clippy
+lint: fmt clippy
+
+# Run cargo fmt with optional params
+fmt *ARGS:
+    cargo fmt --all -- {{ ARGS }}
+
+# Run cargo clippy
+clippy:
+    cargo clippy -- -D warnings
+    cargo clippy --workspace --all-targets --bins --tests --lib --benches --examples -- -D warnings
+
+# Build and open code documentation
+docs:
+    cargo doc --no-deps --open
+
+# Test documentation
+test-doc:
+    cargo test --doc
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+# Test using cargo test with optional params
+test *ARGS:
+    cargo test {{ ARGS }}
+
+# Report current versions of rustc, cargo, and other utils
+sys-info:
+    rustc --version
+    cargo --version
+    {{ just_executable() }} --version
+
+# All tests to run for CI
+ci-test: sys-info (fmt "--check") build test test-doc
+# TODO: clippy
+
+# All stable tests to run for CI with the earliest supported Rust version. Assumes the Rust version is already set by rustup.
+ci-test-msrv: sys-info build test


### PR DESCRIPTION
* Add MSRV to Cargo.toml. The MSRV value will most likely change as the code is cleaned and uses newer language features.
up. It was computed using `cargo msrv`
* Add [justfile](https://just.systems/man/en/) with several commands to help with development
* Use GitHub CI to test everything using latest and MSRV Rust version. CI uses justfile so that it can be tested both in CI and locally.
* Add dependabot configuration and auto-accept - to make sure dependencies are regularly updated and tested
* Add semver checker to ensure that if there is a breaking change, the major/minor version of the crate reflects that