### PR TITLE
Auto-fixed clippy::needless_return

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -1030,7 +1030,7 @@ fn main() {
     } else {
         assert_eq!(num_benchmarks, 1);
         match decompress(&mut io::stdin(), &mut io::stdout(), buffer_size, custom_dictionary.into()) {
-      Ok(_) => return,
+      Ok(_) => (),
       Err(e) => panic!("Error: {:} during brotli decompress\nTo compress with Brotli, specify the -c flag.", e),
     }
     }

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -43,14 +43,14 @@ fn now() -> Duration {
 }
 #[cfg(not(feature = "disable-timer"))]
 fn now() -> SystemTime {
-    return SystemTime::now();
+    SystemTime::now()
 }
 
 #[cfg(not(feature = "disable-timer"))]
 fn elapsed(start: SystemTime) -> (Duration, bool) {
     match start.elapsed() {
-        Ok(delta) => return (delta, false),
-        _ => return (Duration::new(0, 0), true),
+        Ok(delta) => (delta, false),
+        _ => (Duration::new(0, 0), true),
     }
 }
 
@@ -204,7 +204,7 @@ impl Buffer {
             read_offset: 0,
         };
         ret.data.extend(buf);
-        return ret;
+        ret
     }
 }
 impl UnlimitedBuffer {
@@ -214,7 +214,7 @@ impl UnlimitedBuffer {
             read_offset: 0,
         };
         ret.data.extend(buf);
-        return ret;
+        ret
     }
     pub fn reset_read(&mut self) {
         self.read_offset = 0;
@@ -234,7 +234,7 @@ impl io::Read for Buffer {
                 .clone_from_slice(&self.data[self.read_offset..self.read_offset + bytes_to_read]);
         }
         self.read_offset += bytes_to_read;
-        return Ok(bytes_to_read);
+        Ok(bytes_to_read)
     }
 }
 impl io::Write for Buffer {
@@ -243,10 +243,10 @@ impl io::Write for Buffer {
             return Ok(buf.len());
         }
         self.data.extend(buf);
-        return Ok(buf.len());
+        Ok(buf.len())
     }
     fn flush(self: &mut Self) -> io::Result<()> {
-        return Ok(());
+        Ok(())
     }
 }
 impl io::Read for UnlimitedBuffer {
@@ -257,17 +257,17 @@ impl io::Read for UnlimitedBuffer {
                 .clone_from_slice(&self.data[self.read_offset..self.read_offset + bytes_to_read]);
         }
         self.read_offset += bytes_to_read;
-        return Ok(bytes_to_read);
+        Ok(bytes_to_read)
     }
 }
 
 impl io::Write for UnlimitedBuffer {
     fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
         self.data.extend(buf);
-        return Ok(buf.len());
+        Ok(buf.len())
     }
     fn flush(self: &mut Self) -> io::Result<()> {
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -332,7 +332,7 @@ fn roundtrip_helper(in_buf: &[u8], q: i32, lgwin: i32, q9_5: bool) -> usize {
     }
     assert_eq!(output.data.len(), input.data.len());
     assert_eq!(input.read_offset, in_buf.len());
-    return compressed.data[..].len();
+    compressed.data[..].len()
 }
 
 fn total_roundtrip_helper(data: &[u8]) {
@@ -884,7 +884,7 @@ impl<'a> io::Read for LimitedBuffer<'a> {
                 .clone_from_slice(&self.data[self.read_offset..self.read_offset + bytes_to_read]);
         }
         self.read_offset += bytes_to_read;
-        return Ok(bytes_to_read);
+        Ok(bytes_to_read)
     }
 }
 
@@ -901,7 +901,7 @@ impl<'a> io::Write for LimitedBuffer<'a> {
         Ok(bytes_to_write)
     }
     fn flush(self: &mut Self) -> io::Result<()> {
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/src/bin/tests.rs
+++ b/src/bin/tests.rs
@@ -14,7 +14,7 @@ impl Buffer {
             read_offset: 0,
         };
         ret.data.extend(buf);
-        return ret;
+        ret
     }
 }
 impl io::Read for Buffer {
@@ -25,16 +25,16 @@ impl io::Read for Buffer {
                 .clone_from_slice(&self.data[self.read_offset..self.read_offset + bytes_to_read]);
         }
         self.read_offset += bytes_to_read;
-        return Ok(bytes_to_read);
+        Ok(bytes_to_read)
     }
 }
 impl io::Write for Buffer {
     fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
         self.data.extend(buf);
-        return Ok(buf.len());
+        Ok(buf.len())
     }
     fn flush(self: &mut Self) -> io::Result<()> {
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -68,7 +68,7 @@ fn copy_from_to<R: io::Read, W: io::Write>(mut r: R, mut w: W) -> io::Result<usi
             }
         }
     }
-    return Ok(out_size);
+    Ok(out_size)
 }
 
 #[test]

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -14,7 +14,7 @@ struct Tee<OutputA: Write, OutputB: Write>(OutputA, OutputB);
 impl<OutputA: Write, OutputB: Write> Write for Tee<OutputA, OutputB> {
     fn write(&mut self, data: &[u8]) -> Result<usize, io::Error> {
         match self.0.write(data) {
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
             Ok(size) => match self.1.write_all(&data[..size]) {
                 Ok(_) => Ok(size),
                 Err(err) => Err(err),
@@ -23,7 +23,7 @@ impl<OutputA: Write, OutputB: Write> Write for Tee<OutputA, OutputB> {
     }
     fn flush(&mut self) -> Result<(), io::Error> {
         match self.0.flush() {
-            Err(err) => return Err(err),
+            Err(err) => Err(err),
             Ok(_) => loop {
                 match self.1.flush() {
                     Err(e) => match e.kind() {
@@ -167,9 +167,9 @@ pub fn compress_validate<InputType: Read, OutputType: Write>(
     match ret {
         Ok(_ret) => {
             if sha_ok(&mut sha_writer, &mut sha_reader) {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(Error::new(ErrorKind::InvalidData, VALIDATION_FAILED));
+                Err(Error::new(ErrorKind::InvalidData, VALIDATION_FAILED))
             }
         }
         Err(e) => Err(e),

--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -544,7 +544,7 @@ impl BroCatli {
         if *out_offset == out_bytes.len() {
             return BroCatliResult::NeedsMoreOutput;
         }
-        return BroCatliResult::NeedsMoreInput;
+        BroCatliResult::NeedsMoreInput
     }
     fn append_eof_metablock_to_last_bytes(&mut self) {
         assert!(self.last_byte_sanitized);

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -303,7 +303,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
     }
     #[inline(always)]
     fn GetHasherCommon(&mut self) -> &mut Struct1 {
-        return &mut self.GetHasherCommon;
+        &mut self.GetHasherCommon
     }
     #[inline(always)]
     fn HashBytes(&self, data: &[u8]) -> usize {
@@ -707,7 +707,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
     }
     #[inline(always)]
     fn GetHasherCommon(&mut self) -> &mut Struct1 {
-        return &mut self.dict_search_stats_;
+        &mut self.dict_search_stats_
     }
     #[inline(always)]
     fn HashBytes(&self, data: &[u8]) -> usize {
@@ -967,16 +967,15 @@ impl AdvHashSpecialization for HQ5Sub {
     #[inline(always)]
     fn get_hash_mask(&self) -> u64 {
         //return 0xffffffffffffffffu64;
-        return 0xffffffffu64; // make it 32 bit
+        0xffffffffu64 // make it 32 bit
     }
     #[inline(always)]
     fn get_k_hash_mul(&self) -> u64 {
-        return kHashMul32 as u64;
+        kHashMul32 as u64
     }
     #[inline(always)]
     fn load_and_mix_word(&self, data: &[u8]) -> u64 {
-        return (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul())
-            & self.get_hash_mask();
+        (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul()) & self.get_hash_mask()
     }
     #[inline(always)]
     fn set_hash_mask(&mut self, _params_hash_len: i32) {}
@@ -1015,16 +1014,15 @@ impl AdvHashSpecialization for HQ7Sub {
     #[inline(always)]
     fn get_hash_mask(&self) -> u64 {
         //return 0xffffffffffffffffu64;
-        return 0xffffffffu64; // make it 32 bit
+        0xffffffffu64 // make it 32 bit
     }
     #[inline(always)]
     fn get_k_hash_mul(&self) -> u64 {
-        return kHashMul32 as u64;
+        kHashMul32 as u64
     }
     #[inline(always)]
     fn load_and_mix_word(&self, data: &[u8]) -> u64 {
-        return (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul())
-            & self.get_hash_mask();
+        (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul()) & self.get_hash_mask()
     }
     #[inline(always)]
     fn set_hash_mask(&mut self, _params_hash_len: i32) {}
@@ -1048,10 +1046,10 @@ pub struct H5Sub {
 impl AdvHashSpecialization for H5Sub {
     #[inline(always)]
     fn hash_shift(&self) -> i32 {
-        return self.hash_shift_;
+        self.hash_shift_
     }
     fn bucket_size(&self) -> u32 {
-        return self.bucket_size_;
+        self.bucket_size_
     }
     fn block_bits(&self) -> i32 {
         self.block_bits_
@@ -1060,18 +1058,17 @@ impl AdvHashSpecialization for H5Sub {
         1 << self.block_bits_
     }
     fn block_mask(&self) -> u32 {
-        return self.block_mask_;
+        self.block_mask_
     }
     fn get_hash_mask(&self) -> u64 {
         //return 0xffffffffffffffffu64;
-        return 0xffffffffu64; // make it 32 bit
+        0xffffffffu64 // make it 32 bit
     }
     fn get_k_hash_mul(&self) -> u64 {
-        return kHashMul32 as u64;
+        kHashMul32 as u64
     }
     fn load_and_mix_word(&self, data: &[u8]) -> u64 {
-        return (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul())
-            & self.get_hash_mask();
+        (BROTLI_UNALIGNED_LOAD32(data) as u64 * self.get_k_hash_mul()) & self.get_hash_mask()
     }
     #[allow(unused_variables)]
     fn set_hash_mask(&mut self, params_hash_len: i32) {}
@@ -1095,11 +1092,11 @@ pub struct H6Sub {
 impl AdvHashSpecialization for H6Sub {
     #[inline(always)]
     fn hash_shift(&self) -> i32 {
-        return self.hash_shift_;
+        self.hash_shift_
     }
     #[inline(always)]
     fn bucket_size(&self) -> u32 {
-        return self.bucket_size_;
+        self.bucket_size_
     }
     fn block_bits(&self) -> i32 {
         self.block_bits_
@@ -1109,7 +1106,7 @@ impl AdvHashSpecialization for H6Sub {
     }
     #[inline(always)]
     fn block_mask(&self) -> u32 {
-        return self.block_mask_;
+        self.block_mask_
     }
     #[inline(always)]
     fn get_hash_mask(&self) -> u64 {
@@ -1125,8 +1122,7 @@ impl AdvHashSpecialization for H6Sub {
     }
     #[inline(always)]
     fn load_and_mix_word(&self, data: &[u8]) -> u64 {
-        return (BROTLI_UNALIGNED_LOAD64(data) & self.get_hash_mask())
-            .wrapping_mul(self.get_k_hash_mul());
+        (BROTLI_UNALIGNED_LOAD64(data) & self.get_hash_mask()).wrapping_mul(self.get_k_hash_mul())
     }
     #[inline(always)]
     fn HashTypeLength(&self) -> usize {
@@ -2223,28 +2219,28 @@ macro_rules! match_all_hashers {
 }
 impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for UnionHasher<Alloc> {
     fn Opts(&self) -> H9Opts {
-        return match_all_hashers!(self, Opts,);
+        match_all_hashers!(self, Opts,)
     }
     fn GetHasherCommon(&mut self) -> &mut Struct1 {
-        return match_all_hashers_mut!(self, GetHasherCommon,);
+        match_all_hashers_mut!(self, GetHasherCommon,)
     } /*
       fn GetH10Tree(&mut self) -> Option<&mut H10<AllocU32, H10Buckets, H10DefaultParams>> {
         return match_all_hashers_mut!(self, GetH10Tree,);
       }*/
     fn Prepare(&mut self, one_shot: bool, input_size: usize, data: &[u8]) -> HowPrepared {
-        return match_all_hashers_mut!(self, Prepare, one_shot, input_size, data);
+        match_all_hashers_mut!(self, Prepare, one_shot, input_size, data)
     }
     fn HashBytes(&self, data: &[u8]) -> usize {
-        return match_all_hashers!(self, HashBytes, data);
+        match_all_hashers!(self, HashBytes, data)
     }
     fn HashTypeLength(&self) -> usize {
-        return match_all_hashers!(self, HashTypeLength,);
+        match_all_hashers!(self, HashTypeLength,)
     }
     fn StoreLookahead(&self) -> usize {
-        return match_all_hashers!(self, StoreLookahead,);
+        match_all_hashers!(self, StoreLookahead,)
     }
     fn PrepareDistanceCache(&self, distance_cache: &mut [i32]) {
-        return match_all_hashers!(self, PrepareDistanceCache, distance_cache);
+        match_all_hashers!(self, PrepareDistanceCache, distance_cache)
     }
     fn StitchToPreviousBlock(
         &mut self,
@@ -2253,14 +2249,14 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for UnionHa
         ringbuffer: &[u8],
         ringbuffer_mask: usize,
     ) {
-        return match_all_hashers_mut!(
+        match_all_hashers_mut!(
             self,
             StitchToPreviousBlock,
             num_bytes,
             position,
             ringbuffer,
             ringbuffer_mask
-        );
+        )
     }
     fn FindLongestMatch(
         &mut self,
@@ -2276,7 +2272,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for UnionHa
         max_distance: usize,
         out: &mut HasherSearchResult,
     ) -> bool {
-        return match_all_hashers_mut!(
+        match_all_hashers_mut!(
             self,
             FindLongestMatch,
             dictionary,
@@ -2290,16 +2286,16 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for UnionHa
             gap,
             max_distance,
             out
-        );
+        )
     }
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        return match_all_hashers_mut!(self, Store, data, mask, ix);
+        match_all_hashers_mut!(self, Store, data, mask, ix)
     }
     fn StoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
-        return match_all_hashers_mut!(self, StoreRange, data, mask, ix_start, ix_end);
+        match_all_hashers_mut!(self, StoreRange, data, mask, ix_start, ix_end)
     }
     fn BulkStoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
-        return match_all_hashers_mut!(self, BulkStoreRange, data, mask, ix_start, ix_end);
+        match_all_hashers_mut!(self, BulkStoreRange, data, mask, ix_start, ix_end)
     }
 }
 

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -235,7 +235,7 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
     // Add the entropy of the code length code histogram.
     bits += BitsEntropy(depth_histo, BROTLI_CODE_LENGTH_CODES);
     //println_stderr!("{:?} {:?}", depth_histo, bits);
-    return bits;
+    bits
 }
 use alloc::SliceWrapperMut;
 

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -79,7 +79,7 @@ fn prediction_mode_str(
 }
 
 fn is_long_enough_to_be_random(len: usize, high_entropy_detection_quality: u8) -> bool {
-    return match high_entropy_detection_quality {
+    match high_entropy_detection_quality {
         0 => false,
         1 => false,
         2 => len >= 128,
@@ -93,7 +93,7 @@ fn is_long_enough_to_be_random(len: usize, high_entropy_detection_quality: u8) -
         10 => len >= 4,
         11 => len >= 1,
         _ => len >= 8,
-    };
+    }
 }
 const COMMAND_BUFFER_SIZE: usize = 4096;
 
@@ -1069,7 +1069,7 @@ pub struct SimpleSortHuffmanTree {}
 
 impl HuffmanComparator for SimpleSortHuffmanTree {
     fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
-        return (*v0).total_count_ < (*v1).total_count_;
+        (*v0).total_count_ < (*v1).total_count_
     }
 }
 
@@ -1344,7 +1344,7 @@ impl<
     > MetaBlockSplit<Alloc>
 {
     pub fn new() -> Self {
-        return MetaBlockSplit {
+        MetaBlockSplit {
             literal_split: BlockSplit::<Alloc>::new(),
             command_split: BlockSplit::<Alloc>::new(),
             distance_split: BlockSplit::<Alloc>::new(),
@@ -1359,7 +1359,7 @@ impl<
             distance_histograms: <Alloc as Allocator<HistogramDistance>>::AllocatedMemory::default(
             ),
             distance_histograms_size: 0,
-        };
+        }
     }
     pub fn destroy(&mut self, alloc: &mut Alloc) {
         self.literal_split.destroy(alloc);
@@ -1499,10 +1499,10 @@ fn StoreCompressedMetaBlockHeader(
 }
 
 fn NewBlockTypeCodeCalculator() -> BlockTypeCodeCalculator {
-    return BlockTypeCodeCalculator {
+    BlockTypeCodeCalculator {
         last_type: 1,
         second_last_type: 0,
-    };
+    }
 }
 
 fn NewBlockEncoder<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
@@ -1518,7 +1518,7 @@ fn NewBlockEncoder<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     } else {
         block_len = 0;
     }
-    return BlockEncoder::<Alloc> {
+    BlockEncoder::<Alloc> {
         histogram_length_: histogram_length,
         num_block_types_: num_block_types,
         block_types_: block_types,
@@ -1536,7 +1536,7 @@ fn NewBlockEncoder<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
         entropy_ix_: 0,
         depths_: <Alloc as Allocator<u8>>::AllocatedMemory::default(),
         bits_: <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-    };
+    }
 }
 
 fn NextBlockTypeCode(calculator: &mut BlockTypeCodeCalculator, type_: u8) -> usize {
@@ -2306,20 +2306,16 @@ fn StoreCommandExtra(cmd: &Command, storage_ix: &mut usize, storage: &mut [u8]) 
 
 fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
-        ContextType::CONTEXT_LSB6 => {
-            return (p1 as (i32) & 0x3fi32) as (u8);
-        }
-        ContextType::CONTEXT_MSB6 => {
-            return (p1 as (i32) >> 2i32) as (u8);
-        }
+        ContextType::CONTEXT_LSB6 => (p1 as (i32) & 0x3fi32) as (u8),
+        ContextType::CONTEXT_MSB6 => (p1 as (i32) >> 2i32) as (u8),
         ContextType::CONTEXT_UTF8 => {
-            return (kUTF8ContextLookup[p1 as (usize)] as (i32)
+            (kUTF8ContextLookup[p1 as (usize)] as (i32)
                 | kUTF8ContextLookup[(p2 as (i32) + 256i32) as (usize)] as (i32))
-                as (u8);
+                as (u8)
         }
         ContextType::CONTEXT_SIGNED => {
-            return ((kSigned3BitContextLookup[p1 as (usize)] as (i32) << 3i32)
-                + kSigned3BitContextLookup[p2 as (usize)] as (i32)) as (u8);
+            ((kSigned3BitContextLookup[p1 as (usize)] as (i32) << 3i32)
+                + kSigned3BitContextLookup[p2 as (usize)] as (i32)) as (u8)
         }
     }
     //  0i32 as (u8)
@@ -2924,7 +2920,7 @@ struct MetaBlockSplitRefs<'a> {
 }
 
 fn block_split_nop() -> MetaBlockSplitRefs<'static> {
-    return MetaBlockSplitRefs::default();
+    MetaBlockSplitRefs::default()
 }
 
 fn block_split_reference<'a, Alloc: BrotliAlloc>(
@@ -3201,7 +3197,7 @@ fn InputPairFromMaskedInput<'a>(
             &input[0..len.wrapping_sub(len1)],
         );
     }
-    return (&input[masked_pos..masked_pos + len], &[]);
+    (&input[masked_pos..masked_pos + len], &[])
 }
 pub fn BrotliStoreUncompressedMetaBlock<Cb, Alloc: BrotliAlloc>(
     alloc: &mut Alloc,

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -119,8 +119,8 @@ fn GetNextOutInternal<'a>(
     tiny_buf: &'a mut [u8; 16],
 ) -> &'a mut [u8] {
     match next_out {
-        &NextOut::DynamicStorage(offset) => return &mut storage[offset as usize..],
-        &NextOut::TinyBuf(offset) => return &mut tiny_buf[offset as usize..],
+        &NextOut::DynamicStorage(offset) => &mut storage[offset as usize..],
+        &NextOut::TinyBuf(offset) => &mut tiny_buf[offset as usize..],
         &NextOut::None => &mut [],
     }
 }
@@ -131,10 +131,8 @@ macro_rules! GetNextOut {
 }
 fn NextOutIncrement(next_out: &NextOut, inc: i32) -> NextOut {
     match next_out {
-        &NextOut::DynamicStorage(offset) => {
-            return NextOut::DynamicStorage((offset as i32 + inc) as u32)
-        }
-        &NextOut::TinyBuf(offset) => return NextOut::TinyBuf((offset as i32 + inc) as u32),
+        &NextOut::DynamicStorage(offset) => NextOut::DynamicStorage((offset as i32 + inc) as u32),
+        &NextOut::TinyBuf(offset) => NextOut::TinyBuf((offset as i32 + inc) as u32),
         &NextOut::None => NextOut::None,
     }
 }
@@ -376,7 +374,7 @@ pub fn BROTLI_DISTANCE_ALPHABET_SIZE(NPOSTFIX: u32, NDIRECT: u32, MAXNBITS: u32)
 pub const BROTLI_NUM_DISTANCE_SYMBOLS: usize = 1128;
 
 pub fn BrotliEncoderInitParams() -> BrotliEncoderParams {
-    return BrotliEncoderParams {
+    BrotliEncoderParams {
         dist: BrotliDistanceParams {
             distance_postfix_bits: 0,
             num_direct_distance_codes: 0,
@@ -411,7 +409,7 @@ pub fn BrotliEncoderInitParams() -> BrotliEncoderParams {
             num_last_distances_to_check: 16,
             literal_byte_score: 0,
         },
-    };
+    }
 }
 
 fn ExtendLastCommand<Alloc: BrotliAlloc>(
@@ -462,7 +460,7 @@ fn ExtendLastCommand<Alloc: BrotliAlloc>(
 }
 
 fn RingBufferInit<AllocU8: alloc::Allocator<u8>>() -> RingBuffer<AllocU8> {
-    return RingBuffer {
+    RingBuffer {
         size_: 0,
         mask_: 0, // 0xff??
         tail_size_: 0,
@@ -472,7 +470,7 @@ fn RingBufferInit<AllocU8: alloc::Allocator<u8>>() -> RingBuffer<AllocU8> {
         pos_: 0,
         data_mo: AllocU8::AllocatedMemory::default(),
         buffer_index: 0usize,
-    };
+    }
 }
 
 pub fn BrotliEncoderCreateInstance<Alloc: BrotliAlloc>(
@@ -1225,7 +1223,7 @@ fn BrotliMakeHasher<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
         return UnionHasher::H10(InitializeH10(m, false, params, 0));
     }
     // since we don't support all of these, fall back to something sane
-    return InitializeH6(m, params);
+    InitializeH6(m, params)
 
     //  return UnionHasher::Uninit;
 }
@@ -1501,7 +1499,7 @@ fn ChooseContextMode(
     if (params.quality >= 10 && BrotliIsMostlyUTF8(data, pos, mask, length, kMinUTF8Ratio) == 0) {
         return ContextType::CONTEXT_SIGNED;
     }
-    return ContextType::CONTEXT_UTF8;
+    ContextType::CONTEXT_UTF8
 }
 
 #[derive(PartialEq, Eq, Copy, Clone)]
@@ -2012,7 +2010,7 @@ fn ShouldUseComplexStaticContextMap(
     //BROTLI_UNUSED(quality);
     /* Try the more complex static context map only for long data. */
     if (size_hint < (1 << 20)) {
-        return false;
+        false
     } else {
         let end_pos = start_pos + length;
         /* To make entropy calculations faster and to fit on the stack, we collect
@@ -2061,11 +2059,11 @@ fn ShouldUseComplexStaticContextMap(
         ratio is improved. Note however that this heuristics might be too strict
         for some cases and could be tuned further. */
         if (entropy[2] > 3.0 || entropy[1] - entropy[2] < 0.2) {
-            return false;
+            false
         } else {
             *num_literal_contexts = 13;
             *literal_context_map = &kStaticContextMapComplexUTF8;
-            return true;
+            true
         }
     }
 }

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -25,11 +25,11 @@ impl Default for HuffmanTree {
 }
 
 pub fn NewHuffmanTree(count: u32, left: i16, right: i16) -> HuffmanTree {
-    return HuffmanTree {
+    HuffmanTree {
         total_count_: count,
         index_left_: left,
         index_right_or_value_: right,
-    };
+    }
 }
 pub fn InitHuffmanTree(xself: &mut HuffmanTree, count: u32, left: i16, right: i16) {
     *xself = NewHuffmanTree(count, left, right);

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -784,7 +784,7 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyTally<AllocU32> {
                 best_entropy = cur;
             }
         }
-        return best_stride;
+        best_stride
     }
     pub fn peek(&mut self) -> &mut EntropyBucketPopulation<AllocU32> {
         &mut self.pop[0]

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -21,21 +21,21 @@ pub struct HistogramLiteral {
 impl Clone for HistogramLiteral {
     #[inline(always)]
     fn clone(&self) -> HistogramLiteral {
-        return HistogramLiteral {
+        HistogramLiteral {
             data_: self.data_,
             total_count_: self.total_count_,
             bit_cost_: self.bit_cost_,
-        };
+        }
     }
 }
 impl Default for HistogramLiteral {
     #[inline(always)]
     fn default() -> HistogramLiteral {
-        return HistogramLiteral {
+        HistogramLiteral {
             data_: [0; 256],
             total_count_: 0,
             bit_cost_: 3.402e+38 as super::util::floatX,
-        };
+        }
     }
 }
 //#[derive(Clone)] clone is broken for arrays > 32
@@ -47,21 +47,21 @@ pub struct HistogramCommand {
 impl Clone for HistogramCommand {
     #[inline(always)]
     fn clone(&self) -> HistogramCommand {
-        return HistogramCommand {
+        HistogramCommand {
             data_: self.data_,
             total_count_: self.total_count_,
             bit_cost_: self.bit_cost_,
-        };
+        }
     }
 }
 impl Default for HistogramCommand {
     #[inline(always)]
     fn default() -> HistogramCommand {
-        return HistogramCommand {
+        HistogramCommand {
             data_: [0; 704],
             total_count_: 0,
             bit_cost_: 3.402e+38 as super::util::floatX,
-        };
+        }
     }
 }
 //#[derive(Clone)] // #derive is broken for arrays > 32
@@ -78,20 +78,20 @@ pub struct HistogramDistance {
 }
 impl Clone for HistogramDistance {
     fn clone(&self) -> HistogramDistance {
-        return HistogramDistance {
+        HistogramDistance {
             data_: self.data_,
             total_count_: self.total_count_,
             bit_cost_: self.bit_cost_,
-        };
+        }
     }
 }
 impl Default for HistogramDistance {
     fn default() -> HistogramDistance {
-        return HistogramDistance {
+        HistogramDistance {
             data_: [0; BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS],
             total_count_: 0,
             bit_cost_: 3.402e+38 as super::util::floatX,
-        };
+        }
     }
 }
 
@@ -106,52 +106,52 @@ pub trait CostAccessors {
 impl SliceWrapper<u32> for HistogramLiteral {
     #[inline(always)]
     fn slice(&self) -> &[u32] {
-        return &self.data_[..];
+        &self.data_[..]
     }
 }
 impl SliceWrapperMut<u32> for HistogramLiteral {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [u32] {
-        return &mut self.data_[..];
+        &mut self.data_[..]
     }
 }
 pub struct Array264i([Mem256i; 33]);
 impl SliceWrapperMut<Mem256i> for Array264i {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [Mem256i] {
-        return &mut self.0[..];
+        &mut self.0[..]
     }
 }
 
 impl SliceWrapper<Mem256i> for Array264i {
     #[inline(always)]
     fn slice(&self) -> &[Mem256i] {
-        return &self.0[..];
+        &self.0[..]
     }
 }
 impl Default for Array264i {
     #[inline(always)]
     fn default() -> Array264i {
-        return Array264i([Mem256i::default().clone(); 33]);
+        Array264i([Mem256i::default().clone(); 33])
     }
 }
 pub struct Array528i([Mem256i; 66]);
 impl SliceWrapperMut<Mem256i> for Array528i {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [Mem256i] {
-        return &mut self.0[..];
+        &mut self.0[..]
     }
 }
 impl SliceWrapper<Mem256i> for Array528i {
     #[inline(always)]
     fn slice(&self) -> &[Mem256i] {
-        return &self.0[..];
+        &self.0[..]
     }
 }
 impl Default for Array528i {
     #[inline(always)]
     fn default() -> Array528i {
-        return Array528i([Mem256i::default(); 66]);
+        Array528i([Mem256i::default(); 66])
     }
 }
 
@@ -159,19 +159,19 @@ pub struct Array712i([Mem256i; 89]);
 impl SliceWrapperMut<Mem256i> for Array712i {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [Mem256i] {
-        return &mut self.0[..];
+        &mut self.0[..]
     }
 }
 impl SliceWrapper<Mem256i> for Array712i {
     #[inline(always)]
     fn slice(&self) -> &[Mem256i] {
-        return &self.0[..];
+        &self.0[..]
     }
 }
 impl Default for Array712i {
     #[inline(always)]
     fn default() -> Array712i {
-        return Array712i([Mem256i::default(); 89]);
+        Array712i([Mem256i::default(); 89])
     }
 }
 
@@ -180,20 +180,20 @@ pub struct EmptyIVec {}
 impl SliceWrapperMut<Mem256i> for EmptyIVec {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [Mem256i] {
-        return &mut [];
+        &mut []
     }
 }
 impl SliceWrapper<Mem256i> for EmptyIVec {
     #[inline(always)]
     fn slice(&self) -> &[Mem256i] {
-        return &[];
+        &[]
     }
 }
 
 impl Default for EmptyIVec {
     #[inline(always)]
     fn default() -> EmptyIVec {
-        return EmptyIVec {};
+        EmptyIVec {}
     }
 }
 
@@ -206,15 +206,15 @@ pub type HistogramLiteralScratch = EmptyIVec;
 impl CostAccessors for HistogramLiteral {
     type i32vec = HistogramLiteralScratch;
     fn make_nnz_storage() -> Self::i32vec {
-        return HistogramLiteralScratch::default();
+        HistogramLiteralScratch::default()
     }
     #[inline(always)]
     fn total_count(&self) -> usize {
-        return self.total_count_;
+        self.total_count_
     }
     #[inline(always)]
     fn bit_cost(&self) -> super::util::floatX {
-        return self.bit_cost_;
+        self.bit_cost_
     }
     #[inline(always)]
     fn set_bit_cost(&mut self, data: super::util::floatX) {
@@ -229,13 +229,13 @@ impl CostAccessors for HistogramLiteral {
 impl SliceWrapper<u32> for HistogramCommand {
     #[inline(always)]
     fn slice(&self) -> &[u32] {
-        return &self.data_[..];
+        &self.data_[..]
     }
 }
 impl SliceWrapperMut<u32> for HistogramCommand {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [u32] {
-        return &mut self.data_[..];
+        &mut self.data_[..]
     }
 }
 
@@ -248,15 +248,15 @@ pub type HistogramCommandScratch = EmptyIVec;
 impl CostAccessors for HistogramCommand {
     type i32vec = HistogramCommandScratch;
     fn make_nnz_storage() -> Self::i32vec {
-        return HistogramCommandScratch::default();
+        HistogramCommandScratch::default()
     }
     #[inline(always)]
     fn total_count(&self) -> usize {
-        return self.total_count_;
+        self.total_count_
     }
     #[inline(always)]
     fn bit_cost(&self) -> super::util::floatX {
-        return self.bit_cost_;
+        self.bit_cost_
     }
     #[inline(always)]
     fn set_bit_cost(&mut self, data: super::util::floatX) {
@@ -271,13 +271,13 @@ impl CostAccessors for HistogramCommand {
 impl SliceWrapper<u32> for HistogramDistance {
     #[inline(always)]
     fn slice(&self) -> &[u32] {
-        return &self.data_[..];
+        &self.data_[..]
     }
 }
 impl SliceWrapperMut<u32> for HistogramDistance {
     #[inline(always)]
     fn slice_mut(&mut self) -> &mut [u32] {
-        return &mut self.data_[..];
+        &mut self.data_[..]
     }
 }
 
@@ -290,16 +290,16 @@ pub type HistogramDistanceScratch = EmptyIVec;
 impl CostAccessors for HistogramDistance {
     type i32vec = HistogramDistanceScratch;
     fn make_nnz_storage() -> Self::i32vec {
-        return HistogramDistanceScratch::default();
+        HistogramDistanceScratch::default()
     }
 
     #[inline(always)]
     fn total_count(&self) -> usize {
-        return self.total_count_;
+        self.total_count_
     }
     #[inline(always)]
     fn bit_cost(&self) -> super::util::floatX {
-        return self.bit_cost_;
+        self.bit_cost_
     }
     #[inline(always)]
     fn set_bit_cost(&mut self, data: super::util::floatX) {

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -80,7 +80,7 @@ impl<'a> core::cmp::PartialEq for InputPair<'a> {
                 return false;
             }
         }
-        return true;
+        true
     }
 }
 impl<'a> core::ops::Index<usize> for InputPair<'a> {

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -56,7 +56,7 @@ impl LiteralPredictionModeNibble {
         if prediction_mode < 16 {
             return Ok(LiteralPredictionModeNibble(prediction_mode));
         }
-        return Err(());
+        Err(())
     }
     #[inline(always)]
     pub fn prediction_mode(&self) -> u8 {

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -106,20 +106,16 @@ fn compute_huffman_table_index_for_context_map(
 
 pub fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
-        ContextType::CONTEXT_LSB6 => {
-            return (p1 as (i32) & 0x3fi32) as (u8);
-        }
-        ContextType::CONTEXT_MSB6 => {
-            return (p1 as (i32) >> 2i32) as (u8);
-        }
+        ContextType::CONTEXT_LSB6 => (p1 as (i32) & 0x3fi32) as (u8),
+        ContextType::CONTEXT_MSB6 => (p1 as (i32) >> 2i32) as (u8),
         ContextType::CONTEXT_UTF8 => {
-            return (kUTF8ContextLookup[p1 as (usize)] as (i32)
+            (kUTF8ContextLookup[p1 as (usize)] as (i32)
                 | kUTF8ContextLookup[(p2 as (i32) + 256i32) as (usize)] as (i32))
-                as (u8);
+                as (u8)
         }
         ContextType::CONTEXT_SIGNED => {
-            return ((kSigned3BitContextLookup[p1 as (usize)] as (i32) << 3i32)
-                + kSigned3BitContextLookup[p2 as (usize)] as (i32)) as (u8);
+            ((kSigned3BitContextLookup[p1 as (usize)] as (i32) << 3i32)
+                + kSigned3BitContextLookup[p2 as (usize)] as (i32)) as (u8)
         }
     }
     //  0i32 as (u8)

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -128,7 +128,7 @@ fn ComputeDistanceCost(
     }
 
     *cost = BrotliPopulationCost(&histo, scratch) as f64 + extra_bits;
-    return true;
+    true
 }
 
 pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
@@ -478,7 +478,7 @@ fn InitBlockSplitter<
     HistogramClear(&mut histograms.slice_mut()[0]);
     xself.last_histogram_ix_[0] = 0;
     xself.last_histogram_ix_[1] = 0;
-    return xself;
+    xself
 }
 fn InitContextBlockSplitter<
     Alloc: alloc::Allocator<u8> + alloc::Allocator<u32> + alloc::Allocator<HistogramLiteral>,
@@ -563,7 +563,7 @@ fn InitContextBlockSplitter<
     ClearHistograms(&mut histograms.slice_mut()[(0usize)..], num_contexts);
     xself.last_histogram_ix_[0] = 0;
     xself.last_histogram_ix_[1] = 0;
-    return xself;
+    xself
 }
 
 fn BlockSplitterFinishBlock<

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -38,13 +38,13 @@ pub static kBrotliEncDictionary: BrotliDictionary = BrotliDictionary {
 
 #[inline(always)]
 pub fn BrotliGetDictionary() -> &'static BrotliDictionary {
-    return &kBrotliEncDictionary;
+    &kBrotliEncDictionary
 }
 #[inline(always)]
 pub fn BROTLI_UNALIGNED_LOAD32(sl: &[u8]) -> u32 {
     let mut p = [0u8; 4];
     p[..].clone_from_slice(&sl.split_at(4).0);
-    return (p[0] as u32) | ((p[1] as u32) << 8) | ((p[2] as u32) << 16) | ((p[3] as u32) << 24);
+    (p[0] as u32) | ((p[1] as u32) << 8) | ((p[2] as u32) << 16) | ((p[3] as u32) << 24)
 }
 #[inline(always)]
 pub fn Hash(data: &[u8]) -> u32 {
@@ -55,14 +55,14 @@ pub fn Hash(data: &[u8]) -> u32 {
 pub fn BROTLI_UNALIGNED_LOAD64(sl: &[u8]) -> u64 {
     let mut p = [0u8; 8];
     p[..].clone_from_slice(sl.split_at(8).0);
-    return (p[0] as u64)
+    (p[0] as u64)
         | ((p[1] as u64) << 8)
         | ((p[2] as u64) << 16)
         | ((p[3] as u64) << 24)
         | ((p[4] as u64) << 32)
         | ((p[5] as u64) << 40)
         | ((p[6] as u64) << 48)
-        | ((p[7] as u64) << 56);
+        | ((p[7] as u64) << 56)
 }
 #[inline(always)]
 pub fn BROTLI_UNALIGNED_STORE64(outp: &mut [u8], v: u64) {
@@ -129,7 +129,7 @@ pub fn SlowerFindMatchLengthWithLimit(s1: &[u8], s2: &[u8], limit: usize) -> usi
             return index;
         }
     }
-    return limit;
+    limit
 }
 // factor of 5 slower (example takes 90 seconds)
 #[allow(unused)]
@@ -139,7 +139,7 @@ pub fn FindMatchLengthWithLimit(s1: &[u8], s2: &[u8], limit: usize) -> usize {
             return index;
         }
     }
-    return limit;
+    limit
 }
 #[allow(unused)]
 pub fn FindMatchLengthWithLimitMin4(s1: &[u8], s2: &[u8], limit: usize) -> usize {
@@ -154,7 +154,7 @@ pub fn FindMatchLengthWithLimitMin4(s1: &[u8], s2: &[u8], limit: usize) -> usize
     if limit <= 4 || beyond_ok {
         return core::cmp::min(limit, 4);
     }
-    return ComplexFindMatchLengthWithLimit(s1_rest, s2_rest, limit - 5) + 5;
+    ComplexFindMatchLengthWithLimit(s1_rest, s2_rest, limit - 5) + 5
 }
 #[inline]
 pub fn ComplexFindMatchLengthWithLimit(mut s1: &[u8], mut s2: &[u8], mut limit: usize) -> usize {
@@ -348,7 +348,7 @@ pub fn slowFindMatchLengthWithLimit(s1: &[u8], s2: &[u8], limit: usize) -> usize
             return index;
         }
     }
-    return limit;
+    limit
 }
 
 pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_length: usize) -> i32 {

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -222,7 +222,7 @@ fn oneshot_compress(
         BrotliEncoderDestroyInstance(s);
     }
 
-    return (1, next_out_offset);
+    (1, next_out_offset)
 }
 
 fn oneshot_decompress(compressed: &[u8], mut output: &mut [u8]) -> (BrotliResult, usize, usize) {
@@ -255,7 +255,7 @@ fn oneshot_decompress(compressed: &[u8], mut output: &mut [u8]) -> (BrotliResult
         &mut written,
         &mut brotli_state,
     );
-    return (result, input_offset, output_offset);
+    (result, input_offset, output_offset)
 }
 
 fn oneshot(
@@ -281,7 +281,7 @@ fn oneshot(
         //return (BrotliResult::ResultFailure, 0, 0);
         available_in = compressed.len();
     }
-    return oneshot_decompress(&mut compressed[..available_in], output);
+    oneshot_decompress(&mut compressed[..available_in], output)
 }
 
 #[test]

--- a/src/enc/util.rs
+++ b/src/enc/util.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
+#![allow(clippy::excessive_precision)]
+
 use core;
+
 #[cfg(feature = "float64")]
 pub type floatX = f64;
 
@@ -348,7 +351,7 @@ pub fn xFastLog2u16(v: u16) -> floatX {
 #[cfg(feature = "std")]
 #[inline(always)]
 pub fn FastPow2(v: super::util::floatX) -> super::util::floatX {
-    return (2 as super::util::floatX).powf(v);
+    (2 as super::util::floatX).powf(v)
 }
 
 #[cfg(not(feature = "std"))]

--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -347,12 +347,12 @@ pub unsafe extern "C" fn BrotliEncoderMallocU8(
     size: usize,
 ) -> *mut u8 {
     if let Some(alloc_fn) = (*state_ptr).custom_allocator.alloc_func {
-        return core::mem::transmute::<*mut c_void, *mut u8>(alloc_fn(
+        core::mem::transmute::<*mut c_void, *mut u8>(alloc_fn(
             (*state_ptr).custom_allocator.opaque,
             size,
-        ));
+        ))
     } else {
-        return alloc_util::alloc_stdlib(size);
+        alloc_util::alloc_stdlib(size)
     }
 }
 
@@ -378,12 +378,12 @@ pub unsafe extern "C" fn BrotliEncoderMallocUsize(
     size: usize,
 ) -> *mut usize {
     if let Some(alloc_fn) = (*state_ptr).custom_allocator.alloc_func {
-        return core::mem::transmute::<*mut c_void, *mut usize>(alloc_fn(
+        core::mem::transmute::<*mut c_void, *mut usize>(alloc_fn(
             (*state_ptr).custom_allocator.opaque,
             size * core::mem::size_of::<usize>(),
-        ));
+        ))
     } else {
-        return alloc_util::alloc_stdlib(size);
+        alloc_util::alloc_stdlib(size)
     }
 }
 #[no_mangle]

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -200,17 +200,15 @@ pub unsafe extern "C" fn BrotliEncoderCompressMulti(
         match res {
             Ok(size) => {
                 *encoded_size = size;
-                return 1;
+                1
             }
-            Err(_err) => {
-                return 0;
-            }
+            Err(_err) => 0,
         }
     }) {
-        Ok(ret) => return ret,
+        Ok(ret) => ret,
         Err(panic_err) => {
             error_print(panic_err);
-            return 0;
+            0
         }
     }
 }
@@ -422,11 +420,9 @@ pub unsafe extern "C" fn BrotliEncoderCompressWorkPool(
         match res {
             Ok(size) => {
                 *encoded_size = size;
-                return 1;
+                1
             }
-            Err(_err) => {
-                return 0;
-            }
+            Err(_err) => 0,
         }
     }) {
         Ok(ret) => ret, // no panic


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#/needless_return

```
cargo clippy --fix -- -A clippy::all -W clippy::needless_return
```

Also ignored `clippy::excessive_precision` in utils because of a huge number of false positives there.