### PR TITLE
Fixed unnecessary_cast, extra parenthesis and typed literals

### DIFF
--- a/corrosion/backward_references_hq_safe.rs
+++ b/corrosion/backward_references_hq_safe.rs
@@ -440,7 +440,7 @@ pub fn BrotliZopfliCreateCommands(
     mut num_literals : &mut [usize
 ]) {
     let mut pos : usize = 0usize;
-    let mut offset : u32 = (nodes[(0usize)]).u.next;
+    let mut offset : u32 = nodes[0].u.next;
     let mut i : usize;
     let mut gap : usize = 0usize;
     i = 0usize;
@@ -1799,8 +1799,8 @@ pub fn BrotliZopfliComputeShortestPath(
     let mut i : usize;
     let mut gap : usize = 0usize;
     let mut lz_matches_offset : usize = 0usize;
-    (nodes[(0usize)]).length = 0u32;
-    (nodes[(0usize)]).u.cost = 0i32 as (f32);
+    nodes[0].length = 0;
+    nodes[0].u.cost = 0.0;
     InitZopfliCostModel(
         m,
         &mut model ,
@@ -2219,9 +2219,9 @@ fn ZopfliIterate(
     let mut queue : StartPosQueue;
     let mut cur_match_pos : usize = 0usize;
     let mut i : usize;
-    (nodes[(0usize)]).length = 0u32;
-    (nodes[(0usize)]).u.cost = 0i32 as (f32);
-    InitStartPosQueue(&mut queue );
+    nodes[0].length = 0;
+    nodes[0].u.cost = 0.0;
+    InitStartPosQueue(&mut queue);
     i = 0usize;
     while i.wrapping_add(3usize) < num_bytes {
         {

--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -412,7 +412,7 @@ impl BroCatli {
             self.any_bytes_emitted = true;
         }
         new_stream_pending.num_bytes_written =
-            Some((new_stream_pending.num_bytes_written.unwrap() + to_copy as u8));
+            Some(new_stream_pending.num_bytes_written.unwrap() + to_copy as u8);
         if new_stream_pending.num_bytes_written.unwrap() != new_stream_pending.num_bytes_read {
             self.new_stream_pending = Some(new_stream_pending);
             return BroCatliResult::NeedsMoreOutput;

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -170,7 +170,8 @@ where
         num_nodes = input_size;
     }
     let window_mask = (1 << params.lgwin) - 1;
-    let invalid_pos = 0u32.wrapping_sub(window_mask) as u32;
+    // FIXME: BUG? Should this be u32::MAX instead?
+    let invalid_pos = 0u32.wrapping_sub(window_mask);
     let buckets = <Buckets as Allocable<u32, AllocU32>>::new(m32, invalid_pos);
     H10::<AllocU32, Buckets, H10DefaultParams> {
         common: Struct1 {
@@ -302,7 +303,7 @@ where
             {
                 self.Store(data, mask, i);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     fn BulkStoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
@@ -443,7 +444,7 @@ where
     } else {
         0i32
     };
-    let key = xself.HashBytes(&data[(cur_ix_masked as (usize))..]);
+    let key = xself.HashBytes(&data[cur_ix_masked..]);
     let forest: &mut [u32] = xself.forest.slice_mut();
     let mut prev_ix: usize = xself.buckets_.slice()[key] as (usize);
     let mut node_left: usize = LeftChildIndexH10!(xself, cur_ix);
@@ -452,7 +453,7 @@ where
     let mut best_len_right: usize = 0usize;
     let mut depth_remaining: usize;
     if should_reroot_tree != 0 {
-        xself.buckets_.slice_mut()[(key as (usize))] = cur_ix as (u32);
+        xself.buckets_.slice_mut()[key] = cur_ix as u32;
     }
     depth_remaining = 64usize;
     'break16: loop {
@@ -461,8 +462,8 @@ where
             let prev_ix_masked: usize = prev_ix & ring_buffer_mask;
             if backward == 0usize || backward > max_backward || depth_remaining == 0usize {
                 if should_reroot_tree != 0 {
-                    forest[(node_left as (usize))] = xself.invalid_pos_;
-                    forest[(node_right as (usize))] = xself.invalid_pos_;
+                    forest[node_left] = xself.invalid_pos_;
+                    forest[node_right] = xself.invalid_pos_;
                 }
                 break 'break16;
             }
@@ -485,33 +486,31 @@ where
                 }
                 if len >= max_comp_len {
                     if should_reroot_tree != 0 {
-                        forest[(node_left as (usize))] =
-                            forest[(LeftChildIndexH10!(xself, prev_ix) as (usize))];
-                        forest[(node_right as (usize))] =
-                            forest[(RightChildIndexH10!(xself, prev_ix) as (usize))];
+                        forest[node_left] = forest[LeftChildIndexH10!(xself, prev_ix)];
+                        forest[node_right] = forest[RightChildIndexH10!(xself, prev_ix)];
                     }
                     break 'break16;
                 }
-                if data[(cur_ix_masked.wrapping_add(len) as (usize))] as (i32)
-                    > data[(prev_ix_masked.wrapping_add(len) as (usize))] as (i32)
+                if (data[cur_ix_masked.wrapping_add(len)] as i32)
+                    > (data[prev_ix_masked.wrapping_add(len)] as i32)
                 {
                     best_len_left = len;
                     if should_reroot_tree != 0 {
-                        forest[(node_left as (usize))] = prev_ix as (u32);
+                        forest[node_left] = prev_ix as u32;
                     }
                     node_left = RightChildIndexH10!(xself, prev_ix);
-                    prev_ix = forest[(node_left as (usize))] as (usize);
+                    prev_ix = forest[node_left] as usize;
                 } else {
                     best_len_right = len;
                     if should_reroot_tree != 0 {
-                        forest[(node_right as (usize))] = prev_ix as (u32);
+                        forest[node_right] = prev_ix as u32;
                     }
                     node_right = LeftChildIndexH10!(xself, prev_ix);
-                    prev_ix = forest[(node_right as (usize))] as (usize);
+                    prev_ix = forest[node_right] as usize;
                 }
             }
         }
-        depth_remaining = depth_remaining.wrapping_sub(1 as (usize));
+        depth_remaining = depth_remaining.wrapping_sub(1);
     }
     matches_offset
 }

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -61,8 +61,8 @@ pub fn BrotliInitZopfliNodes(array: &mut [ZopfliNode], length: usize) {
     let mut i: usize;
     i = 0usize;
     while i < length {
-        array[(i as (usize))] = stub;
-        i = i.wrapping_add(1 as (usize));
+        array[i] = stub;
+        i = i.wrapping_add(1);
     }
 }
 
@@ -113,7 +113,7 @@ pub fn BrotliZopfliCreateCommands(
     num_literals: &mut usize,
 ) {
     let mut pos: usize = 0usize;
-    let mut offset: u32 = match (nodes[(0usize)]).u {
+    let mut offset: u32 = match nodes[0].u {
         Union1::next(off) => off,
         _ => 0,
     };
@@ -122,7 +122,7 @@ pub fn BrotliZopfliCreateCommands(
     i = 0usize;
     while offset != !(0u32) {
         {
-            let next: &ZopfliNode = &nodes[(pos.wrapping_add(offset as (usize)) as (usize))];
+            let next: &ZopfliNode = &nodes[pos.wrapping_add(offset as (usize))];
             let copy_length: usize = ZopfliNodeCopyLength(next) as (usize);
             let mut insert_length: usize = (next.dcode_insert_length & 0x7ffffff) as (usize);
             pos = pos.wrapping_add(insert_length);
@@ -146,7 +146,7 @@ pub fn BrotliZopfliCreateCommands(
                 };
                 let dist_code: usize = ZopfliNodeDistanceCode(next) as (usize);
                 InitCommand(
-                    &mut commands[(i as (usize))],
+                    &mut commands[i],
                     &params.dist,
                     insert_length,
                     copy_length,
@@ -154,16 +154,16 @@ pub fn BrotliZopfliCreateCommands(
                     dist_code,
                 );
                 if is_dictionary == 0 && (dist_code > 0usize) {
-                    dist_cache[(3usize)] = dist_cache[(2usize)];
-                    dist_cache[(2usize)] = dist_cache[(1usize)];
-                    dist_cache[(1usize)] = dist_cache[(0usize)];
-                    dist_cache[(0usize)] = distance as (i32);
+                    dist_cache[3] = dist_cache[2];
+                    dist_cache[2] = dist_cache[1];
+                    dist_cache[1] = dist_cache[0];
+                    dist_cache[0] = distance as i32;
                 }
             }
             *num_literals = (*num_literals).wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     *last_insert_len = (*last_insert_len).wrapping_add(num_bytes.wrapping_sub(pos));
 }
@@ -258,34 +258,33 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
         num_bytes,
         ringbuffer_mask,
         ringbuffer,
-        &mut literal_costs[1usize..],
+        &mut literal_costs[1..],
     );
-    literal_costs[(0usize)] = 0.0 as (floatX);
+    literal_costs[0] = 0.0;
     i = 0usize;
     while i < num_bytes {
         {
-            literal_carry = literal_carry as floatX
-                + literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX;
-            literal_costs[(i.wrapping_add(1usize) as (usize))] =
-                (literal_costs[(i as (usize))] as floatX + literal_carry) as floatX;
-            literal_carry -= (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
-                - literal_costs[(i as (usize))] as floatX);
+            literal_carry = literal_carry as floatX + literal_costs[i.wrapping_add(1)] as floatX;
+            literal_costs[i.wrapping_add(1)] =
+                (literal_costs[i] as floatX + literal_carry) as floatX;
+            literal_carry -=
+                (literal_costs[i.wrapping_add(1)] as floatX - literal_costs[i] as floatX);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < BROTLI_NUM_COMMAND_SYMBOLS {
         {
-            cost_cmd[(i as (usize))] = FastLog2((11u64).wrapping_add(i as (u64))) as (floatX);
+            cost_cmd[i] = FastLog2(11u64.wrapping_add(i as u64)) as floatX;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < xself.distance_histogram_size as (usize) {
         {
-            cost_dist[(i as (usize))] = FastLog2((20u64).wrapping_add(i as (u64))) as (floatX);
+            cost_dist[i] = FastLog2(20u64.wrapping_add(i as u64)) as floatX;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     xself.min_cost_cmd_ = FastLog2(11) as (floatX);
 }
@@ -402,16 +401,16 @@ where
                     break 'break14;
                 }
                 prev_ix &= ring_buffer_mask;
-                if data[(cur_ix_masked as (usize))] as (i32) != data[(prev_ix as (usize))] as (i32)
-                    || data[(cur_ix_masked.wrapping_add(1usize) as (usize))] as (i32)
-                        != data[(prev_ix.wrapping_add(1usize) as (usize))] as (i32)
+                if data[cur_ix_masked] as i32 != data[prev_ix] as i32
+                    || data[cur_ix_masked.wrapping_add(1)] as i32
+                        != data[prev_ix.wrapping_add(1)] as i32
                 {
                     break 'continue15;
                 }
                 {
                     let len: usize = FindMatchLengthWithLimit(
-                        &data[(prev_ix as (usize))..],
-                        &data[(cur_ix_masked as (usize))..],
+                        &data[prev_ix..],
+                        &data[cur_ix_masked..],
                         max_length,
                     );
                     if len > best_len {
@@ -427,7 +426,7 @@ where
             }
             break;
         }
-        i = i.wrapping_sub(1 as (usize));
+        i = i.wrapping_sub(1);
     }
     if best_len < max_length {
         let loc_offset = StoreAndFindMatchesH10(
@@ -445,16 +444,16 @@ where
     i = 0usize;
     while i <= 37usize {
         {
-            dict_matches[(i as (usize))] = kInvalidMatch;
+            dict_matches[i] = kInvalidMatch;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     {
         let minlen: usize = brotli_max_size_t(4usize, best_len.wrapping_add(1usize));
         if dictionary.is_some()
             && BrotliFindAllStaticDictionaryMatches(
                 dictionary.unwrap(),
-                &data[(cur_ix_masked as (usize))..],
+                &data[cur_ix_masked..],
                 minlen,
                 max_length,
                 &mut dict_matches[..],
@@ -466,7 +465,7 @@ where
             l = minlen;
             while l <= maxlen {
                 {
-                    let dict_id: u32 = dict_matches[(l as (usize))];
+                    let dict_id: u32 = dict_matches[l];
                     if dict_id < kInvalidMatch {
                         let distance: usize = max_backward
                             .wrapping_add(gap)
@@ -483,7 +482,7 @@ where
                         }
                     }
                 }
-                l = l.wrapping_add(1 as (usize));
+                l = l.wrapping_add(1);
             }
         }
     }
@@ -508,18 +507,18 @@ fn ComputeDistanceShortcut(
     gap: usize,
     nodes: &[ZopfliNode],
 ) -> u32 {
-    let clen: usize = ZopfliNodeCopyLength(&nodes[(pos as (usize))]) as (usize);
-    let ilen: usize = ((nodes[(pos as (usize))]).dcode_insert_length) as (usize) & 0x7ffffff;
-    let dist: usize = ZopfliNodeCopyDistance(&nodes[(pos as (usize))]) as (usize);
+    let clen: usize = ZopfliNodeCopyLength(&nodes[pos]) as usize;
+    let ilen: usize = (nodes[pos].dcode_insert_length) as usize & 0x7ffffff;
+    let dist: usize = ZopfliNodeCopyDistance(&nodes[pos]) as usize;
     if pos == 0usize {
         0u32
     } else if dist.wrapping_add(clen) <= block_start.wrapping_add(pos).wrapping_add(gap)
         && (dist <= max_backward.wrapping_add(gap))
-        && (ZopfliNodeDistanceCode(&nodes[(pos as (usize))]) > 0u32)
+        && (ZopfliNodeDistanceCode(&nodes[pos]) > 0)
     {
         pos as (u32)
     } else {
-        match (nodes[(pos.wrapping_sub(clen).wrapping_sub(ilen) as (usize))]).u {
+        match nodes[pos.wrapping_sub(clen).wrapping_sub(ilen)].u {
             Union1::shortcut(shrt) => shrt,
             _ => 0,
         }
@@ -532,7 +531,7 @@ fn ZopfliCostModelGetLiteralCosts<AllocF: Allocator<floatX>>(
     from: usize,
     to: usize,
 ) -> floatX {
-    xself.literal_costs_.slice()[(to as (usize))] - xself.literal_costs_.slice()[(from as (usize))]
+    xself.literal_costs_.slice()[to] - xself.literal_costs_.slice()[from]
 }
 fn ComputeDistanceCache(
     pos: usize,
@@ -541,14 +540,14 @@ fn ComputeDistanceCache(
     dist_cache: &mut [i32],
 ) {
     let mut idx: i32 = 0i32;
-    let mut p: usize = match (nodes[(pos as (usize))]).u {
+    let mut p: usize = match nodes[pos].u {
         Union1::shortcut(shrt) => shrt,
         _ => 0,
     } as (usize);
     while idx < 4i32 && (p > 0usize) {
-        let ilen: usize = ((nodes[(p as (usize))]).dcode_insert_length) as (usize) & 0x7ffffff;
-        let clen: usize = ZopfliNodeCopyLength(&nodes[(p as (usize))]) as (usize);
-        let dist: usize = ZopfliNodeCopyDistance(&nodes[(p as (usize))]) as (usize);
+        let ilen: usize = nodes[p].dcode_insert_length as usize & 0x7ffffff;
+        let clen = ZopfliNodeCopyLength(&nodes[p]) as usize;
+        let dist = ZopfliNodeCopyDistance(&nodes[p]) as usize;
         dist_cache[({
             let _old = idx;
             idx += 1;
@@ -579,27 +578,24 @@ fn StartPosQueueSize(xself: &StartPosQueue) -> usize {
 fn StartPosQueuePush(xself: &mut StartPosQueue, posdata: &PosData) {
     let mut offset: usize = !{
         let _old = xself.idx_;
-        xself.idx_ = xself.idx_.wrapping_add(1 as (usize));
+        xself.idx_ = xself.idx_.wrapping_add(1);
         _old
     } & 7usize;
     let len: usize = StartPosQueueSize(xself);
     let mut i: usize;
     let q: &mut [PosData; 8] = &mut xself.q_;
-    q[(offset as (usize))] = *posdata;
+    q[offset] = *posdata;
     i = 1usize;
     while i < len {
         {
-            if (q[((offset & 7usize) as (usize))]).costdiff
-                > (q[((offset.wrapping_add(1usize) & 7usize) as (usize))]).costdiff
-            {
-                let mut __brotli_swap_tmp: PosData = q[((offset & 7usize) as (usize))];
-                q[((offset & 7usize) as (usize))] =
-                    q[((offset.wrapping_add(1usize) & 7usize) as (usize))];
-                q[((offset.wrapping_add(1usize) & 7usize) as (usize))] = __brotli_swap_tmp;
+            if q[offset & 7usize].costdiff > q[offset.wrapping_add(1) & 7usize].costdiff {
+                let __brotli_swap_tmp: PosData = q[offset & 7usize];
+                q[offset & 7usize] = q[offset.wrapping_add(1) & 7usize];
+                q[offset.wrapping_add(1) & 7usize] = __brotli_swap_tmp;
             }
-            offset = offset.wrapping_add(1 as (usize));
+            offset = offset.wrapping_add(1);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -613,11 +609,11 @@ fn EvaluateNode<AllocF: Allocator<floatX>>(
     queue: &mut StartPosQueue,
     nodes: &mut [ZopfliNode],
 ) {
-    let node_cost: floatX = match (nodes[(pos as (usize))]).u {
+    let node_cost: floatX = match nodes[pos].u {
         Union1::cost(cst) => cst,
         _ => 0.0,
     };
-    (nodes[(pos as (usize))]).u = Union1::shortcut(ComputeDistanceShortcut(
+    nodes[pos].u = Union1::shortcut(ComputeDistanceShortcut(
         block_start,
         pos,
         max_backward_limit,
@@ -643,7 +639,7 @@ fn EvaluateNode<AllocF: Allocator<floatX>>(
 
 #[inline(always)]
 fn StartPosQueueAt(xself: &StartPosQueue, k: usize) -> &PosData {
-    &xself.q_[((k.wrapping_sub(xself.idx_) & 7usize) as (usize))]
+    &xself.q_[k.wrapping_sub(xself.idx_) & 7usize]
 }
 
 #[inline(always)]
@@ -665,12 +661,12 @@ fn ComputeMinimumCopyLength(
     let mut next_len_bucket: usize = 4usize;
     let mut next_len_offset: usize = 10usize;
     while pos.wrapping_add(len) <= num_bytes
-        && (match (nodes[(pos.wrapping_add(len) as (usize))]).u {
+        && (match nodes[pos.wrapping_add(len)].u {
             Union1::cost(cst) => cst,
             _ => 0.0,
         } <= min_cost)
     {
-        len = len.wrapping_add(1 as (usize));
+        len = len.wrapping_add(1);
         if len == next_len_offset {
             min_cost += 1.0 as floatX;
             next_len_offset = next_len_offset.wrapping_add(next_len_bucket);
@@ -689,7 +685,7 @@ fn ZopfliCostModelGetDistanceCost<AllocF: Allocator<floatX>>(
     xself: &ZopfliCostModel<AllocF>,
     distcode: usize,
 ) -> floatX {
-    xself.cost_dist_.slice()[(distcode as (usize))]
+    xself.cost_dist_.slice()[distcode]
 }
 
 #[inline(always)]
@@ -716,7 +712,7 @@ fn UpdateZopfliNode(
     short_code: usize,
     cost: floatX,
 ) {
-    let next = &mut nodes[(pos.wrapping_add(len) as (usize))];
+    let next = &mut nodes[pos.wrapping_add(len)];
     next.length =
         (len | len.wrapping_add(9u32 as (usize)).wrapping_sub(len_code) << 25i32) as (u32);
     next.distance = dist as (u32);
@@ -792,20 +788,19 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                 'break29: while j < 16usize && (best_len < max_len) {
                     'continue30: loop {
                         {
-                            let idx: usize = kDistanceCacheIndex[(j as (usize))] as (usize);
+                            let idx = kDistanceCacheIndex[j] as usize;
                             let distance_cache_len_minus_1 = 3;
                             debug_assert_eq!(
                                 distance_cache_len_minus_1 + 1,
                                 posdata.distance_cache.len()
                             );
                             let backward: usize = (posdata.distance_cache
-                                [(idx as (usize) & distance_cache_len_minus_1)]
-                                + i32::from(kDistanceCacheOffset[(j as (usize))]))
-                                as (usize);
+                                [idx & distance_cache_len_minus_1]
+                                + i32::from(kDistanceCacheOffset[j]))
+                                as usize;
                             let mut prev_ix: usize = cur_ix.wrapping_sub(backward);
                             let len: usize;
-                            let continuation: u8 =
-                                ringbuffer[(cur_ix_masked.wrapping_add(best_len) as (usize))];
+                            let continuation: u8 = ringbuffer[cur_ix_masked.wrapping_add(best_len)];
                             if cur_ix_masked.wrapping_add(best_len) > ringbuffer_mask {
                                 break 'break29;
                             }
@@ -818,15 +813,14 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 }
                                 prev_ix &= ringbuffer_mask;
                                 if prev_ix.wrapping_add(best_len) > ringbuffer_mask
-                                    || continuation as (i32)
-                                        != ringbuffer[(prev_ix.wrapping_add(best_len) as (usize))]
-                                            as (i32)
+                                    || (continuation as i32)
+                                        != (ringbuffer[prev_ix.wrapping_add(best_len)] as i32)
                                 {
                                     break 'continue30;
                                 }
                                 len = FindMatchLengthWithLimit(
-                                    &ringbuffer[(prev_ix as (usize))..],
-                                    &ringbuffer[(cur_ix_masked as (usize))..],
+                                    &ringbuffer[prev_ix..],
+                                    &ringbuffer[cur_ix_masked..],
                                     max_len,
                                 );
                             } else {
@@ -852,7 +846,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                         }) + GetCopyExtra(copycode) as (floatX)
                                             + ZopfliCostModelGetCommandCost(model, cmdcode);
                                         if cost
-                                            < match (nodes[(pos.wrapping_add(l) as (usize))]).u {
+                                            < match nodes[pos.wrapping_add(l)].u {
                                                 Union1::cost(cost) => cost,
                                                 _ => 0.0,
                                             }
@@ -871,13 +865,13 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                         }
                                         best_len = l;
                                     }
-                                    l = l.wrapping_add(1 as (usize));
+                                    l = l.wrapping_add(1);
                                 }
                             }
                         }
                         break;
                     }
-                    j = j.wrapping_add(1 as (usize));
+                    j = j.wrapping_add(1);
                 }
                 if k >= 2usize {
                     break 'continue28;
@@ -887,7 +881,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                     j = 0usize;
                     while j < num_matches {
                         {
-                            let mut match_: BackwardMatch = BackwardMatch(matches[(j as (usize))]);
+                            let mut match_ = BackwardMatch(matches[j]);
                             let dist: usize = match_.distance() as (usize);
                             let is_dictionary_match: i32 =
                                 if !!(dist > max_distance.wrapping_add(gap)) {
@@ -931,8 +925,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                     let cost: floatX = dist_cost
                                         + GetCopyExtra(copycode) as (floatX)
                                         + ZopfliCostModelGetCommandCost(model, cmdcode);
-                                    if let Union1::cost(nodeCost) =
-                                        (nodes[(pos.wrapping_add(len) as (usize))]).u
+                                    if let Union1::cost(nodeCost) = nodes[(pos.wrapping_add(len))].u
                                     {
                                         if cost < nodeCost {
                                             UpdateZopfliNode(
@@ -943,16 +936,16 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                         }
                                     }
                                 }
-                                len = len.wrapping_add(1 as (usize));
+                                len = len.wrapping_add(1);
                             }
                         }
-                        j = j.wrapping_add(1 as (usize));
+                        j = j.wrapping_add(1);
                     }
                 }
             }
             break;
         }
-        k = k.wrapping_add(1 as (usize));
+        k = k.wrapping_add(1);
     }
     result
 }
@@ -979,17 +972,15 @@ fn ZopfliNodeCommandLength(xself: &ZopfliNode) -> u32 {
 fn ComputeShortestPathFromNodes(num_bytes: usize, nodes: &mut [ZopfliNode]) -> usize {
     let mut index: usize = num_bytes;
     let mut num_commands: usize = 0usize;
-    while ((nodes[(index as (usize))]).dcode_insert_length & 0x7ffffff) == 0
-        && ((nodes[(index as (usize))]).length == 1u32)
-    {
-        index = index.wrapping_sub(1 as (usize));
+    while (nodes[index].dcode_insert_length & 0x7ffffff) == 0 && nodes[index].length == 1 {
+        index = index.wrapping_sub(1);
     }
-    nodes[(index as (usize))].u = Union1::next(!(0u32));
+    nodes[index].u = Union1::next(!(0u32));
     while index != 0usize {
-        let len: usize = ZopfliNodeCommandLength(&mut nodes[(index as (usize))]) as (usize);
+        let len = ZopfliNodeCommandLength(&mut nodes[index]) as usize;
         index = index.wrapping_sub(len);
-        (nodes[(index as (usize))]).u = Union1::next(len as (u32));
-        num_commands = num_commands.wrapping_add(1 as (usize));
+        nodes[index].u = Union1::next(len as u32);
+        num_commands = num_commands.wrapping_add(1);
     }
     num_commands
 }
@@ -1031,8 +1022,8 @@ where
     let mut i: usize;
     let gap: usize = 0usize;
     let lz_matches_offset: usize = 0usize;
-    (nodes[(0usize)]).length = 0u32;
-    (nodes[(0usize)]).u = Union1::cost(0.0);
+    nodes[0].length = 0;
+    nodes[0].u = Union1::cost(0.0);
     model = InitZopfliCostModel(m, &params.dist, num_bytes);
     if !(0i32 == 0) {
         return 0usize;
@@ -1055,15 +1046,14 @@ where
                 max_distance,
                 gap,
                 params,
-                &mut matches[(lz_matches_offset as (usize))..],
+                &mut matches[lz_matches_offset..],
             );
-            if num_matches > 0usize
-                && (BackwardMatchLength(&BackwardMatch(
-                    matches[(num_matches.wrapping_sub(1usize) as (usize))],
-                )) > max_zopfli_len)
+            if num_matches > 0
+                && BackwardMatchLength(&BackwardMatch(matches[num_matches.wrapping_sub(1)]))
+                    > max_zopfli_len
             {
-                matches[(0usize)] = matches[(num_matches.wrapping_sub(1usize) as (usize))];
-                num_matches = 1usize;
+                matches[0] = matches[num_matches.wrapping_sub(1)];
+                num_matches = 1;
             }
             skip = UpdateNodes(
                 num_bytes,
@@ -1084,10 +1074,9 @@ where
                 skip = 0usize;
             }
             if num_matches == 1usize
-                && (BackwardMatchLength(&BackwardMatch(matches[(0usize)])) > max_zopfli_len)
+                && (BackwardMatchLength(&BackwardMatch(matches[0])) > max_zopfli_len)
             {
-                skip =
-                    brotli_max_size_t(BackwardMatchLength(&BackwardMatch(matches[(0usize)])), skip);
+                skip = brotli_max_size_t(BackwardMatchLength(&BackwardMatch(matches[0])), skip);
             }
             if skip > 1usize {
                 handle.StoreRange(
@@ -1096,9 +1085,9 @@ where
                     pos.wrapping_add(1usize),
                     brotli_min_size_t(pos.wrapping_add(skip), store_end),
                 );
-                skip = skip.wrapping_sub(1 as (usize));
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as (usize));
+                    i = i.wrapping_add(1);
                     if i.wrapping_add(handle.HashTypeLength()).wrapping_sub(1usize) >= num_bytes {
                         break;
                     }
@@ -1112,11 +1101,11 @@ where
                         &mut queue,
                         nodes,
                     );
-                    skip = skip.wrapping_sub(1 as (usize));
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 
     CleanupZopfliCostModel(m, &mut model);
@@ -1195,22 +1184,18 @@ fn SetCost(histogram: &[u32], histogram_size: usize, literal_histogram: i32, cos
     let mut i: usize;
     i = 0usize;
     while i < histogram_size {
-        {
-            sum = sum.wrapping_add(u64::from(histogram[(i as (usize))]));
-        }
-        i = i.wrapping_add(1 as (usize));
+        sum = sum.wrapping_add(u64::from(histogram[i]));
+        i = i.wrapping_add(1);
     }
     let log2sum: floatX = FastLog2(sum) as (floatX);
     missing_symbol_sum = sum;
     if literal_histogram == 0 {
         i = 0usize;
         while i < histogram_size {
-            {
-                if histogram[(i as (usize))] == 0u32 {
-                    missing_symbol_sum = missing_symbol_sum.wrapping_add(1);
-                }
+            if histogram[i] == 0 {
+                missing_symbol_sum = missing_symbol_sum.wrapping_add(1);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     let missing_symbol_cost: floatX =
@@ -1219,19 +1204,18 @@ fn SetCost(histogram: &[u32], histogram_size: usize, literal_histogram: i32, cos
     while i < histogram_size {
         'continue56: loop {
             {
-                if histogram[(i as (usize))] == 0u32 {
-                    cost[(i as (usize))] = missing_symbol_cost;
+                if histogram[i] == 0 {
+                    cost[i] = missing_symbol_cost;
                     break 'continue56;
                 }
-                cost[(i as (usize))] =
-                    log2sum - FastLog2(u64::from(histogram[(i as (usize))])) as (floatX);
-                if cost[(i as (usize))] < 1i32 as (floatX) {
-                    cost[(i as (usize))] = 1i32 as (floatX);
+                cost[i] = log2sum - FastLog2(u64::from(histogram[i])) as (floatX);
+                if cost[i] < 1.0 {
+                    cost[i] = 1.0;
                 }
             }
             break;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -1264,36 +1248,34 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
     i = 0usize;
     while i < num_commands {
         {
-            let inslength: usize = (commands[(i as (usize))]).insert_len_ as (usize);
-            let copylength: usize = CommandCopyLen(&commands[(i as (usize))]) as (usize);
-            let distcode: usize =
-                ((commands[(i as (usize))]).dist_prefix_ as (i32) & 0x3ff) as (usize);
-            let cmdcode: usize = (commands[(i as (usize))]).cmd_prefix_ as (usize);
+            let inslength = commands[i].insert_len_ as usize;
+            let copylength = CommandCopyLen(&commands[i]) as usize;
+            let distcode = (commands[i].dist_prefix_ as (i32) & 0x3ff) as usize;
+            let cmdcode = commands[i].cmd_prefix_ as usize;
             let mut j: usize;
             {
                 let _rhs = 1;
-                let _lhs = &mut histogram_cmd[(cmdcode as (usize))];
+                let _lhs = &mut histogram_cmd[cmdcode];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
             }
             if cmdcode >= 128usize {
                 let _rhs = 1;
-                let _lhs = &mut histogram_dist[(distcode as (usize))];
+                let _lhs = &mut histogram_dist[distcode];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
             }
             j = 0usize;
             while j < inslength {
                 {
                     let _rhs = 1;
-                    let _lhs = &mut histogram_literal[(ringbuffer
-                        [((pos.wrapping_add(j) & ringbuffer_mask) as (usize))]
-                        as (usize))];
+                    let _lhs = &mut histogram_literal
+                        [ringbuffer[pos.wrapping_add(j) & ringbuffer_mask] as usize];
                     *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
                 }
-                j = j.wrapping_add(1 as (usize));
+                j = j.wrapping_add(1);
             }
             pos = pos.wrapping_add(inslength.wrapping_add(copylength));
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     SetCost(
         &histogram_literal[..],
@@ -1315,29 +1297,27 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
     );
     i = 0usize;
     while i < 704usize {
-        {
-            min_cost_cmd = brotli_min_float(min_cost_cmd, cost_cmd[(i as (usize))]);
-        }
-        i = i.wrapping_add(1 as (usize));
+        min_cost_cmd = brotli_min_float(min_cost_cmd, cost_cmd[i]);
+        i = i.wrapping_add(1);
     }
     xself.min_cost_cmd_ = min_cost_cmd;
     {
         let literal_costs: &mut [floatX] = xself.literal_costs_.slice_mut();
         let mut literal_carry: floatX = 0.0;
         let num_bytes: usize = xself.num_bytes_;
-        literal_costs[(0usize)] = 0.0 as (floatX);
-        i = 0usize;
+        literal_costs[0] = 0.0;
+        i = 0;
         while i < num_bytes {
             {
-                literal_carry += cost_literal[(ringbuffer
-                    [((position.wrapping_add(i) & ringbuffer_mask) as (usize))]
-                    as (usize))] as floatX;
-                literal_costs[(i.wrapping_add(1usize) as (usize))] =
-                    (literal_costs[(i as (usize))] as floatX + literal_carry) as floatX;
-                literal_carry -= (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
-                    - literal_costs[(i as (usize))] as floatX);
+                literal_carry += cost_literal
+                    [ringbuffer[position.wrapping_add(i) & ringbuffer_mask] as (usize)]
+                    as floatX;
+                literal_costs[i.wrapping_add(1)] =
+                    (literal_costs[i] as floatX + literal_carry) as floatX;
+                literal_carry -=
+                    (literal_costs[i.wrapping_add(1)] as floatX - literal_costs[i] as floatX);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -1360,8 +1340,8 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
     let mut queue: StartPosQueue;
     let mut cur_match_pos: usize = 0usize;
     let mut i: usize;
-    (nodes[(0usize)]).length = 0u32;
-    (nodes[(0usize)]).u = Union1::cost(0.0);
+    nodes[0].length = 0;
+    nodes[0].u = Union1::cost(0.0);
     queue = InitStartPosQueue();
     i = 0usize;
     while i.wrapping_add(3usize) < num_bytes {
@@ -1375,8 +1355,8 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
                 params,
                 max_backward_limit,
                 dist_cache,
-                num_matches[(i as (usize))] as (usize),
-                &matches[(cur_match_pos as (usize))..],
+                num_matches[i] as usize,
+                &matches[cur_match_pos..],
                 model,
                 &mut queue,
                 nodes,
@@ -1384,24 +1364,21 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
             if skip < 16384usize {
                 skip = 0usize;
             }
-            cur_match_pos = cur_match_pos.wrapping_add(num_matches[(i as (usize))] as (usize));
-            if num_matches[(i as (usize))] == 1u32
-                && (BackwardMatchLength(&BackwardMatch(
-                    matches[(cur_match_pos.wrapping_sub(1usize) as (usize))],
-                )) > max_zopfli_len)
+            cur_match_pos = cur_match_pos.wrapping_add(num_matches[i] as usize);
+            if num_matches[i] == 1
+                && (BackwardMatchLength(&BackwardMatch(matches[cur_match_pos.wrapping_sub(1)]))
+                    > max_zopfli_len)
             {
                 skip = brotli_max_size_t(
-                    BackwardMatchLength(&BackwardMatch(
-                        matches[(cur_match_pos.wrapping_sub(1usize) as (usize))],
-                    )),
+                    BackwardMatchLength(&BackwardMatch(matches[cur_match_pos.wrapping_sub(1)])),
                     skip,
                 );
             }
-            if skip > 1usize {
-                skip = skip.wrapping_sub(1 as (usize));
+            if skip > 1 {
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as (usize));
-                    if i.wrapping_add(3usize) >= num_bytes {
+                    i = i.wrapping_add(1);
+                    if i.wrapping_add(3) >= num_bytes {
                         break;
                     }
                     EvaluateNode(
@@ -1414,13 +1391,12 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
                         &mut queue,
                         nodes,
                     );
-                    cur_match_pos =
-                        cur_match_pos.wrapping_add(num_matches[(i as (usize))] as (usize));
-                    skip = skip.wrapping_sub(1 as (usize));
+                    cur_match_pos = cur_match_pos.wrapping_add(num_matches[i] as usize);
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     ComputeShortestPathFromNodes(num_bytes, nodes)
 }
@@ -1540,28 +1516,27 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                 max_distance,
                 gap,
                 params,
-                &mut matches.slice_mut()[(cur_match_pos.wrapping_add(shadow_matches) as (usize))..],
+                &mut matches.slice_mut()[cur_match_pos.wrapping_add(shadow_matches)..],
             );
             let cur_match_end: usize = cur_match_pos.wrapping_add(num_found_matches);
             j = cur_match_pos;
             while j.wrapping_add(1usize) < cur_match_end {
-                {}
-                j = j.wrapping_add(1 as (usize));
+                j = j.wrapping_add(1);
             }
-            num_matches.slice_mut()[(i as (usize))] = num_found_matches as (u32);
+            num_matches.slice_mut()[i] = num_found_matches as u32;
             if num_found_matches > 0usize {
                 let match_len: usize = BackwardMatchLength(&BackwardMatch(
-                    matches.slice()[(cur_match_end.wrapping_sub(1usize) as (usize))],
+                    matches.slice()[cur_match_end.wrapping_sub(1)],
                 ));
                 if match_len > 325usize {
                     let skip: usize = match_len.wrapping_sub(1usize);
-                    let tmp = matches.slice()[(cur_match_end.wrapping_sub(1usize) as (usize))];
-                    matches.slice_mut()[({
+                    let tmp = matches.slice()[cur_match_end.wrapping_sub(1)];
+                    matches.slice_mut()[{
                         let _old = cur_match_pos;
-                        cur_match_pos = cur_match_pos.wrapping_add(1 as (usize));
+                        cur_match_pos = cur_match_pos.wrapping_add(1);
                         _old
-                    } as (usize))] = tmp;
-                    num_matches.slice_mut()[(i as (usize))] = 1u32;
+                    }] = tmp;
+                    num_matches.slice_mut()[i] = 1;
                     hasher.StoreRange(
                         ringbuffer,
                         ringbuffer_mask,
@@ -1584,7 +1559,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     let orig_num_literals: usize = *num_literals;
     let orig_last_insert_len: usize = *last_insert_len;
@@ -1668,7 +1643,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                 num_literals,
             );
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     CleanupZopfliCostModel(alloc, &mut model);
     {

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -310,7 +310,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         self.buckets_.HashBytes(data) as usize
     }
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        let (_, data_window) = data.split_at((ix & mask) as (usize));
+        let (_, data_window) = data.split_at(ix & mask);
         let key: u32 = self.HashBytes(data_window) as u32;
         let off: u32 = (ix >> 3i32).wrapping_rem(self.buckets_.BUCKET_SWEEP() as usize) as (u32);
         self.buckets_.slice_mut()[key.wrapping_add(off) as (usize)] = ix as (u32);
@@ -330,7 +330,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         let partial_prepare_threshold = (4 << self.buckets_.BUCKET_BITS()) >> 7;
         if one_shot && input_size <= partial_prepare_threshold {
             for i in 0..input_size {
-                let key = self.HashBytes(&data[i..]) as usize;
+                let key = self.HashBytes(&data[i..]);
                 let bs = self.buckets_.BUCKET_SWEEP() as usize;
                 for item in self.buckets_.slice_mut()[key..(key + bs)].iter_mut() {
                     *item = 0;
@@ -362,21 +362,20 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         let opts = self.Opts();
         let best_len_in: usize = out.len;
         let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
-        let key: u32 = self.HashBytes(&data[(cur_ix_masked as (usize))..]) as u32;
-        let mut compare_char: i32 =
-            data[(cur_ix_masked.wrapping_add(best_len_in) as (usize))] as (i32);
+        let key: u32 = self.HashBytes(&data[cur_ix_masked..]) as u32;
+        let mut compare_char = data[cur_ix_masked.wrapping_add(best_len_in)] as i32;
         let mut best_score: u64 = out.score;
         let mut best_len: usize = best_len_in;
-        let cached_backward: usize = distance_cache[(0usize)] as (usize);
+        let cached_backward = distance_cache[0] as usize;
         let mut prev_ix: usize = cur_ix.wrapping_sub(cached_backward);
         let mut is_match_found: i32 = 0i32;
         out.len_x_code = 0usize;
         if prev_ix < cur_ix {
             prev_ix &= ring_buffer_mask as (u32) as (usize);
-            if compare_char == data[(prev_ix.wrapping_add(best_len) as (usize))] as (i32) {
+            if compare_char == data[prev_ix.wrapping_add(best_len)] as i32 {
                 let len: usize = FindMatchLengthWithLimitMin4(
-                    &data[(prev_ix as (usize))..],
-                    &data[(cur_ix_masked as (usize))..],
+                    &data[prev_ix..],
+                    &data[cur_ix_masked..],
                     max_length,
                 );
                 if len != 0 {
@@ -385,7 +384,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                     out.len = len;
                     out.distance = cached_backward;
                     out.score = best_score;
-                    compare_char = data[(cur_ix_masked.wrapping_add(best_len) as (usize))] as (i32);
+                    compare_char = data[cur_ix_masked.wrapping_add(best_len)] as i32;
                     if self.buckets_.BUCKET_SWEEP() == 1i32 {
                         self.buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
                         return true;
@@ -401,17 +400,14 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
             self.buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
             let backward: usize = cur_ix.wrapping_sub(prev_ix);
             prev_ix &= ring_buffer_mask as (u32) as (usize);
-            if compare_char != data[(prev_ix.wrapping_add(best_len_in) as (usize))] as (i32) {
+            if compare_char != data[prev_ix.wrapping_add(best_len_in)] as i32 {
                 return false;
             }
             if backward == 0usize || backward > max_backward {
                 return false;
             }
-            let len: usize = FindMatchLengthWithLimitMin4(
-                &data[(prev_ix as (usize))..],
-                &data[(cur_ix_masked as (usize))..],
-                max_length,
-            );
+            let len: usize =
+                FindMatchLengthWithLimitMin4(&data[prev_ix..], &data[cur_ix_masked..], max_length);
             if len != 0 {
                 out.len = len;
                 out.distance = backward;
@@ -425,15 +421,15 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                 let mut prev_ix = *prev_ix_ref as usize;
                 let backward: usize = cur_ix.wrapping_sub(prev_ix);
                 prev_ix &= ring_buffer_mask as (u32) as (usize);
-                if compare_char != data[(prev_ix.wrapping_add(best_len) as (usize))] as (i32) {
+                if compare_char != data[prev_ix.wrapping_add(best_len)] as i32 {
                     continue;
                 }
                 if backward == 0usize || backward > max_backward {
                     continue;
                 }
                 let len = FindMatchLengthWithLimitMin4(
-                    &data[(prev_ix as (usize))..],
-                    &data[(cur_ix_masked as (usize))..],
+                    &data[prev_ix..],
+                    &data[cur_ix_masked..],
                     max_length,
                 );
                 if len != 0 {
@@ -444,8 +440,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                         out.len = best_len;
                         out.distance = backward;
                         out.score = score;
-                        compare_char =
-                            data[(cur_ix_masked.wrapping_add(best_len) as (usize))] as (i32);
+                        compare_char = data[cur_ix_masked.wrapping_add(best_len)] as i32;
                         is_match_found = 1i32;
                     }
                 }
@@ -456,7 +451,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                 dictionary.unwrap(),
                 dictionary_hash,
                 self,
-                &data[(cur_ix_masked as (usize))..],
+                &data[cur_ix_masked..],
                 max_length,
                 max_backward.wrapping_add(gap),
                 max_distance,
@@ -620,21 +615,21 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> PartialEq<H9<Alloc>> 
 
 fn adv_prepare_distance_cache(distance_cache: &mut [i32], num_distances: i32) {
     if num_distances > 4i32 {
-        let last_distance: i32 = distance_cache[(0usize)];
-        distance_cache[(4usize)] = last_distance - 1i32;
-        distance_cache[(5usize)] = last_distance + 1i32;
-        distance_cache[(6usize)] = last_distance - 2i32;
-        distance_cache[(7usize)] = last_distance + 2i32;
-        distance_cache[(8usize)] = last_distance - 3i32;
-        distance_cache[(9usize)] = last_distance + 3i32;
+        let last_distance: i32 = distance_cache[0];
+        distance_cache[4] = last_distance - 1;
+        distance_cache[5] = last_distance + 1;
+        distance_cache[6] = last_distance - 2;
+        distance_cache[7] = last_distance + 2;
+        distance_cache[8] = last_distance - 3;
+        distance_cache[9] = last_distance + 3;
         if num_distances > 10i32 {
-            let next_last_distance: i32 = distance_cache[(1usize)];
-            distance_cache[(10usize)] = next_last_distance - 1i32;
-            distance_cache[(11usize)] = next_last_distance + 1i32;
-            distance_cache[(12usize)] = next_last_distance - 2i32;
-            distance_cache[(13usize)] = next_last_distance + 2i32;
-            distance_cache[(14usize)] = next_last_distance - 3i32;
-            distance_cache[(15usize)] = next_last_distance + 3i32;
+            let next_last_distance: i32 = distance_cache[1];
+            distance_cache[10] = next_last_distance - 1;
+            distance_cache[11] = next_last_distance + 1;
+            distance_cache[12] = next_last_distance - 2;
+            distance_cache[13] = next_last_distance + 2;
+            distance_cache[14] = next_last_distance - 3;
+            distance_cache[15] = next_last_distance + 3;
         }
     }
 }
@@ -765,11 +760,8 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
                 continue;
             }
             {
-                let len: usize = FindMatchLengthWithLimit(
-                    &data[(prev_ix as (usize))..],
-                    &data[(cur_ix_masked as (usize))..],
-                    max_length,
-                );
+                let len: usize =
+                    FindMatchLengthWithLimit(&data[prev_ix..], &data[cur_ix_masked..], max_length);
                 if len >= 3 || (len == 2 && i < 2) {
                     let score = BackwardReferenceScoreUsingLastDistanceH9(len, i, self.h9_opts);
                     if best_score < score {
@@ -805,20 +797,20 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
             while i > down {
                 i -= 1;
                 let mut prev_ix = bucket[i & H9_BLOCK_MASK] as usize;
-                let backward = cur_ix.wrapping_sub(prev_ix) as usize;
+                let backward = cur_ix.wrapping_sub(prev_ix);
                 if (backward > max_backward) {
                     break;
                 }
                 prev_ix &= ring_buffer_mask;
                 if (prev_ix.wrapping_add(best_len) > ring_buffer_mask
-                    || prev_best_val != data[prev_ix.wrapping_add(best_len) as usize])
+                    || prev_best_val != data[prev_ix.wrapping_add(best_len)])
                 {
                     continue;
                 }
                 {
                     let len = FindMatchLengthWithLimit(
                         data.split_at(prev_ix).1,
-                        data.split_at((cur_ix_masked as usize)).1,
+                        data.split_at(cur_ix_masked).1,
                         max_length,
                     );
                     if (len >= 4) {
@@ -836,7 +828,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
                             if cur_ix_masked.wrapping_add(best_len) > ring_buffer_mask {
                                 break;
                             }
-                            prev_best_val = data[cur_ix_masked.wrapping_add(best_len) as usize];
+                            prev_best_val = data[cur_ix_masked.wrapping_add(best_len)];
                         }
                     }
                 }
@@ -845,7 +837,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
             *self_num_key = self_num_key.wrapping_add(1);
         }
         if is_match_found == 0 && dictionary.is_some() {
-            let (_, cur_data) = data.split_at(cur_ix_masked as usize);
+            let (_, cur_data) = data.split_at(cur_ix_masked);
             is_match_found = SearchInStaticDictionary(
                 dictionary.unwrap(),
                 dictionary_hash,
@@ -862,7 +854,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
     }
 
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        let (_, data_window) = data.split_at((ix & mask) as (usize));
+        let (_, data_window) = data.split_at(ix & mask);
         let key: u32 = self.HashBytes(data_window) as u32;
         let self_num_key = &mut self.num_.slice_mut()[key as usize];
         let minor_ix: usize = (*self_num_key as usize & H9_BLOCK_MASK);
@@ -1133,7 +1125,7 @@ impl AdvHashSpecialization for H6Sub {
 }
 
 fn BackwardReferencePenaltyUsingLastDistance(distance_short_code: usize) -> u64 {
-    (39u64).wrapping_add((0x1ca10u64 >> (distance_short_code & 0xeusize) & 0xeu64))
+    (39u64).wrapping_add(0x1ca10u64 >> (distance_short_code & 0xeusize) & 0xeu64)
 }
 
 impl<
@@ -1621,10 +1613,10 @@ impl<
         buckets[offset3] = (ix + 12) as u32;
     }
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        let (_, data_window) = data.split_at((ix & mask) as (usize));
+        let (_, data_window) = data.split_at(ix & mask);
         let key: u32 = self.HashBytes(data_window) as u32;
         let minor_ix: usize = (self.num.slice()[(key as (usize))] as (u32)
-            & self.specialization.block_mask() as u32) as (usize);
+            & self.specialization.block_mask()) as usize;
         let offset: usize =
             minor_ix.wrapping_add((key << self.specialization.block_bits()) as (usize));
         self.buckets.slice_mut()[offset] = ix as (u32);
@@ -1687,7 +1679,7 @@ impl<
         while i < self.GetHasherCommon.params.num_last_distances_to_check as (usize) {
             'continue45: loop {
                 {
-                    let backward: usize = distance_cache[(i as (usize))] as (usize);
+                    let backward = distance_cache[i] as usize;
                     let mut prev_ix: usize = cur_ix.wrapping_sub(backward);
                     if prev_ix >= cur_ix {
                         break 'continue45;
@@ -1725,7 +1717,7 @@ impl<
                 }
                 break;
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         {
             let key: u32 = self.HashBytes(cur_data) as u32;
@@ -1764,7 +1756,7 @@ impl<
                     if backward > max_backward {
                         break;
                     }
-                    let prev_data = data.split_at(prev_ix as usize).1;
+                    let prev_data = data.split_at(prev_ix).1;
                     let len = FindMatchLengthWithLimitMin4(prev_data, cur_data, max_length);
                     if len != 0 {
                         let score: u64 = BackwardReferenceScore(len, backward, opts);
@@ -1779,12 +1771,11 @@ impl<
                     }
                 }
             }
-            bucket[((num_copy as (u32) & (self).specialization.block_mask() as u32) as (usize))] =
-                cur_ix as (u32);
+            bucket[((num_copy as u32) & self.specialization.block_mask()) as usize] = cur_ix as u32;
             *num_ref_mut = num_ref_mut.wrapping_add(1);
         }
         if is_match_found == 0 && dictionary.is_some() {
-            let (_, cur_data) = data.split_at(cur_ix_masked as usize);
+            let (_, cur_data) = data.split_at(cur_ix_masked);
             is_match_found = SearchInStaticDictionary(
                 dictionary.unwrap(),
                 dictionary_hash,
@@ -1917,9 +1908,8 @@ fn TestStaticDictionaryItem(
     }
     {
         let cut: u64 = len.wrapping_sub(matchlen) as u64;
-        let transform_id: usize = (cut << 2i32)
-            .wrapping_add(kCutoffTransforms as u64 >> cut.wrapping_mul(6) & 0x3f)
-            as usize;
+        let transform_id =
+            (cut << 2i32).wrapping_add(kCutoffTransforms >> cut.wrapping_mul(6) & 0x3f) as usize;
         backward = max_backward
             .wrapping_add(dist)
             .wrapping_add(1usize)
@@ -1962,8 +1952,8 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
     i = 0usize;
     while i < if shallow != 0 { 1u32 } else { 2u32 } as (usize) {
         {
-            let item: usize = dictionary_hash[(key as (usize))] as (usize);
-            xself.dict_num_lookups = xself.dict_num_lookups.wrapping_add(1 as (usize));
+            let item = dictionary_hash[key] as usize;
+            xself.dict_num_lookups = xself.dict_num_lookups.wrapping_add(1);
             if item != 0usize {
                 let item_matches: i32 = TestStaticDictionaryItem(
                     dictionary,
@@ -1976,13 +1966,13 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
                     out,
                 );
                 if item_matches != 0 {
-                    xself.dict_num_matches = xself.dict_num_matches.wrapping_add(1 as (usize));
+                    xself.dict_num_matches = xself.dict_num_matches.wrapping_add(1);
                     is_match_found = 1i32;
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
-        key = key.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
+        key = key.wrapping_add(1);
     }
     is_match_found
 }
@@ -2432,7 +2422,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
             &mut sr,
         ) {
             let mut delayed_backward_references_in_row: i32 = 0i32;
-            max_length = max_length.wrapping_sub(1 as (usize));
+            max_length = max_length.wrapping_sub(1);
             'break6: loop {
                 'continue7: loop {
                     let cost_diff_lazy: u64 = 175;
@@ -2467,8 +2457,8 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                         &mut sr2,
                     );
                     if is_match_found && (sr2.score >= sr.score.wrapping_add(cost_diff_lazy)) {
-                        position = position.wrapping_add(1 as (usize));
-                        insert_length = insert_length.wrapping_add(1 as (usize));
+                        position = position.wrapping_add(1);
+                        insert_length = insert_length.wrapping_add(1);
                         sr = sr2;
                         if {
                             delayed_backward_references_in_row += 1;
@@ -2483,7 +2473,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                     }
                     break 'break6;
                 }
-                max_length = max_length.wrapping_sub(1 as (usize));
+                max_length = max_length.wrapping_sub(1);
             }
             apply_random_heuristics = position
                 .wrapping_add((2usize).wrapping_mul(sr.len))
@@ -2493,10 +2483,10 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                 let distance_code: usize =
                     ComputeDistanceCode(sr.distance, max_distance, dist_cache);
                 if sr.distance <= max_distance && (distance_code > 0usize) {
-                    dist_cache[(3usize)] = dist_cache[(2usize)];
-                    dist_cache[(2usize)] = dist_cache[(1usize)];
-                    dist_cache[(1usize)] = dist_cache[(0usize)];
-                    dist_cache[(0usize)] = sr.distance as (i32);
+                    dist_cache[3] = dist_cache[2];
+                    dist_cache[2] = dist_cache[1];
+                    dist_cache[1] = dist_cache[0];
+                    dist_cache[0] = sr.distance as i32;
                     hasher.PrepareDistanceCache(dist_cache);
                 }
                 new_commands_count += 1;
@@ -2524,8 +2514,8 @@ fn CreateBackwardReferences<AH: AnyHasher>(
             );
             position = position.wrapping_add(sr.len);
         } else {
-            insert_length = insert_length.wrapping_add(1 as (usize));
-            position = position.wrapping_add(1 as (usize));
+            insert_length = insert_length.wrapping_add(1);
+            position = position.wrapping_add(1);
 
             if position > apply_random_heuristics {
                 let kMargin: usize =

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -269,7 +269,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     if count == 1i32 {
         return kOneSymbolHistogramCost;
@@ -278,9 +278,9 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         return kTwoSymbolHistogramCost + (*histogram).total_count() as super::util::floatX;
     }
     if count == 3i32 {
-        let histo0: u32 = (*histogram).slice()[s[0usize]];
-        let histo1: u32 = (*histogram).slice()[s[1usize]];
-        let histo2: u32 = (*histogram).slice()[s[2usize]];
+        let histo0: u32 = (*histogram).slice()[s[0]];
+        let histo1: u32 = (*histogram).slice()[s[1]];
+        let histo2: u32 = (*histogram).slice()[s[2]];
         let histomax: u32 = brotli_max_uint32_t(histo0, brotli_max_uint32_t(histo1, histo2));
         return kThreeSymbolHistogramCost
             + (2u32).wrapping_mul(histo0.wrapping_add(histo1).wrapping_add(histo2))
@@ -295,7 +295,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
             {
                 histo[i] = (*histogram).slice()[s[i]];
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         i = 0usize;
         while i < 4usize {
@@ -308,17 +308,16 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                             histo.swap(j, i);
                         }
                     }
-                    j = j.wrapping_add(1 as (usize));
+                    j = j.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
-        let h23: u32 = histo[2usize].wrapping_add(histo[3usize]);
-        let histomax: u32 = brotli_max_uint32_t(h23, histo[0usize]);
+        let h23: u32 = histo[2].wrapping_add(histo[3]);
+        let histomax: u32 = brotli_max_uint32_t(h23, histo[0]);
         return kFourSymbolHistogramCost
             + (3u32).wrapping_mul(h23) as super::util::floatX
-            + (2u32).wrapping_mul(histo[0usize].wrapping_add(histo[1usize]))
-                as super::util::floatX
+            + (2u32).wrapping_mul(histo[0].wrapping_add(histo[1])) as super::util::floatX
             - histomax as super::util::floatX;
     }
     if vectorize_population_cost {
@@ -336,7 +335,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 nnz += 1;
             } else {
                 let mut reps: u32 = 1;
-                for hd in (*histogram).slice()[i + 1..(data_size as usize)].iter() {
+                for hd in histogram.slice()[i + 1..data_size].iter() {
                     if *hd != 0 {
                         break;
                     }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -873,11 +873,11 @@ fn BrotliStoreHuffmanTreeOfHuffmanTreeToBitMask(
             codes_to_store = codes_to_store.wrapping_sub(1);
         }
     }
-    if code_length_bitdepth[(kStorageOrder[0usize] as (usize))] as (i32) == 0i32
-        && (code_length_bitdepth[(kStorageOrder[1usize] as (usize))] as (i32) == 0i32)
+    if code_length_bitdepth[kStorageOrder[0] as usize] == 0
+        && code_length_bitdepth[kStorageOrder[1] as usize] == 0
     {
         skip_some = 2;
-        if code_length_bitdepth[(kStorageOrder[2usize] as (usize))] as (i32) == 0i32 {
+        if code_length_bitdepth[kStorageOrder[2] as usize] == 0 {
             skip_some = 3;
         }
     }
@@ -890,7 +890,7 @@ fn BrotliStoreHuffmanTreeOfHuffmanTreeToBitMask(
                 let l: usize =
                     code_length_bitdepth[(kStorageOrder[i as usize] as (usize))] as (usize);
                 BrotliWriteBits(
-                    kHuffmanBitLengthHuffmanCodeBitLengths[l] as (u8),
+                    kHuffmanBitLengthHuffmanCodeBitLengths[l],
                     kHuffmanBitLengthHuffmanCodeSymbols[l] as u64,
                     storage_ix,
                     storage,
@@ -914,30 +914,20 @@ fn BrotliStoreHuffmanTreeToBitMask(
     i = 0usize;
     while i < huffman_tree_size {
         {
-            let ix: usize = huffman_tree[(i as (usize))] as (usize);
+            let ix = huffman_tree[i] as usize;
             BrotliWriteBits(
-                code_length_bitdepth[(ix as (usize))] as (u8),
-                code_length_bitdepth_symbols[(ix as (usize))] as (u64),
+                code_length_bitdepth[ix],
+                code_length_bitdepth_symbols[ix] as u64,
                 storage_ix,
                 storage,
             );
-            if ix == 16usize {
-                BrotliWriteBits(
-                    2,
-                    huffman_tree_extra_bits[(i as (usize))] as (u64),
-                    storage_ix,
-                    storage,
-                );
-            } else if ix == 17usize {
-                BrotliWriteBits(
-                    3,
-                    huffman_tree_extra_bits[(i as (usize))] as (u64),
-                    storage_ix,
-                    storage,
-                );
+            if ix == 16 {
+                BrotliWriteBits(2, huffman_tree_extra_bits[i] as u64, storage_ix, storage);
+            } else if ix == 17 {
+                BrotliWriteBits(3, huffman_tree_extra_bits[i] as u64, storage_ix, storage);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -994,7 +984,7 @@ pub fn BrotliStoreHuffmanTree(
             let _lhs = &mut huffman_tree_histogram[huffman_tree[i] as (usize)];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     'break3: while i < 18usize {
@@ -1013,7 +1003,7 @@ pub fn BrotliStoreHuffmanTree(
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     BrotliCreateHuffmanTree(
         &mut huffman_tree_histogram,
@@ -1090,9 +1080,9 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
     }
     if count <= 1 {
         BrotliWriteBits(4, 1, storage_ix, storage);
-        BrotliWriteBits(max_bits as u8, symbols[0usize], storage_ix, storage);
-        depth[symbols[0usize] as (usize)] = 0i32 as (u8);
-        bits[symbols[0usize] as (usize)] = 0i32 as (u16);
+        BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
+        depth[symbols[0] as usize] = 0;
+        bits[symbols[0] as usize] = 0;
         return;
     }
     for depth_elem in depth[..(length as usize)].iter_mut() {
@@ -1133,7 +1123,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                                 l as (i16),
                             );
                         }
-                        node_index = node_index.wrapping_add(1 as (u32));
+                        node_index = node_index.wrapping_add(1);
                     }
                 }
                 {
@@ -1199,7 +1189,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
     if count <= 4 {
         let mut i: u64;
         BrotliWriteBits(2, 1, storage_ix, storage);
-        BrotliWriteBits(2, count.wrapping_sub(1) as u64, storage_ix, storage);
+        BrotliWriteBits(2, count.wrapping_sub(1), storage_ix, storage);
         i = 0;
         while i < count {
             {
@@ -1207,8 +1197,8 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                 j = i.wrapping_add(1);
                 while j < count {
                     {
-                        if depth[(symbols[j as usize] as (usize))] as (i32)
-                            < depth[(symbols[i as usize] as (usize)) as usize] as (i32)
+                        if (depth[symbols[j as usize] as usize] as i32)
+                            < (depth[symbols[i as usize] as usize] as i32)
                         {
                             symbols.swap(j as usize, i as usize);
                         }
@@ -1219,24 +1209,24 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
             i = i.wrapping_add(1);
         }
         if count == 2 {
-            BrotliWriteBits(max_bits as u8, symbols[0usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[1usize], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[1], storage_ix, storage);
         } else if count == 3 {
-            BrotliWriteBits(max_bits as u8, symbols[0usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[1usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[2usize], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[1], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[2], storage_ix, storage);
         } else {
-            BrotliWriteBits(max_bits as u8, symbols[0usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[1usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[2usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[3usize], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[1], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[2], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[3], storage_ix, storage);
             BrotliWriteBits(
                 1,
-                if depth[(symbols[0usize] as (usize))] as (i32) == 1i32 {
-                    1i32
+                if depth[symbols[0] as usize] == 1 {
+                    1
                 } else {
-                    0i32
-                } as (u64),
+                    0
+                },
                 storage_ix,
                 storage,
             );
@@ -1268,7 +1258,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
             } else {
                 if previous_value as (i32) != value as (i32) {
                     BrotliWriteBits(
-                        kCodeLengthDepth[value as (usize)] as (u8),
+                        kCodeLengthDepth[value as usize],
                         kCodeLengthBits[value as (usize)] as (u64),
                         storage_ix,
                         storage,
@@ -1279,8 +1269,8 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                     while reps != 0 {
                         reps = reps.wrapping_sub(1);
                         BrotliWriteBits(
-                            kCodeLengthDepth[value as (usize)] as (u8),
-                            kCodeLengthBits[value as (usize)] as (u64),
+                            kCodeLengthDepth[value as usize],
+                            kCodeLengthBits[value as usize] as u64,
                             storage_ix,
                             storage,
                         );
@@ -1288,7 +1278,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                 } else {
                     reps = reps.wrapping_sub(3);
                     BrotliWriteBits(
-                        kNonZeroRepsDepth[reps as usize] as (u8),
+                        kNonZeroRepsDepth[reps as usize] as u8,
                         kNonZeroRepsBits[reps as usize] as u64,
                         storage_ix,
                         storage,
@@ -1416,7 +1406,7 @@ fn Log2FloorNonZero(mut n: u64) -> u32 {
             n
         } != 0
         {
-            result = result.wrapping_add(1 as (u32));
+            result = result.wrapping_add(1);
             continue 'loop1;
         } else {
             break 'loop1;
@@ -1429,8 +1419,8 @@ fn BrotliEncodeMlen(length: u32, bits: &mut u64, numbits: &mut u32, nibblesbits:
     let lg: u32 = (if length == 1u32 {
         1u32
     } else {
-        Log2FloorNonZero(length.wrapping_sub(1u32) as (u32) as (u64)).wrapping_add(1u32)
-    }) as (u32);
+        Log2FloorNonZero(length.wrapping_sub(1) as u64).wrapping_add(1)
+    });
     let mnibbles: u32 = (if lg < 16u32 {
         16u32
     } else {
@@ -1535,7 +1525,7 @@ fn BlockLengthPrefixCode(len: u32) -> u32 {
     while code < (26i32 - 1i32) as (u32)
         && (len >= kBlockLengthPrefixCode[code.wrapping_add(1u32) as (usize)].offset)
     {
-        code = code.wrapping_add(1 as (u32));
+        code = code.wrapping_add(1);
     }
     code
 }
@@ -1570,82 +1560,31 @@ fn StoreSimpleHuffmanTree(
                 j = i.wrapping_add(1usize);
                 while j < num_symbols {
                     {
-                        if depths[(symbols[(j as (usize))] as (usize))] as (i32)
-                            < depths[(symbols[(i as (usize))] as (usize))] as (i32)
-                        {
-                            symbols.swap((j as (usize)), (i as (usize)));
+                        if (depths[symbols[j]] as i32) < (depths[symbols[i]] as i32) {
+                            symbols.swap(j, i);
                         }
                     }
-                    j = j.wrapping_add(1 as (usize));
+                    j = j.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
-    if num_symbols == 2usize {
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(0usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(1usize)] as u64,
-            storage_ix,
-            storage,
-        );
-    } else if num_symbols == 3usize {
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(0usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(1usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(2usize)] as u64,
-            storage_ix,
-            storage,
-        );
+    if num_symbols == 2 {
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
+    } else if num_symbols == 3 {
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[2] as u64, storage_ix, storage);
     } else {
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(0usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(1usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(2usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(3usize)] as u64,
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[2] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[3] as u64, storage_ix, storage);
         BrotliWriteBits(
             1,
-            if depths[(symbols[(0usize)] as (usize))] as (i32) == 1i32 {
-                1i32
-            } else {
-                0i32
-            } as (u64),
+            if depths[symbols[0]] == 1 { 1 } else { 0 },
             storage_ix,
             storage,
         );
@@ -1669,7 +1608,7 @@ fn BuildAndStoreHuffmanTree(
     i = 0usize;
     'break31: while i < histogram_length {
         {
-            if histogram[(i as (usize))] != 0 {
+            if histogram[i] != 0 {
                 if count < 4usize {
                     s4[count] = i;
                 } else if count > 4usize {
@@ -1677,23 +1616,23 @@ fn BuildAndStoreHuffmanTree(
                         break 'break31;
                     }
                 }
-                count = count.wrapping_add(1 as (usize));
+                count = count.wrapping_add(1);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     {
         let mut max_bits_counter: usize = alphabet_size.wrapping_sub(1usize);
         while max_bits_counter != 0 {
             max_bits_counter >>= 1i32;
-            max_bits = max_bits.wrapping_add(1 as (usize));
+            max_bits = max_bits.wrapping_add(1);
         }
     }
     if count <= 1usize {
         BrotliWriteBits(4, 1, storage_ix, storage);
-        BrotliWriteBits(max_bits as u8, s4[0usize] as u64, storage_ix, storage);
-        depth[(s4[0usize] as (usize))] = 0i32 as (u8);
-        bits[(s4[0usize] as (usize))] = 0i32 as (u16);
+        BrotliWriteBits(max_bits as u8, s4[0] as u64, storage_ix, storage);
+        depth[s4[0]] = 0;
+        bits[s4[0]] = 0;
         return;
     }
 
@@ -1737,7 +1676,7 @@ fn StoreBlockSwitch(
     }
     GetBlockLengthPrefixCode(block_len, &mut lencode, &mut len_nextra, &mut len_extra);
     BrotliWriteBits(
-        code.length_depths[lencode] as (u8),
+        code.length_depths[lencode],
         code.length_bits[lencode] as (u64),
         storage_ix,
         storage,
@@ -1762,8 +1701,7 @@ fn BuildAndStoreBlockSplitCode(
     i = 0usize;
     while i < num_blocks {
         {
-            let type_code: usize =
-                NextBlockTypeCode(&mut type_code_calculator, types[(i as (usize))]);
+            let type_code: usize = NextBlockTypeCode(&mut type_code_calculator, types[i]);
             if i != 0usize {
                 let _rhs = 1;
                 let _lhs = &mut type_histo[type_code];
@@ -1771,12 +1709,11 @@ fn BuildAndStoreBlockSplitCode(
             }
             {
                 let _rhs = 1;
-                let _lhs =
-                    &mut length_histo[BlockLengthPrefixCode(lengths[(i as (usize))]) as (usize)];
+                let _lhs = &mut length_histo[BlockLengthPrefixCode(lengths[i]) as usize];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     StoreVarLenUint8(num_types.wrapping_sub(1) as u64, storage_ix, storage);
     if num_types > 1usize {
@@ -1800,14 +1737,7 @@ fn BuildAndStoreBlockSplitCode(
             storage_ix,
             storage,
         );
-        StoreBlockSwitch(
-            code,
-            lengths[(0usize)],
-            types[(0usize)],
-            1i32,
-            storage_ix,
-            storage,
-        );
+        StoreBlockSwitch(code, lengths[0], types[0], 1, storage_ix, storage);
     }
 }
 
@@ -1853,13 +1783,13 @@ fn StoreTrivialContextMap(
             storage,
         );
         histogram[repeat_code] = num_types as (u32);
-        histogram[0usize] = 1u32;
+        histogram[0] = 1;
         i = context_bits;
         while i < alphabet_size {
             {
                 histogram[i] = 1u32;
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         BuildAndStoreHuffmanTree(
             &mut histogram[..],
@@ -1879,21 +1809,16 @@ fn StoreTrivialContextMap(
                 } else {
                     i.wrapping_add(context_bits).wrapping_sub(1usize)
                 };
+                BrotliWriteBits(depths[code], bits[code] as u64, storage_ix, storage);
                 BrotliWriteBits(
-                    depths[code] as (u8),
-                    bits[code] as (u64),
-                    storage_ix,
-                    storage,
-                );
-                BrotliWriteBits(
-                    depths[repeat_code] as (u8),
-                    bits[repeat_code] as (u64),
+                    depths[repeat_code],
+                    bits[repeat_code] as u64,
                     storage_ix,
                     storage,
                 );
                 BrotliWriteBits(repeat_code as u8, repeat_bits as u64, storage_ix, storage);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         BrotliWriteBits(1, 1, storage_ix, storage);
     }
@@ -1902,27 +1827,23 @@ fn StoreTrivialContextMap(
 fn IndexOf(v: &[u8], v_size: usize, value: u8) -> usize {
     let mut i: usize = 0usize;
     while i < v_size {
-        {
-            if v[(i as (usize))] as (i32) == value as (i32) {
-                return i;
-            }
+        if (v[i] as i32) == (value as i32) {
+            return i;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i
 }
 
 fn MoveToFront(v: &mut [u8], index: usize) {
-    let value: u8 = v[(index as (usize))];
+    let value = v[index];
     let mut i: usize;
     i = index;
-    while i != 0usize {
-        {
-            v[(i as (usize))] = v[(i.wrapping_sub(1usize) as (usize))];
-        }
-        i = i.wrapping_sub(1 as (usize));
+    while i != 0 {
+        v[i] = v[i.wrapping_sub(1)];
+        i = i.wrapping_sub(1);
     }
-    v[(0usize)] = value;
+    v[0] = value;
 }
 
 fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
@@ -1932,15 +1853,15 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
     if v_size == 0usize {
         return;
     }
-    max_value = v_in[(0usize)];
+    max_value = v_in[0];
     i = 1usize;
     while i < v_size {
         {
-            if v_in[(i as (usize))] > max_value {
-                max_value = v_in[(i as (usize))];
+            if v_in[i] > max_value {
+                max_value = v_in[i];
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     0i32;
     i = 0usize;
@@ -1948,19 +1869,16 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
         {
             mtf[i] = i as (u8);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     {
         let mtf_size: usize = max_value.wrapping_add(1u32) as (usize);
         i = 0usize;
         while i < v_size {
-            {
-                let index: usize = IndexOf(&mtf[..], mtf_size, v_in[(i as (usize))] as (u8));
-                0i32;
-                v_out[(i as (usize))] = index as (u32);
-                MoveToFront(&mut mtf[..], index);
-            }
-            i = i.wrapping_add(1 as (usize));
+            let index: usize = IndexOf(&mtf[..], mtf_size, v_in[i] as u8);
+            v_out[i] = index as u32;
+            MoveToFront(&mut mtf[..], index);
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -1993,14 +1911,12 @@ fn RunLengthCodeZeros(
     i = 0usize;
     while i < in_size {
         let mut reps: u32 = 0u32;
-        while i < in_size && (v[(i as (usize))] != 0u32) {
-            i = i.wrapping_add(1 as (usize));
+        while i < in_size && v[i] != 0 {
+            i = i.wrapping_add(1);
         }
-        while i < in_size && (v[(i as (usize))] == 0u32) {
-            {
-                reps = reps.wrapping_add(1 as (u32));
-            }
-            i = i.wrapping_add(1 as (usize));
+        while i < in_size && v[i] == 0 {
+            reps = reps.wrapping_add(1);
+            i = i.wrapping_add(1);
         }
         max_reps = brotli_max_uint32_t(reps, max_reps);
     }
@@ -2015,27 +1931,25 @@ fn RunLengthCodeZeros(
     i = 0usize;
     while i < in_size {
         0i32;
-        if v[(i as (usize))] != 0u32 {
-            v[(*out_size as (usize))] = (v[(i as (usize))]).wrapping_add(*max_run_length_prefix);
-            i = i.wrapping_add(1 as (usize));
-            *out_size = (*out_size).wrapping_add(1 as (usize));
+        if v[i] != 0 {
+            v[*out_size] = v[i].wrapping_add(*max_run_length_prefix);
+            i = i.wrapping_add(1);
+            *out_size = (*out_size).wrapping_add(1);
         } else {
             let mut reps: u32 = 1u32;
             let mut k: usize;
             k = i.wrapping_add(1usize);
-            while k < in_size && (v[(k as (usize))] == 0u32) {
-                {
-                    reps = reps.wrapping_add(1 as (u32));
-                }
-                k = k.wrapping_add(1 as (usize));
+            while k < in_size && v[k] == 0 {
+                reps = reps.wrapping_add(1);
+                k = k.wrapping_add(1);
             }
             i = i.wrapping_add(reps as (usize));
             while reps != 0u32 {
                 if reps < 2u32 << max_prefix {
                     let run_length_prefix: u32 = Log2FloorNonZero(reps as (u64));
                     let extra_bits: u32 = reps.wrapping_sub(1u32 << run_length_prefix);
-                    v[(*out_size as (usize))] = run_length_prefix.wrapping_add(extra_bits << 9i32);
-                    *out_size = (*out_size).wrapping_add(1 as (usize));
+                    v[*out_size] = run_length_prefix.wrapping_add(extra_bits << 9i32);
+                    *out_size = (*out_size).wrapping_add(1);
                     {
                         {
                             break;
@@ -2043,9 +1957,9 @@ fn RunLengthCodeZeros(
                     }
                 } else {
                     let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1u32);
-                    v[(*out_size as (usize))] = max_prefix.wrapping_add(extra_bits << 9i32);
+                    v[*out_size] = max_prefix.wrapping_add(extra_bits << 9i32);
                     reps = reps.wrapping_sub((2u32 << max_prefix).wrapping_sub(1u32));
-                    *out_size = (*out_size).wrapping_add(1 as (usize));
+                    *out_size = (*out_size).wrapping_add(1);
                 }
             }
         }
@@ -2093,11 +2007,10 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     while i < num_rle_symbols {
         {
             let _rhs = 1;
-            let _lhs =
-                &mut histogram[(rle_symbols.slice()[(i as (usize))] & kSymbolMask) as (usize)];
+            let _lhs = &mut histogram[(rle_symbols.slice()[i] & kSymbolMask) as usize];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     {
         let use_rle: i32 = if !!(max_run_length_prefix > 0u32) {
@@ -2128,11 +2041,11 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     i = 0usize;
     while i < num_rle_symbols {
         {
-            let rle_symbol: u32 = rle_symbols.slice()[(i as (usize))] & kSymbolMask;
-            let extra_bits_val: u32 = rle_symbols.slice()[(i as (usize))] >> 9i32;
+            let rle_symbol: u32 = rle_symbols.slice()[i] & kSymbolMask;
+            let extra_bits_val: u32 = rle_symbols.slice()[i] >> 9i32;
             BrotliWriteBits(
-                depths[rle_symbol as (usize)] as (u8),
-                bits[rle_symbol as (usize)] as (u64),
+                depths[rle_symbol as usize],
+                bits[rle_symbol as usize] as u64,
                 storage_ix,
                 storage,
             );
@@ -2145,7 +2058,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
                 );
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     BrotliWriteBits(1, 1, storage_ix, storage);
     m.free_cell(rle_symbols);
@@ -2182,17 +2095,17 @@ fn BuildAndStoreEntropyCodes<
             {
                 let ix: usize = i.wrapping_mul(xself.histogram_length_);
                 BuildAndStoreHuffmanTree(
-                    &(histograms[(i as (usize))]).slice()[0..],
+                    &histograms[i].slice()[0..],
                     xself.histogram_length_,
                     alphabet_size,
                     tree,
-                    &mut xself.depths_.slice_mut()[(ix as (usize))..],
-                    &mut xself.bits_.slice_mut()[(ix as (usize))..],
+                    &mut xself.depths_.slice_mut()[ix..],
+                    &mut xself.bits_.slice_mut()[ix..],
                     storage_ix,
                     storage,
                 );
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -2205,11 +2118,11 @@ fn StoreSymbol<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 ) {
     if xself.block_len_ == 0usize {
         let block_ix: usize = {
-            xself.block_ix_ = xself.block_ix_.wrapping_add(1 as (usize));
+            xself.block_ix_ = xself.block_ix_.wrapping_add(1);
             xself.block_ix_
         };
-        let block_len: u32 = xself.block_lengths_[(block_ix as (usize))];
-        let block_type: u8 = xself.block_types_[(block_ix as (usize))];
+        let block_len: u32 = xself.block_lengths_[block_ix];
+        let block_type: u8 = xself.block_types_[block_ix];
         xself.block_len_ = block_len as (usize);
         xself.entropy_ix_ = (block_type as (usize)).wrapping_mul(xself.histogram_length_);
         StoreBlockSwitch(
@@ -2221,12 +2134,12 @@ fn StoreSymbol<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
             storage,
         );
     }
-    xself.block_len_ = xself.block_len_.wrapping_sub(1 as (usize));
+    xself.block_len_ = xself.block_len_.wrapping_sub(1);
     {
         let ix: usize = xself.entropy_ix_.wrapping_add(symbol);
         BrotliWriteBits(
-            xself.depths_.slice()[(ix as (usize))] as (u8),
-            xself.bits_.slice()[(ix as (usize))] as (u64),
+            xself.depths_.slice()[ix],
+            xself.bits_.slice()[ix] as u64,
             storage_ix,
             storage,
         );
@@ -2298,11 +2211,11 @@ fn StoreSymbolWithContext<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 ) {
     if xself.block_len_ == 0usize {
         let block_ix: usize = {
-            xself.block_ix_ = xself.block_ix_.wrapping_add(1 as (usize));
+            xself.block_ix_ = xself.block_ix_.wrapping_add(1);
             xself.block_ix_
         };
-        let block_len: u32 = xself.block_lengths_[(block_ix as (usize))];
-        let block_type: u8 = xself.block_types_[(block_ix as (usize))];
+        let block_len: u32 = xself.block_lengths_[block_ix];
+        let block_type: u8 = xself.block_types_[block_ix];
         xself.block_len_ = block_len as (usize);
         xself.entropy_ix_ = block_type as (usize) << context_bits;
         StoreBlockSwitch(
@@ -2314,16 +2227,15 @@ fn StoreSymbolWithContext<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
             storage,
         );
     }
-    xself.block_len_ = xself.block_len_.wrapping_sub(1 as (usize));
+    xself.block_len_ = xself.block_len_.wrapping_sub(1);
     {
-        let histo_ix: usize =
-            context_map[(xself.entropy_ix_.wrapping_add(context) as (usize))] as (usize);
+        let histo_ix = context_map[xself.entropy_ix_.wrapping_add(context)] as usize;
         let ix: usize = histo_ix
             .wrapping_mul(xself.histogram_length_)
             .wrapping_add(symbol);
         BrotliWriteBits(
-            xself.depths_.slice()[(ix as (usize))] as (u8),
-            xself.bits_.slice()[(ix as (usize))] as (u64),
+            xself.depths_.slice()[ix],
+            xself.bits_.slice()[ix] as u64,
             storage_ix,
             storage,
         );
@@ -2353,7 +2265,7 @@ fn CleanupBlockEncoder<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 
 pub fn JumpToByteBoundary(storage_ix: &mut usize, storage: &mut [u8]) {
     *storage_ix = (*storage_ix).wrapping_add(7u32 as (usize)) & !7u32 as (usize);
-    storage[((*storage_ix >> 3i32) as (usize))] = 0i32 as (u8);
+    storage[*storage_ix >> 3i32] = 0;
 }
 
 pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
@@ -2454,7 +2366,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
         {
             BrotliWriteBits(2, literal_context_mode as (u64), storage_ix, storage);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     if mb.literal_context_map_size == 0usize {
         StoreTrivialContextMap(
@@ -2530,7 +2442,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))];
+            let cmd = commands[i];
             let cmd_code: usize = cmd.cmd_prefix_ as (usize);
             StoreSymbol(&mut command_enc, cmd_code, storage_ix, storage);
             StoreCommandExtra(&cmd, storage_ix, storage);
@@ -2541,13 +2453,13 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
                     {
                         StoreSymbol(
                             &mut literal_enc,
-                            input[((pos & mask) as (usize))] as (usize),
+                            input[pos & mask] as usize,
                             storage_ix,
                             storage,
                         );
-                        pos = pos.wrapping_add(1 as (usize));
+                        pos = pos.wrapping_add(1);
                     }
-                    j = j.wrapping_sub(1 as (usize));
+                    j = j.wrapping_sub(1);
                 }
             } else {
                 let mut j: usize;
@@ -2556,7 +2468,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
                     {
                         let context: usize =
                             Context(prev_byte, prev_byte2, literal_context_mode) as (usize);
-                        let literal: u8 = input[((pos & mask) as (usize))];
+                        let literal: u8 = input[pos & mask];
                         StoreSymbolWithContext(
                             &mut literal_enc,
                             literal as (usize),
@@ -2568,15 +2480,15 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
                         );
                         prev_byte2 = prev_byte;
                         prev_byte = literal;
-                        pos = pos.wrapping_add(1 as (usize));
+                        pos = pos.wrapping_add(1);
                     }
-                    j = j.wrapping_sub(1 as (usize));
+                    j = j.wrapping_sub(1);
                 }
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as (usize));
             if CommandCopyLen(&cmd) != 0 {
-                prev_byte2 = input[((pos.wrapping_sub(2usize) & mask) as (usize))];
-                prev_byte = input[((pos.wrapping_sub(1usize) & mask) as (usize))];
+                prev_byte2 = input[pos.wrapping_sub(2) & mask];
+                prev_byte = input[pos.wrapping_sub(1) & mask];
                 if cmd.cmd_prefix_ as (i32) >= 128i32 {
                     let dist_code: usize = cmd.dist_prefix_ as (usize) & 0x3ff;
                     let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10i32; //FIXME: from command
@@ -2599,7 +2511,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     CleanupBlockEncoder(alloc, &mut distance_enc);
     CleanupBlockEncoder(alloc, &mut command_enc);
@@ -2624,23 +2536,21 @@ fn BuildHistograms(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))];
+            let cmd = commands[i];
             let mut j: usize;
             HistogramAddItem(cmd_histo, cmd.cmd_prefix_ as (usize));
             j = cmd.insert_len_ as (usize);
-            while j != 0usize {
-                {
-                    HistogramAddItem(lit_histo, input[((pos & mask) as (usize))] as (usize));
-                    pos = pos.wrapping_add(1 as (usize));
-                }
-                j = j.wrapping_sub(1 as (usize));
+            while j != 0 {
+                HistogramAddItem(lit_histo, input[pos & mask] as usize);
+                pos = pos.wrapping_add(1);
+                j = j.wrapping_sub(1);
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as (usize));
             if CommandCopyLen(&cmd) != 0 && (cmd.cmd_prefix_ as (i32) >= 128i32) {
                 HistogramAddItem(dist_histo, cmd.dist_prefix_ as (usize) & 0x3ff);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 fn StoreDataWithHuffmanCodes(
@@ -2663,12 +2573,12 @@ fn StoreDataWithHuffmanCodes(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))];
+            let cmd = commands[i];
             let cmd_code: usize = cmd.cmd_prefix_ as (usize);
             let mut j: usize;
             BrotliWriteBits(
-                cmd_depth[(cmd_code as (usize))] as (u8),
-                cmd_bits[(cmd_code as (usize))] as (u64),
+                cmd_depth[cmd_code],
+                cmd_bits[cmd_code] as u64,
                 storage_ix,
                 storage,
             );
@@ -2676,16 +2586,16 @@ fn StoreDataWithHuffmanCodes(
             j = cmd.insert_len_ as (usize);
             while j != 0usize {
                 {
-                    let literal: u8 = input[((pos & mask) as (usize))];
+                    let literal: u8 = input[pos & mask];
                     BrotliWriteBits(
-                        lit_depth[(literal as (usize))] as (u8),
-                        lit_bits[(literal as (usize))] as (u64),
+                        lit_depth[literal as usize],
+                        lit_bits[literal as usize] as u64,
                         storage_ix,
                         storage,
                     );
-                    pos = pos.wrapping_add(1 as (usize));
+                    pos = pos.wrapping_add(1);
                 }
-                j = j.wrapping_sub(1 as (usize));
+                j = j.wrapping_sub(1);
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as (usize));
             if CommandCopyLen(&cmd) != 0 && (cmd.cmd_prefix_ as (i32) >= 128i32) {
@@ -2693,8 +2603,8 @@ fn StoreDataWithHuffmanCodes(
                 let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10i32;
                 let distextra: u32 = cmd.dist_extra_;
                 BrotliWriteBits(
-                    dist_depth[(dist_code as (usize))] as (u8),
-                    dist_bits[(dist_code as (usize))] as (u64),
+                    dist_depth[dist_code],
+                    dist_bits[dist_code] as u64,
                     storage_ix,
                     storage,
                 );
@@ -2706,7 +2616,7 @@ fn StoreDataWithHuffmanCodes(
                 );
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -2998,24 +2908,24 @@ pub fn BrotliStoreMetaBlockFast<Cb, Alloc: BrotliAlloc>(
         i = 0usize;
         while i < n_commands {
             {
-                let cmd: Command = commands[(i as (usize))];
+                let cmd = commands[i];
                 let mut j: usize;
                 j = cmd.insert_len_ as (usize);
                 while j != 0usize {
                     {
                         {
                             let _rhs = 1;
-                            let _lhs = &mut histogram[input[((pos & mask) as (usize))] as (usize)];
+                            let _lhs = &mut histogram[input[pos & mask] as usize];
                             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
                         }
-                        pos = pos.wrapping_add(1 as (usize));
+                        pos = pos.wrapping_add(1);
                     }
-                    j = j.wrapping_sub(1 as (usize));
+                    j = j.wrapping_sub(1);
                 }
                 num_literals = num_literals.wrapping_add(cmd.insert_len_ as (usize));
                 pos = pos.wrapping_add(CommandCopyLen(&cmd) as (usize));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         BrotliBuildAndStoreHuffmanTreeFast(
             m,
@@ -3127,7 +3037,7 @@ fn BrotliStoreUncompressedMetaBlockHeader(
     BrotliWriteBits(1, 0, storage_ix, storage);
     BrotliEncodeMlen(length as u32, &mut lenbits, &mut nlenbits, &mut nibblesbits);
     BrotliWriteBits(2, nibblesbits as u64, storage_ix, storage);
-    BrotliWriteBits(nlenbits as u8, lenbits as u64, storage_ix, storage);
+    BrotliWriteBits(nlenbits as u8, lenbits, storage_ix, storage);
     BrotliWriteBits(1, 1, storage_ix, storage);
 }
 
@@ -3171,10 +3081,10 @@ pub fn BrotliStoreUncompressedMetaBlock<Cb, Alloc: BrotliAlloc>(
     let (input0, input1) = InputPairFromMaskedInput(input, position, len, mask);
     BrotliStoreUncompressedMetaBlockHeader(len, storage_ix, storage);
     JumpToByteBoundary(storage_ix, storage);
-    let dst_start0 = ((*storage_ix >> 3i32) as (usize));
+    let dst_start0 = *storage_ix >> 3;
     storage[dst_start0..(dst_start0 + input0.len())].clone_from_slice(input0);
     *storage_ix = (*storage_ix).wrapping_add(input0.len() << 3i32);
-    let dst_start1 = ((*storage_ix >> 3i32) as (usize));
+    let dst_start1 = *storage_ix >> 3;
     storage[dst_start1..(dst_start1 + input1.len())].clone_from_slice(input1);
     *storage_ix = (*storage_ix).wrapping_add(input1.len() << 3i32);
     BrotliWriteBitsPrepareStorage(*storage_ix, storage);

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -118,13 +118,13 @@ fn BrotliCompareAndPushToQueue<
             if *num_pairs > 0i32 as (usize) && HistogramPairIsLess(&pairs[0i32 as (usize)], &p) {
                 /* Replace the top of the queue if needed. */
                 if *num_pairs < max_num_pairs {
-                    pairs[*num_pairs as (usize)] = pairs[0i32 as (usize)];
-                    *num_pairs = (*num_pairs).wrapping_add(1 as (usize));
+                    pairs[*num_pairs] = pairs[0];
+                    *num_pairs = (*num_pairs).wrapping_add(1);
                 }
                 pairs[0i32 as (usize)] = p;
             } else if *num_pairs < max_num_pairs {
-                pairs[*num_pairs as (usize)] = p;
-                *num_pairs = (*num_pairs).wrapping_add(1 as (usize));
+                pairs[*num_pairs] = p;
+                *num_pairs = (*num_pairs).wrapping_add(1);
             }
         }
     }
@@ -161,23 +161,23 @@ pub fn BrotliHistogramCombine<
                         BrotliCompareAndPushToQueue(
                             out,
                             cluster_size,
-                            clusters[(idx1 as (usize))],
-                            clusters[(idx2 as (usize))],
+                            clusters[idx1],
+                            clusters[idx2],
                             max_num_pairs,
                             scratch_space,
                             pairs,
                             &mut num_pairs,
                         );
                     }
-                    idx2 = idx2.wrapping_add(1 as (usize));
+                    idx2 = idx2.wrapping_add(1);
                 }
             }
-            idx1 = idx1.wrapping_add(1 as (usize));
+            idx1 = idx1.wrapping_add(1);
         }
     }
     while num_clusters > min_cluster_size {
         let mut i: usize;
-        if (pairs[(0usize)]).cost_diff >= cost_diff_threshold {
+        if (pairs[0]).cost_diff >= cost_diff_threshold {
             cost_diff_threshold = 1e38 as super::util::floatX;
             min_cluster_size = max_clusters;
             {
@@ -187,10 +187,10 @@ pub fn BrotliHistogramCombine<
             }
         }
         /* Take the best pair from the top of heap. */
-        let best_idx1: u32 = (pairs[(0usize)]).idx1;
-        let best_idx2: u32 = (pairs[(0usize)]).idx2;
+        let best_idx1: u32 = pairs[0].idx1;
+        let best_idx2: u32 = pairs[0].idx2;
         HistogramSelfAddHistogram(out, (best_idx1 as (usize)), (best_idx2 as (usize)));
-        (out[(best_idx1 as (usize))]).set_bit_cost((pairs[(0usize)]).cost_combo);
+        out[best_idx1 as usize].set_bit_cost(pairs[0].cost_combo);
         {
             let _rhs = cluster_size[(best_idx2 as (usize))];
             let _lhs = &mut cluster_size[(best_idx1 as (usize))];
@@ -199,25 +199,25 @@ pub fn BrotliHistogramCombine<
         i = 0usize;
         while i < symbols_size {
             {
-                if symbols[(i as (usize))] == best_idx2 {
-                    symbols[(i as (usize))] = best_idx1;
+                if symbols[i] == best_idx2 {
+                    symbols[i] = best_idx1;
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         i = 0usize;
         'break9: while i < num_clusters {
             {
-                if clusters[(i as (usize))] == best_idx2 {
+                if clusters[i] == best_idx2 {
                     for offset in 0..(num_clusters - i - 1) {
                         clusters[i + offset] = clusters[i + 1 + offset];
                     }
                     break 'break9;
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
-        num_clusters = num_clusters.wrapping_sub(1 as (usize));
+        num_clusters = num_clusters.wrapping_sub(1);
         {
             /* Remove pairs intersecting the just combined best pair. */
             let mut copy_to_idx: usize = 0usize;
@@ -225,7 +225,7 @@ pub fn BrotliHistogramCombine<
             while i < num_pairs {
                 'continue12: loop {
                     {
-                        let p: HistogramPair = pairs[(i as (usize))];
+                        let p: HistogramPair = pairs[i];
                         if (p).idx1 == best_idx1
                             || (p).idx2 == best_idx1
                             || (p).idx1 == best_idx2
@@ -236,19 +236,19 @@ pub fn BrotliHistogramCombine<
                                 break 'continue12;
                             }
                         }
-                        if HistogramPairIsLess(&pairs[(0usize)], &p) {
+                        if HistogramPairIsLess(&pairs[0], &p) {
                             /* Replace the top of the queue if needed. */
-                            let front: HistogramPair = pairs[(0usize)];
-                            pairs[(0usize)] = p;
-                            pairs[(copy_to_idx as (usize))] = front;
+                            let front: HistogramPair = pairs[0];
+                            pairs[0] = p;
+                            pairs[copy_to_idx] = front;
                         } else {
-                            pairs[(copy_to_idx as (usize))] = p;
+                            pairs[copy_to_idx] = p;
                         }
-                        copy_to_idx = copy_to_idx.wrapping_add(1 as (usize));
+                        copy_to_idx = copy_to_idx.wrapping_add(1);
                     }
                     break;
                 }
-                i = i.wrapping_add(1 as (usize));
+                i = i.wrapping_add(1);
             }
             num_pairs = copy_to_idx;
         }
@@ -260,14 +260,14 @@ pub fn BrotliHistogramCombine<
                     out,
                     cluster_size,
                     best_idx1,
-                    clusters[(i as (usize))],
+                    clusters[i],
                     max_num_pairs,
                     scratch_space,
                     pairs,
                     &mut num_pairs,
                 );
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     num_clusters
@@ -312,12 +312,12 @@ pub fn BrotliHistogramRemap<
     while i < in_size {
         {
             let mut best_out: u32 = if i == 0usize {
-                symbols[(0usize)]
+                symbols[0]
             } else {
-                symbols[(i.wrapping_sub(1usize) as (usize))]
+                symbols[i.wrapping_sub(1)]
             };
             let mut best_bits: super::util::floatX = BrotliHistogramBitCostDistance(
-                &inp[(i as (usize))],
+                &inp[i],
                 &mut out[(best_out as (usize))],
                 scratch_space,
             );
@@ -326,38 +326,31 @@ pub fn BrotliHistogramRemap<
             while j < num_clusters {
                 {
                     let cur_bits: super::util::floatX = BrotliHistogramBitCostDistance(
-                        &inp[(i as (usize))],
-                        &mut out[(clusters[(j as (usize))] as (usize))],
+                        &inp[i],
+                        &mut out[clusters[j] as usize],
                         scratch_space,
                     );
                     if cur_bits < best_bits {
                         best_bits = cur_bits;
-                        best_out = clusters[(j as (usize))];
+                        best_out = clusters[j];
                     }
                 }
-                j = j.wrapping_add(1 as (usize));
+                j = j.wrapping_add(1);
             }
-            symbols[(i as (usize))] = best_out;
+            symbols[i] = best_out;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     /* Recompute each out based on raw and symbols. */
     while i < num_clusters {
-        {
-            HistogramClear(&mut out[(clusters[(i as (usize))] as (usize))]);
-        }
-        i = i.wrapping_add(1 as (usize));
+        HistogramClear(&mut out[clusters[i] as usize]);
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < in_size {
-        {
-            HistogramAddHistogram(
-                &mut out[(symbols[(i as (usize))] as (usize))],
-                &inp[(i as (usize))],
-            );
-        }
-        i = i.wrapping_add(1 as (usize));
+        HistogramAddHistogram(&mut out[symbols[i] as usize], &inp[i]);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -391,21 +384,19 @@ pub fn BrotliHistogramReindex<
     let mut i: usize;
     i = 0usize;
     while i < length {
-        {
-            new_index.slice_mut()[(i as (usize))] = kInvalidIndex;
-        }
-        i = i.wrapping_add(1 as (usize));
+        new_index.slice_mut()[i] = kInvalidIndex;
+        i = i.wrapping_add(1);
     }
     next_index = 0u32;
     i = 0usize;
     while i < length {
         {
-            if new_index.slice()[(symbols[(i as (usize))] as (usize))] == kInvalidIndex {
-                new_index.slice_mut()[(symbols[(i as (usize))] as (usize))] = next_index;
-                next_index = next_index.wrapping_add(1 as (u32));
+            if new_index.slice()[symbols[i] as usize] == kInvalidIndex {
+                new_index.slice_mut()[symbols[i] as usize] = next_index;
+                next_index = next_index.wrapping_add(1);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     /* TODO: by using idea of "cycle-sort" we can avoid allocation of
     tmp and reduce the number of copying by the factor of 2. */
@@ -418,24 +409,21 @@ pub fn BrotliHistogramReindex<
     i = 0usize;
     while i < length {
         {
-            if new_index.slice()[(symbols[(i as (usize))] as (usize))] == next_index {
-                tmp.slice_mut()[(next_index as (usize))] =
-                    out[(symbols[(i as (usize))] as (usize))].clone();
-                next_index = next_index.wrapping_add(1 as (u32));
+            if new_index.slice()[symbols[i] as usize] == next_index {
+                tmp.slice_mut()[next_index as usize] = out[symbols[i] as usize].clone();
+                next_index = next_index.wrapping_add(1);
             }
-            symbols[(i as (usize))] = new_index.slice()[(symbols[(i as (usize))] as (usize))];
+            symbols[i] = new_index.slice()[symbols[i] as usize];
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     {
         <Alloc as Allocator<u32>>::free_cell(alloc, new_index);
     }
     i = 0usize;
     while i < next_index as (usize) {
-        {
-            out[(i as (usize))] = tmp.slice()[(i as (usize))].clone();
-        }
-        i = i.wrapping_add(1 as (usize));
+        out[i] = tmp.slice()[i].clone();
+        i = i.wrapping_add(1);
     }
     {
         <Alloc as Allocator<HistogramType>>::free_cell(alloc, tmp)
@@ -476,20 +464,17 @@ pub fn BrotliClusterHistograms<
     let mut i: usize;
     i = 0usize;
     while i < in_size {
-        {
-            cluster_size.slice_mut()[(i as (usize))] = 1u32;
-        }
-        i = i.wrapping_add(1 as (usize));
+        cluster_size.slice_mut()[i] = 1;
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < in_size {
         {
-            out[(i as (usize))] = inp[(i as (usize))].clone();
-            (out[(i as (usize))])
-                .set_bit_cost(BrotliPopulationCost(&inp[(i as (usize))], scratch_space));
-            histogram_symbols[(i as (usize))] = i as (u32);
+            out[i] = inp[i].clone();
+            out[i].set_bit_cost(BrotliPopulationCost(&inp[i], scratch_space));
+            histogram_symbols[i] = i as u32;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < in_size {
@@ -500,17 +485,14 @@ pub fn BrotliClusterHistograms<
             let mut j: usize;
             j = 0usize;
             while j < num_to_combine {
-                {
-                    clusters.slice_mut()[(num_clusters.wrapping_add(j) as (usize))] =
-                        i.wrapping_add(j) as (u32);
-                }
-                j = j.wrapping_add(1 as (usize));
+                clusters.slice_mut()[num_clusters.wrapping_add(j)] = i.wrapping_add(j) as u32;
+                j = j.wrapping_add(1);
             }
             let num_new_clusters: usize = BrotliHistogramCombine(
                 out,
                 cluster_size.slice_mut(),
-                &mut histogram_symbols[(i as (usize))..],
-                &mut clusters.slice_mut()[(num_clusters as (usize))..],
+                &mut histogram_symbols[i..],
+                &mut clusters.slice_mut()[num_clusters..],
                 pairs.slice_mut(),
                 num_to_combine,
                 num_to_combine,

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -40,19 +40,19 @@ pub fn CommandDistanceContext(xself: &Command) -> u32 {
 pub fn ComputeDistanceCode(distance: usize, max_distance: usize, dist_cache: &[i32]) -> usize {
     if distance <= max_distance {
         let distance_plus_3: usize = distance.wrapping_add(3usize);
-        let offset0: usize = distance_plus_3.wrapping_sub(dist_cache[(0usize)] as (usize));
-        let offset1: usize = distance_plus_3.wrapping_sub(dist_cache[(1usize)] as (usize));
-        if distance == dist_cache[(0usize)] as (usize) {
+        let offset0: usize = distance_plus_3.wrapping_sub(dist_cache[0] as usize);
+        let offset1: usize = distance_plus_3.wrapping_sub(dist_cache[1] as usize);
+        if distance == (dist_cache[0] as usize) {
             return 0usize;
-        } else if distance == dist_cache[(1usize)] as (usize) {
+        } else if distance == (dist_cache[1] as usize) {
             return 1usize;
         } else if offset0 < 7usize {
             return (0x9750468i32 >> (4usize).wrapping_mul(offset0) & 0xfi32) as (usize);
         } else if offset1 < 7usize {
             return (0xfdb1acei32 >> (4usize).wrapping_mul(offset1) & 0xfi32) as (usize);
-        } else if distance == dist_cache[(2usize)] as (usize) {
+        } else if distance == (dist_cache[2] as usize) {
             return 2usize;
-        } else if distance == dist_cache[(3usize)] as (usize) {
+        } else if distance == (dist_cache[3] as usize) {
             return 3usize;
         }
     }
@@ -130,10 +130,10 @@ pub fn PrefixEncodeCopyDistance(
         *code = distance_code as (u16);
         *extra_bits = 0u32;
     } else {
-        let dist: u64 = (1u64 << (postfix_bits as u64).wrapping_add(2u32 as (u64))).wrapping_add(
+        let dist = (1u64 << postfix_bits.wrapping_add(2)).wrapping_add(
             (distance_code as u64)
                 .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES as u64)
-                .wrapping_sub(num_direct_codes as u64) as u64,
+                .wrapping_sub(num_direct_codes as u64),
         );
         let bucket: u64 = Log2FloorNonZero(dist).wrapping_sub(1u32) as (u64);
         let postfix_mask: u64 = (1u32 << postfix_bits).wrapping_sub(1u32) as (u64);
@@ -171,13 +171,13 @@ pub fn CommandRestoreDistanceCode(xself: &Command, dist: &BrotliDistanceParams) 
         let postfix_mask = (1u32 << dist.distance_postfix_bits) - 1;
         let hcode = dcode
             .wrapping_sub(dist.num_direct_distance_codes)
-            .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES as u32)
+            .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES)
             >> dist.distance_postfix_bits;
         let lcode = dcode
             .wrapping_sub(dist.num_direct_distance_codes)
-            .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES as u32)
+            .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES)
             & postfix_mask;
-        let offset = (2u32.wrapping_add((hcode & 1)) << nbits).wrapping_sub(4);
+        let offset = (2u32.wrapping_add(hcode & 1) << nbits).wrapping_sub(4);
         (offset.wrapping_add(extra) << dist.distance_postfix_bits)
             .wrapping_add(lcode)
             .wrapping_add(dist.num_direct_distance_codes)
@@ -220,7 +220,7 @@ pub fn CommandDistanceIndexAndOffset(cmd: &Command, dist: &BrotliDistanceParams)
         return (0, ret);
     }
     let postfix_mask = (1 << n_postfix) - 1;
-    let dcode = dprefix as u32 - BROTLI_NUM_DISTANCE_SHORT_CODES as u32 - n_direct;
+    let dcode = (dprefix as u32) - BROTLI_NUM_DISTANCE_SHORT_CODES - n_direct;
     let hcode = dcode >> n_postfix;
     let lcode = dcode & postfix_mask;
     let offset = ((2 + (hcode & 1)) << n_dist_bits) - 4;
@@ -370,7 +370,7 @@ pub fn RecomputeDistancePrefixes(
     i = 0usize;
     while i < num_commands {
         {
-            let cmd: &mut Command = &mut cmds[(i as (usize))];
+            let cmd = &mut cmds[i];
             if CommandCopyLen(cmd) != 0 && (cmd.cmd_prefix_ as (i32) >= 128i32) {
                 PrefixEncodeCopyDistance(
                     CommandRestoreDistanceCode(cmd, dist) as (usize),
@@ -381,7 +381,7 @@ pub fn RecomputeDistancePrefixes(
                 );
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -37,12 +37,10 @@ fn Hash(p: &[u8], shift: usize) -> u32 {
     (h >> shift) as (u32)
 }
 fn IsMatch(p1: &[u8], p2: &[u8]) -> i32 {
-    if !!(BROTLI_UNALIGNED_LOAD32(p1) == BROTLI_UNALIGNED_LOAD32(p2)
-        && (p1[(4usize)] as (i32) == p2[(4usize)] as (i32)))
-    {
-        1i32
+    if BROTLI_UNALIGNED_LOAD32(p1) == BROTLI_UNALIGNED_LOAD32(p2) && p1[4] == p2[4] {
+        1
     } else {
-        0i32
+        0
     }
 }
 
@@ -63,10 +61,10 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         while i < input_size {
             {
                 let _rhs = 1;
-                let _lhs = &mut histogram[input[(i as (usize))] as (usize)];
+                let _lhs = &mut histogram[input[i] as usize];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         histogram_total = input_size;
         i = 0usize;
@@ -80,7 +78,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
                 }
                 histogram_total = histogram_total.wrapping_add(adjust as (usize));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     } else {
         static kSampleRate: usize = 29usize;
@@ -88,7 +86,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         while i < input_size {
             {
                 let _rhs = 1;
-                let _lhs = &mut histogram[input[(i as (usize))] as (usize)];
+                let _lhs = &mut histogram[input[i] as usize];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
             }
             i = i.wrapping_add(kSampleRate);
@@ -109,7 +107,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
                 }
                 histogram_total = histogram_total.wrapping_add(adjust as (usize));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     BrotliBuildAndStoreHuffmanTreeFast(
@@ -128,12 +126,11 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         while i < 256usize {
             {
                 if histogram[i] != 0 {
-                    literal_ratio = literal_ratio.wrapping_add(
-                        histogram[i].wrapping_mul(depths[(i as (usize))] as (u32)) as (usize),
-                    );
+                    literal_ratio = literal_ratio
+                        .wrapping_add(histogram[i].wrapping_mul(depths[i] as u32) as usize);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         literal_ratio
             .wrapping_mul(125usize)
@@ -157,15 +154,10 @@ fn EmitInsertLen(
 ) {
     if insertlen < 6usize {
         let code: usize = insertlen.wrapping_add(40usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if insertlen < 130usize {
@@ -176,8 +168,8 @@ fn EmitInsertLen(
             .wrapping_add(prefix)
             .wrapping_add(42usize);
         BrotliWriteBits(
-            depth[(inscode as (usize))] as (usize),
-            bits[(inscode as (usize))] as (u64),
+            depth[inscode] as usize,
+            bits[inscode] as u64,
             storage_ix,
             storage,
         );
@@ -189,19 +181,14 @@ fn EmitInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(inscode as (usize))];
+            let _lhs = &mut histo[inscode];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if insertlen < 2114usize {
         let tail: usize = insertlen.wrapping_sub(66usize);
         let nbits: u32 = Log2FloorNonZero(tail as u64);
         let code: usize = nbits.wrapping_add(50u32) as (usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         BrotliWriteBits(
             nbits as (usize),
             (tail as u64).wrapping_sub(1 << nbits),
@@ -210,16 +197,11 @@ fn EmitInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else {
-        BrotliWriteBits(
-            depth[(61usize)] as (usize),
-            bits[(61usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[61] as usize, bits[61] as u64, storage_ix, storage);
         BrotliWriteBits(
             12usize,
             (insertlen as u64).wrapping_sub(2114u64),
@@ -228,7 +210,7 @@ fn EmitInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(61usize)];
+            let _lhs = &mut histo[61];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     }
@@ -249,7 +231,7 @@ fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mu
     let mask: usize = (1u32 << bitpos).wrapping_sub(1u32) as (usize);
     {
         let _rhs = mask as (u8);
-        let _lhs = &mut storage[((new_storage_ix >> 3i32) as (usize))];
+        let _lhs = &mut storage[new_storage_ix >> 3];
         *_lhs = (*_lhs as (i32) & _rhs as (i32)) as (u8);
     }
     *storage_ix = new_storage_ix;
@@ -265,9 +247,9 @@ fn EmitUncompressedMetaBlock(
     RewindBitPosition(storage_ix_start, storage_ix, storage);
     BrotliStoreMetaBlockHeader(len, 1i32, storage_ix, storage);
     *storage_ix = (*storage_ix).wrapping_add(7u32 as (usize)) & !7u32 as (usize);
-    memcpy(storage, ((*storage_ix >> 3i32) as (usize)), begin, 0, len);
+    memcpy(storage, (*storage_ix >> 3), begin, 0, len);
     *storage_ix = (*storage_ix).wrapping_add(len << 3i32);
-    storage[((*storage_ix >> 3i32) as (usize))] = 0i32 as (u8);
+    storage[*storage_ix >> 3] = 0;
 }
 
 fn EmitLongInsertLen(
@@ -279,12 +261,7 @@ fn EmitLongInsertLen(
     storage: &mut [u8],
 ) {
     if insertlen < 22594usize {
-        BrotliWriteBits(
-            depth[(62usize)] as (usize),
-            bits[(62usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[62] as usize, bits[62] as u64, storage_ix, storage);
         BrotliWriteBits(
             14usize,
             (insertlen as u64).wrapping_sub(6210),
@@ -293,16 +270,11 @@ fn EmitLongInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(62usize)];
+            let _lhs = &mut histo[62];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else {
-        BrotliWriteBits(
-            depth[(63usize)] as (usize),
-            bits[(63usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[63] as usize, bits[63] as u64, storage_ix, storage);
         BrotliWriteBits(
             24usize,
             (insertlen as u64).wrapping_sub(22594),
@@ -311,7 +283,7 @@ fn EmitLongInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(63usize)];
+            let _lhs = &mut histo[63];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     }
@@ -329,7 +301,7 @@ fn EmitLiterals(
     j = 0usize;
     while j < len {
         {
-            let lit: u8 = input[(j as (usize))];
+            let lit: u8 = input[j];
             BrotliWriteBits(
                 depth[(lit as (usize))] as (usize),
                 bits[(lit as (usize))] as (u64),
@@ -337,7 +309,7 @@ fn EmitLiterals(
                 storage,
             );
         }
-        j = j.wrapping_add(1 as (usize));
+        j = j.wrapping_add(1);
     }
 }
 
@@ -350,7 +322,7 @@ fn EmitDistance(
     storage: &mut [u8],
 ) {
     let d: u64 = distance.wrapping_add(3usize) as u64;
-    let nbits: u32 = Log2FloorNonZero(d as u64).wrapping_sub(1u32);
+    let nbits: u32 = Log2FloorNonZero(d).wrapping_sub(1);
     let prefix: u64 = d >> nbits & 1;
     let offset: u64 = (2u64).wrapping_add(prefix) << nbits;
     let distcode: u64 = ((2u32).wrapping_mul(nbits.wrapping_sub(1u32)) as (u64))
@@ -385,14 +357,14 @@ fn EmitCopyLenLastDistance(
 ) {
     if copylen < 12usize {
         BrotliWriteBits(
-            depth[(copylen.wrapping_sub(4usize) as (usize))] as (usize),
-            bits[(copylen.wrapping_sub(4usize) as (usize))] as (u64),
+            depth[copylen.wrapping_sub(4)] as usize,
+            bits[copylen.wrapping_sub(4)] as u64,
             storage_ix,
             storage,
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(copylen.wrapping_sub(4usize) as (usize))];
+            let _lhs = &mut histo[copylen.wrapping_sub(4)];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if copylen < 72usize {
@@ -402,12 +374,7 @@ fn EmitCopyLenLastDistance(
         let code: usize = ((nbits << 1i32) as (usize))
             .wrapping_add(prefix)
             .wrapping_add(4usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         BrotliWriteBits(
             nbits as (usize),
             tail.wrapping_sub(prefix << nbits) as u64,
@@ -416,33 +383,23 @@ fn EmitCopyLenLastDistance(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if copylen < 136usize {
         let tail: usize = copylen.wrapping_sub(8usize);
         let code: usize = (tail >> 5i32).wrapping_add(30usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         BrotliWriteBits(5usize, tail as u64 & 31, storage_ix, storage);
-        BrotliWriteBits(
-            depth[(64usize)] as (usize),
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as u64, storage_ix, storage);
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if copylen < 2120usize {
@@ -461,12 +418,7 @@ fn EmitCopyLenLastDistance(
             storage_ix,
             storage,
         );
-        BrotliWriteBits(
-            depth[(64usize)] as (usize),
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as u64, storage_ix, storage);
         {
             let _rhs = 1;
             let _lhs = &mut histo[(code as (usize))];
@@ -474,36 +426,26 @@ fn EmitCopyLenLastDistance(
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else {
-        BrotliWriteBits(
-            depth[(39usize)] as (usize),
-            bits[(39usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[39] as usize, bits[39] as u64, storage_ix, storage);
         BrotliWriteBits(
             24usize,
             copylen.wrapping_sub(2120usize) as u64,
             storage_ix,
             storage,
         );
-        BrotliWriteBits(
-            depth[(64usize)] as (usize),
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as u64, storage_ix, storage);
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(39usize)];
+            let _lhs = &mut histo[39];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     }
@@ -526,14 +468,14 @@ fn EmitCopyLen(
 ) {
     if copylen < 10usize {
         BrotliWriteBits(
-            depth[(copylen.wrapping_add(14usize) as (usize))] as (usize),
-            bits[(copylen.wrapping_add(14usize) as (usize))] as (u64),
+            depth[copylen.wrapping_add(14)] as usize,
+            bits[copylen.wrapping_add(14)] as u64,
             storage_ix,
             storage,
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(copylen.wrapping_add(14usize) as (usize))];
+            let _lhs = &mut histo[copylen.wrapping_add(14)];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if copylen < 134usize {
@@ -543,12 +485,7 @@ fn EmitCopyLen(
         let code: usize = ((nbits << 1i32) as (usize))
             .wrapping_add(prefix)
             .wrapping_add(20usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         BrotliWriteBits(
             nbits as (usize),
             (tail as u64).wrapping_sub((prefix as u64) << nbits),
@@ -557,19 +494,14 @@ fn EmitCopyLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else if copylen < 2118usize {
         let tail: usize = copylen.wrapping_sub(70usize);
         let nbits: u32 = Log2FloorNonZero(tail as u64);
         let code: usize = nbits.wrapping_add(28u32) as (usize);
-        BrotliWriteBits(
-            depth[(code as (usize))] as (usize),
-            bits[(code as (usize))] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[code] as usize, bits[code] as u64, storage_ix, storage);
         BrotliWriteBits(
             nbits as (usize),
             (tail as u64).wrapping_sub(1 << nbits),
@@ -578,16 +510,11 @@ fn EmitCopyLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(code as (usize))];
+            let _lhs = &mut histo[code];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     } else {
-        BrotliWriteBits(
-            depth[(39usize)] as (usize),
-            bits[(39usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[39] as usize, bits[39] as u64, storage_ix, storage);
         BrotliWriteBits(
             24usize,
             (copylen as u64).wrapping_sub(2118),
@@ -596,7 +523,7 @@ fn EmitCopyLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(39usize)];
+            let _lhs = &mut histo[39];
             *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
         }
     }
@@ -610,7 +537,7 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> i32 {
     while i < len {
         {
             let _rhs = 1;
-            let _lhs = &mut histo[data[(i as (usize))] as (usize)];
+            let _lhs = &mut histo[data[i] as usize];
             *_lhs = (*_lhs).wrapping_add(_rhs as (usize));
         }
         i = i.wrapping_add(kSampleRate);
@@ -627,9 +554,9 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> i32 {
         while i < 256usize {
             {
                 r -= histo[i] as (super::util::floatX)
-                    * (depths[(i as (usize))] as (super::util::floatX) + FastLog2(histo[i] as u64));
+                    * (depths[i] as (super::util::floatX) + FastLog2(histo[i] as u64));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         if !!(r >= 0.0 as super::util::floatX) {
             1i32
@@ -648,9 +575,9 @@ fn UpdateBits(mut n_bits: usize, mut bits: u32, mut pos: usize, array: &mut [u8]
         let total_bits: usize = n_unchanged_bits.wrapping_add(n_changed_bits);
         let mask: u32 = !(1u32 << total_bits).wrapping_sub(1u32)
             | (1u32 << n_unchanged_bits).wrapping_sub(1u32);
-        let unchanged_bits: u32 = array[(byte_pos as (usize))] as (u32) & mask;
+        let unchanged_bits: u32 = (array[byte_pos] as u32) & mask;
         let changed_bits: u32 = bits & (1u32 << n_changed_bits).wrapping_sub(1u32);
-        array[(byte_pos as (usize))] = (changed_bits << n_unchanged_bits | unchanged_bits) as (u8);
+        array[byte_pos] = (changed_bits << n_unchanged_bits | unchanged_bits) as u8;
         n_bits = n_bits.wrapping_sub(n_changed_bits);
         bits >>= n_changed_bits;
         pos = pos.wrapping_add(n_changed_bits);
@@ -670,11 +597,11 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
-        &histogram[64usize..],
+        &histogram[64..],
         64usize,
         14i32,
         &mut tree[..],
-        &mut depth[64usize..],
+        &mut depth[64..],
     );
     /* We have to jump through a few hoops here in order to compute
     the command bits because the symbols are in a different order than in
@@ -724,7 +651,7 @@ fn BuildAndStoreCommandPrefixCode(
     memcpy(bits, (40usize), &cmd_bits[..], 24i32 as (usize), 8usize);
     memcpy(bits, (48usize), &cmd_bits[..], 40i32 as (usize), 8usize);
     memcpy(bits, (56usize), &cmd_bits[..], 56i32 as (usize), 8usize);
-    BrotliConvertBitDepthsToSymbols(&mut depth[64usize..], 64usize, &mut bits[64usize..]);
+    BrotliConvertBitDepthsToSymbols(&mut depth[64..], 64, &mut bits[64..]);
     {
         let mut i: usize;
         for item in cmd_depth[..64].iter_mut() {
@@ -769,7 +696,7 @@ fn BuildAndStoreCommandPrefixCode(
                 cmd_depth[(448usize).wrapping_add((8usize).wrapping_mul(i))] =
                     depth[i.wrapping_add(56)];
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         BrotliStoreHuffmanTree(
             &mut cmd_depth[..],
@@ -780,7 +707,7 @@ fn BuildAndStoreCommandPrefixCode(
         );
     }
     BrotliStoreHuffmanTree(
-        &mut depth[64usize..],
+        &mut depth[64..],
         64usize,
         &mut tree[..],
         storage_ix,
@@ -963,7 +890,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             );
                         }
                         EmitLiterals(
-                            &input_ptr[(next_emit as (usize))..],
+                            &input_ptr[next_emit..],
                             insert,
                             &mut lit_depth[..],
                             &mut lit_bits[..],
@@ -1062,7 +989,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                         {
                             assert!(ip_index >= 3);
                             let input_bytes: u64 =
-                                BROTLI_UNALIGNED_LOAD64(&input_ptr[ip_index as usize - 3..]);
+                                BROTLI_UNALIGNED_LOAD64(&input_ptr[ip_index - 3..]);
                             let mut prev_hash: u32 = HashBytesAtOffset(input_bytes, 0i32, shift);
                             let cur_hash: u32 = HashBytesAtOffset(input_bytes, 3i32, shift);
                             table[prev_hash as usize] =
@@ -1176,7 +1103,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                 BrotliWriteBits(13usize, 0, storage_ix, storage);
                 literal_ratio = BuildAndStoreLiteralPrefixCode(
                     m,
-                    &input_ptr[(input_index as (usize))..],
+                    &input_ptr[input_index..],
                     block_size,
                     &mut lit_depth[..],
                     &mut lit_bits[..],

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -33,10 +33,8 @@ fn get_stride_cdf_low(
     cm_prior: usize,
     high_nibble: u8,
 ) -> &mut [u16] {
-    let index: usize = 1 + 2
-        * (cm_prior as usize
-            | ((stride_prior as usize & 0xf) << 8)
-            | ((high_nibble as usize) << 12));
+    let index: usize =
+        1 + 2 * (cm_prior | ((stride_prior as usize & 0xf) << 8) | ((high_nibble as usize) << 12));
     data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
@@ -44,7 +42,7 @@ fn get_stride_cdf_low(
 }
 
 fn get_stride_cdf_high(data: &mut [u16], stride_prior: u8, cm_prior: usize) -> &mut [u16] {
-    let index: usize = 2 * (cm_prior as usize | ((stride_prior as usize) << 8));
+    let index: usize = 2 * (cm_prior | ((stride_prior as usize) << 8));
     data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
@@ -52,7 +50,7 @@ fn get_stride_cdf_high(data: &mut [u16], stride_prior: u8, cm_prior: usize) -> &
 }
 
 fn get_cm_cdf_low(data: &mut [u16], cm_prior: usize, high_nibble: u8) -> &mut [u16] {
-    let index: usize = (high_nibble as usize + 1) + 17 * cm_prior as usize;
+    let index: usize = (high_nibble as usize + 1) + 17 * cm_prior;
     data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
@@ -60,7 +58,7 @@ fn get_cm_cdf_low(data: &mut [u16], cm_prior: usize, high_nibble: u8) -> &mut [u
 }
 
 fn get_cm_cdf_high(data: &mut [u16], cm_prior: usize) -> &mut [u16] {
-    let index: usize = 17 * cm_prior as usize;
+    let index: usize = 17 * cm_prior;
     data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -796,9 +796,9 @@ fn RingBufferInitBuffer<AllocU8: alloc::Allocator<u8>>(
             rb.data_mo.slice_mut()[(rb
                 .buffer_index
                 .wrapping_add(rb.cur_size_ as (usize))
-                .wrapping_add(i) as (usize))] = 0;
+                .wrapping_add(i))] = 0;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -810,7 +810,7 @@ fn RingBufferWriteTail<AllocU8: alloc::Allocator<u8>>(
     let masked_pos: usize = (rb.pos_ & rb.mask_) as (usize);
     if masked_pos < rb.tail_size_ as (usize) {
         let p: usize = (rb.size_ as (usize)).wrapping_add(masked_pos);
-        let begin = (rb.buffer_index.wrapping_add(p) as (usize));
+        let begin = rb.buffer_index.wrapping_add(p);
         let lim = brotli_min_size_t(n, (rb.tail_size_ as (usize)).wrapping_sub(masked_pos));
         rb.data_mo.slice_mut()[begin..(begin + lim)].clone_from_slice(&bytes[..lim]);
     }
@@ -825,7 +825,7 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
     if rb.pos_ == 0u32 && (n < rb.tail_size_ as (usize)) {
         rb.pos_ = n as (u32);
         RingBufferInitBuffer(m, rb.pos_, rb);
-        rb.data_mo.slice_mut()[(rb.buffer_index as (usize))..((rb.buffer_index as (usize)) + n)]
+        rb.data_mo.slice_mut()[rb.buffer_index..(rb.buffer_index + n)]
             .clone_from_slice(&bytes[..n]);
         return;
     }
@@ -837,29 +837,30 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
         rb.data_mo.slice_mut()[(rb
             .buffer_index
             .wrapping_add(rb.size_ as (usize))
-            .wrapping_sub(2usize) as (usize))] = 0i32 as (u8);
+            .wrapping_sub(2))] = 0;
         rb.data_mo.slice_mut()[(rb
             .buffer_index
             .wrapping_add(rb.size_ as (usize))
-            .wrapping_sub(1usize) as (usize))] = 0i32 as (u8);
+            .wrapping_sub(1))] = 0;
     }
     {
         let masked_pos: usize = (rb.pos_ & rb.mask_) as (usize);
         RingBufferWriteTail(bytes, n, rb);
         if masked_pos.wrapping_add(n) <= rb.size_ as (usize) {
             // a single write fits
-            let start = (rb.buffer_index.wrapping_add(masked_pos) as (usize));
+            let start = (rb.buffer_index.wrapping_add(masked_pos));
             rb.data_mo.slice_mut()[start..(start + n)].clone_from_slice(&bytes[..n]);
         } else {
             {
-                let start = (rb.buffer_index.wrapping_add(masked_pos) as (usize));
+                let start = (rb.buffer_index.wrapping_add(masked_pos));
                 let mid =
                     brotli_min_size_t(n, (rb.total_size_ as (usize)).wrapping_sub(masked_pos));
                 rb.data_mo.slice_mut()[start..(start + mid)].clone_from_slice(&bytes[..mid]);
             }
-            let xstart = (rb.buffer_index.wrapping_add(0usize) as (usize));
+            // FIXME?  Adding zero?
+            let xstart = (rb.buffer_index.wrapping_add(0));
             let size = n.wrapping_sub((rb.size_ as (usize)).wrapping_sub(masked_pos));
-            let bytes_start = ((rb.size_ as (usize)).wrapping_sub(masked_pos) as (usize));
+            let bytes_start = ((rb.size_ as (usize)).wrapping_sub(masked_pos));
             rb.data_mo.slice_mut()[xstart..(xstart + size)]
                 .clone_from_slice(&bytes[bytes_start..(bytes_start + size)]);
         }
@@ -867,13 +868,13 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
     let data_2 = rb.data_mo.slice()[(rb
         .buffer_index
         .wrapping_add(rb.size_ as (usize))
-        .wrapping_sub(2usize) as (usize))];
-    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2usize) as (usize))] = data_2;
+        .wrapping_sub(2))];
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2))] = data_2;
     let data_1 = rb.data_mo.slice()[(rb
         .buffer_index
         .wrapping_add(rb.size_ as (usize))
-        .wrapping_sub(1usize) as (usize))];
-    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(1usize) as (usize))] = data_1;
+        .wrapping_sub(1))];
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(1))] = data_1;
     rb.pos_ = rb.pos_.wrapping_add(n as (u32));
     if rb.pos_ > 1u32 << 30i32 {
         rb.pos_ = rb.pos_ & (1u32 << 30i32).wrapping_sub(1u32) | 1u32 << 30i32;
@@ -894,9 +895,10 @@ fn CopyInputToRingBuffer<Alloc: BrotliAlloc>(
     }
     s.input_pos_ = s.input_pos_.wrapping_add(input_size as u64);
     if (s.ringbuffer_).pos_ <= (s.ringbuffer_).mask_ {
-        let start = ((s.ringbuffer_)
+        let start = (s
+            .ringbuffer_
             .buffer_index
-            .wrapping_add((s.ringbuffer_).pos_ as (usize)) as (usize));
+            .wrapping_add(s.ringbuffer_.pos_ as usize));
         for item in (s.ringbuffer_).data_mo.slice_mut()[start..(start + 7)].iter_mut() {
             *item = 0;
         }
@@ -1107,7 +1109,7 @@ fn InitializeH5<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
         specialization: H5Sub {
             hash_shift_: 32i32 - params.hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
-            block_bits_: params.hasher.block_bits as i32,
+            block_bits_: params.hasher.block_bits,
             block_mask_: block_size.wrapping_sub(1u64) as u32,
         },
     })
@@ -1296,17 +1298,17 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
     }
     s.custom_dictionary = true;
     if size > max_dict_size {
-        dict = &dict[(size.wrapping_sub(max_dict_size) as (usize))..];
+        dict = &dict[size.wrapping_sub(max_dict_size)..];
         dict_size = max_dict_size;
     }
     CopyInputToRingBuffer(s, dict_size, dict);
     s.last_flush_pos_ = dict_size as u64;
     s.last_processed_pos_ = dict_size as u64;
     if dict_size > 0 {
-        s.prev_byte_ = dict[(dict_size.wrapping_sub(1usize) as (usize))];
+        s.prev_byte_ = dict[dict_size.wrapping_sub(1)];
     }
     if dict_size > 1usize {
-        s.prev_byte2_ = dict[(dict_size.wrapping_sub(2usize) as (usize))];
+        s.prev_byte2_ = dict[dict_size.wrapping_sub(2)];
     }
     let m16 = &mut s.m8;
     if cfg!(debug_assertions) || !has_optional_hasher {
@@ -1419,13 +1421,12 @@ fn ShouldCompress(
             {
                 {
                     let _rhs = 1;
-                    let _lhs =
-                        &mut literal_histo[data[((pos as (usize) & mask) as (usize))] as (usize)];
+                    let _lhs = &mut literal_histo[data[(pos as usize) & mask] as usize];
                     *_lhs = (*_lhs).wrapping_add(_rhs as (u32));
                 }
                 pos = pos.wrapping_add(kSampleRate);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         if BitsEntropy(&literal_histo[..], 256usize) > bit_cost_threshold {
             return 0i32;
@@ -1470,19 +1471,19 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
     let mut result: usize = 0usize;
     let mut offset: usize = 0usize;
     if input_size == 0usize {
-        output[(0usize)] = 6i32 as (u8);
-        return 1usize;
+        output[0] = 6;
+        return 1;
     }
     output[({
         let _old = result;
-        result = result.wrapping_add(1 as (usize));
+        result = result.wrapping_add(1);
         _old
-    } as (usize))] = 0x21i32 as (u8);
+    })] = 0x21;
     output[({
         let _old = result;
-        result = result.wrapping_add(1 as (usize));
+        result = result.wrapping_add(1);
         _old
-    } as (usize))] = 0x3i32 as (u8);
+    })] = 0x03;
     while size > 0usize {
         let mut nibbles: u32 = 0u32;
 
@@ -1503,27 +1504,27 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
             | 1u32 << (19u32).wrapping_add((4u32).wrapping_mul(nibbles));
         output[({
             let _old = result;
-            result = result.wrapping_add(1 as (usize));
+            result = result.wrapping_add(1);
             _old
-        } as (usize))] = bits as (u8);
+        })] = bits as u8;
         output[({
             let _old = result;
-            result = result.wrapping_add(1 as (usize));
+            result = result.wrapping_add(1);
             _old
-        } as (usize))] = (bits >> 8i32) as (u8);
+        })] = (bits >> 8) as u8;
         output[({
             let _old = result;
-            result = result.wrapping_add(1 as (usize));
+            result = result.wrapping_add(1);
             _old
-        } as (usize))] = (bits >> 16i32) as (u8);
+        })] = (bits >> 16) as u8;
         if nibbles == 2u32 {
             output[({
                 let _old = result;
-                result = result.wrapping_add(1 as (usize));
+                result = result.wrapping_add(1);
                 _old
-            } as (usize))] = (bits >> 24i32) as (u8);
+            })] = (bits >> 24) as u8;
         }
-        output[(result as usize)..(result + chunk_size as usize)]
+        output[result..(result + chunk_size as usize)]
             .clone_from_slice(&input[offset..(offset + chunk_size as usize)]);
         result = result.wrapping_add(chunk_size as (usize));
         offset = offset.wrapping_add(chunk_size as (usize));
@@ -1531,9 +1532,9 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
     }
     output[({
         let _old = result;
-        result = result.wrapping_add(1 as (usize));
+        result = result.wrapping_add(1);
         _old
-    } as (usize))] = 3i32 as (u8);
+    })] = 3;
     result
 }
 pub fn BrotliEncoderCompress<
@@ -1651,17 +1652,17 @@ fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<A
 
     seal_bits = seal_bits.wrapping_add(6usize);
     if !IsNextOutNull(&s.next_out_) {
-        destination = &mut GetNextOut!(*s)[(s.available_out_ as (usize))..];
+        destination = &mut GetNextOut!(*s)[s.available_out_..];
     } else {
         destination = &mut s.tiny_buf_[..];
         s.next_out_ = NextOut::TinyBuf(0);
     }
-    destination[(0usize)] = seal as (u8);
+    destination[0] = seal as u8;
     if seal_bits > 8usize {
-        destination[(1usize)] = (seal >> 8i32) as (u8);
+        destination[1] = (seal >> 8) as u8;
     }
     if seal_bits > 16usize {
-        destination[(2usize)] = (seal >> 16i32) as (u8);
+        destination[2] = (seal >> 16) as u8;
     }
     s.available_out_ = s
         .available_out_
@@ -1854,63 +1855,59 @@ fn ChooseContextMap(
     while i < 9usize {
         {
             {
-                let _rhs = bigram_histo[(i as (usize))];
+                let _rhs = bigram_histo[i];
                 let _lhs = &mut monogram_histo[i.wrapping_rem(3usize)];
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
             {
-                let _rhs = bigram_histo[(i as (usize))];
+                let _rhs = bigram_histo[i];
                 let _lhs = &mut two_prefix_histo[i.wrapping_rem(6usize)];
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
-    entropy[1usize] = ShannonEntropy(&monogram_histo[..], 3usize, &mut dummy);
-    entropy[2usize] = ShannonEntropy(&two_prefix_histo[..], 3usize, &mut dummy)
-        + ShannonEntropy(&two_prefix_histo[3i32 as (usize)..], 3usize, &mut dummy);
-    entropy[3usize] = 0i32 as (super::util::floatX);
+    entropy[1] = ShannonEntropy(&monogram_histo[..], 3, &mut dummy);
+    entropy[2] = ShannonEntropy(&two_prefix_histo[..], 3, &mut dummy)
+        + ShannonEntropy(&two_prefix_histo[3..], 3, &mut dummy);
+    entropy[3] = 0.0;
     i = 0usize;
     while i < 3usize {
         {
-            let _rhs = ShannonEntropy(
-                &bigram_histo[((3usize).wrapping_mul(i) as (usize))..],
-                3usize,
-                &mut dummy,
-            );
-            let _lhs = &mut entropy[3usize];
+            let _rhs = ShannonEntropy(&bigram_histo[(3usize).wrapping_mul(i)..], 3, &mut dummy);
+            let _lhs = &mut entropy[3];
             *_lhs += _rhs;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
-    let total: usize = monogram_histo[0usize]
-        .wrapping_add(monogram_histo[1usize])
-        .wrapping_add(monogram_histo[2usize]) as (usize);
-    0i32;
-    entropy[0usize] = 1.0 as super::util::floatX / total as (super::util::floatX);
+    let total = monogram_histo[0]
+        .wrapping_add(monogram_histo[1])
+        .wrapping_add(monogram_histo[2]) as usize;
+
+    entropy[0] = 1.0 as super::util::floatX / total as (super::util::floatX);
     {
-        let _rhs = entropy[0usize];
-        let _lhs = &mut entropy[1usize];
+        let _rhs = entropy[0];
+        let _lhs = &mut entropy[1];
         *_lhs *= _rhs;
     }
     {
-        let _rhs = entropy[0usize];
-        let _lhs = &mut entropy[2usize];
+        let _rhs = entropy[0];
+        let _lhs = &mut entropy[2];
         *_lhs *= _rhs;
     }
     {
-        let _rhs = entropy[0usize];
-        let _lhs = &mut entropy[3usize];
+        let _rhs = entropy[0];
+        let _lhs = &mut entropy[3];
         *_lhs *= _rhs;
     }
     if quality < 7i32 {
-        entropy[3usize] = entropy[1usize] * 10i32 as (super::util::floatX);
+        entropy[3] = entropy[1] * 10i32 as (super::util::floatX);
     }
-    if entropy[1usize] - entropy[2usize] < 0.2 as super::util::floatX
-        && (entropy[1usize] - entropy[3usize] < 0.2 as super::util::floatX)
+    if entropy[1] - entropy[2] < 0.2 as super::util::floatX
+        && (entropy[1] - entropy[3] < 0.2 as super::util::floatX)
     {
         *num_literal_contexts = 1usize;
-    } else if entropy[2usize] - entropy[3usize] < 0.02 as super::util::floatX {
+    } else if entropy[2] - entropy[3] < 0.02 as super::util::floatX {
         *num_literal_contexts = 2usize;
         *literal_context_map = &kStaticContextMapSimpleUTF8[..];
     } else {
@@ -2040,14 +2037,12 @@ fn DecideOverLiteralContextModeling(
             {
                 static lut: [i32; 4] = [0i32, 0i32, 1i32, 2i32];
                 let stride_end_pos: usize = start_pos.wrapping_add(64usize);
-                let mut prev: i32 = lut
-                    [(input[((start_pos & mask) as (usize))] as (i32) >> 6i32) as (usize)]
-                    * 3i32;
+                let mut prev: i32 = lut[(input[start_pos & mask] as (i32) >> 6i32) as usize] * 3i32;
                 let mut pos: usize;
                 pos = start_pos.wrapping_add(1usize);
                 while pos < stride_end_pos {
                     {
-                        let literal: u8 = input[((pos & mask) as (usize))];
+                        let literal = input[pos & mask];
                         {
                             let _rhs = 1;
                             let cur_ind = (prev + lut[(literal as (i32) >> 6i32) as (usize)]);
@@ -2056,7 +2051,7 @@ fn DecideOverLiteralContextModeling(
                         }
                         prev = lut[(literal as (i32) >> 6i32) as (usize)] * 3i32;
                     }
-                    pos = pos.wrapping_add(1 as (usize));
+                    pos = pos.wrapping_add(1);
                 }
             }
             start_pos = start_pos.wrapping_add(4096usize);
@@ -2390,8 +2385,8 @@ where
     if let IsFirst::NothingWritten = s.is_first_mb {
         if s.params.magic_number {
             BrotliWriteMetadataMetaBlock(&s.params, &mut storage_ix, s.storage_.slice_mut());
-            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[storage_ix >> 3i32] as u16
+                | ((s.storage_.slice()[1 + (storage_ix >> 3i32)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
             s.next_out_ = NextOut::DynamicStorage(0);
             catable_header_size = storage_ix >> 3;
@@ -2407,8 +2402,7 @@ where
         assert!(s.last_processed_pos_ < 2 || s.custom_dictionary);
         let num_bytes_to_write_uncompressed: usize = core::cmp::min(2, bytes as usize);
         {
-            let data =
-                &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..];
+            let data = &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..];
             BrotliStoreUncompressedMetaBlock(
                 &mut s.m8,
                 0,
@@ -2423,8 +2417,8 @@ where
                 false, /* suppress meta-block logging */
                 callback,
             );
-            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[storage_ix >> 3] as u16
+                | ((s.storage_.slice()[1 + (storage_ix >> 3)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
             s.prev_byte2_ = s.prev_byte_;
             s.prev_byte_ = data[s.last_flush_pos_ as usize & mask as usize];
@@ -2466,8 +2460,7 @@ where
                 *out_size = catable_header_size;
                 return 1i32;
             }
-            let data =
-                &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..];
+            let data = &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..];
 
             //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
             //        (*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
@@ -2504,8 +2497,8 @@ where
                     s.storage_.slice_mut(),
                 );
             }
-            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | ((s.storage_.slice()[((storage_ix >> 3i32) as (usize)) + 1] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[storage_ix >> 3] as u16
+                | ((s.storage_.slice()[(storage_ix >> 3) + 1] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
         }
         UpdateLastProcessedPos(s);
@@ -2537,7 +2530,7 @@ where
     InitOrStitchToPreviousBlock(
         &mut s.m8,
         &mut s.hasher_,
-        &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..],
+        &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..],
         mask as (usize),
         &mut s.params,
         wrapped_last_processed_pos as (usize),
@@ -2594,13 +2587,13 @@ where
             dictionary,
             bytes as (usize),
             wrapped_last_processed_pos as (usize),
-            &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as usize)..],
+            &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..],
             mask as (usize),
             &mut s.params,
             &mut s.hasher_,
             &mut s.dist_cache_,
             &mut s.last_insert_len_,
-            &mut s.commands_.slice_mut()[(s.num_commands_ as (usize))..],
+            &mut s.commands_.slice_mut()[s.num_commands_..],
             &mut s.num_commands_,
             &mut s.num_literals_,
         );
@@ -2641,9 +2634,9 @@ where
         InitInsertCommand(
             &mut s.commands_.slice_mut()[({
                 let _old = s.num_commands_;
-                s.num_commands_ = s.num_commands_.wrapping_add(1 as (usize));
+                s.num_commands_ = s.num_commands_.wrapping_add(1);
                 _old
-            } as (usize))],
+            })],
             s.last_insert_len_,
         );
         s.num_literals_ = s.num_literals_.wrapping_add(s.last_insert_len_);
@@ -2655,13 +2648,13 @@ where
     }
     {
         let metablock_size: u32 = s.input_pos_.wrapping_sub(s.last_flush_pos_) as (u32);
-        //let mut storage_ix: usize = (*s).last_bytes_bits_ as (usize);
-        //(*s).storage_.slice_mut()[(0usize)] = (*s).last_bytes_ as u8;
-        //(*s).storage_.slice_mut()[(1usize)] = ((*s).last_bytes_ >> 8) as u8;
+        // let mut storage_ix = s.last_bytes_bits_ as usize;
+        // s.storage_.slice_mut()[0] = s.last_bytes_ as u8;
+        // s.storage_.slice_mut()[1] = (s.last_bytes_ >> 8) as u8;
 
         WriteMetaBlockInternal(
             &mut s.m8,
-            &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as usize)..],
+            &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..],
             mask as (usize),
             s.last_flush_pos_,
             metablock_size as (usize),
@@ -2684,14 +2677,14 @@ where
             callback,
         );
 
-        s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-            | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+        s.last_bytes_ = s.storage_.slice()[storage_ix >> 3] as u16
+            | ((s.storage_.slice()[1 + (storage_ix >> 3)] as u16) << 8);
         s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
         s.last_flush_pos_ = s.input_pos_;
         if UpdateLastProcessedPos(s) != 0 {
             HasherReset(&mut s.hasher_);
         }
-        let data = &s.ringbuffer_.data_mo.slice()[s.ringbuffer_.buffer_index as usize..];
+        let data = &s.ringbuffer_.data_mo.slice()[s.ringbuffer_.buffer_index..];
         if s.last_flush_pos_ > 0 {
             s.prev_byte_ =
                 data[(((s.last_flush_pos_ as (u32)).wrapping_sub(1u32) & mask) as (usize))];
@@ -2714,8 +2707,8 @@ fn WriteMetadataHeader<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Allo
     let header = GetNextOut!(*s);
     let mut storage_ix: usize;
     storage_ix = s.last_bytes_bits_ as (usize);
-    header[(0usize)] = s.last_bytes_ as u8;
-    header[(1usize)] = (s.last_bytes_ >> 8) as u8;
+    header[0] = s.last_bytes_ as u8;
+    header[1] = (s.last_bytes_ >> 8) as u8;
     s.last_bytes_ = 0;
     s.last_bytes_bits_ = 0;
     BrotliWriteBits(1usize, 0, &mut storage_ix, header);
@@ -2960,8 +2953,8 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 GetBrotliStorage(s, max_out_size);
                 storage = s.storage_.slice_mut();
             }
-            storage[(0usize)] = s.last_bytes_ as u8;
-            storage[(1usize)] = (s.last_bytes_ >> 8) as u8;
+            storage[0] = s.last_bytes_ as u8;
+            storage[1] = (s.last_bytes_ >> 8) as u8;
             let table: &mut [i32] = GetHashTable!(s, s.params.quality, block_size, &mut table_size);
             if s.params.quality == 0i32 {
                 BrotliCompressFragmentFast(
@@ -2992,13 +2985,13 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                     storage,
                 );
             }
-            *next_in_offset += block_size as usize;
+            *next_in_offset += block_size;
             *available_in = (*available_in).wrapping_sub(block_size);
             if inplace != 0 {
                 let out_bytes: usize = storage_ix >> 3i32;
                 0i32;
                 0i32;
-                *next_out_offset += out_bytes as (usize);
+                *next_out_offset += out_bytes;
                 *available_out = (*available_out).wrapping_sub(out_bytes);
                 s.total_out_ = s.total_out_.wrapping_add(out_bytes as u64);
                 if let &mut Some(ref mut total_out_inner) = total_out {
@@ -3009,8 +3002,8 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 s.next_out_ = NextOut::DynamicStorage(0);
                 s.available_out_ = out_bytes;
             }
-            s.last_bytes_ = storage[((storage_ix >> 3i32) as (usize))] as u16
-                | ((storage[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+            s.last_bytes_ =
+                storage[storage_ix >> 3] as u16 | ((storage[1 + (storage_ix >> 3)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
             if force_flush != 0 {
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
@@ -3127,7 +3120,7 @@ pub fn BrotliEncoderCompressStream<
         if remaining_block_size != 0usize && (*available_in != 0usize) {
             let copy_input_size: usize = brotli_min_size_t(remaining_block_size, *available_in);
             CopyInputToRingBuffer(s, copy_input_size, &next_in_array[*next_in_offset..]);
-            *next_in_offset += copy_input_size as (usize);
+            *next_in_offset += copy_input_size;
             *available_in = (*available_in).wrapping_sub(copy_input_size);
             {
                 {

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -31,7 +31,7 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
     let mut level: i32 = 0i32;
     let mut p: i32 = p0;
     0i32;
-    stack[0usize] = -1i32;
+    stack[0] = -1;
     loop {
         if (pool[(p as (usize))]).index_left_ as (i32) >= 0i32 {
             level += 1;
@@ -84,15 +84,15 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
         i = 1usize;
         while i < n {
             {
-                let mut tmp: HuffmanTree = items[(i as (usize))];
+                let mut tmp: HuffmanTree = items[i];
                 let mut k: usize = i;
                 let mut j: usize = i.wrapping_sub(1usize);
-                while comparator.Cmp(&mut tmp, &mut items[(j as (usize))]) {
-                    items[(k as (usize))] = items[(j as (usize))];
+                while comparator.Cmp(&mut tmp, &mut items[j]) {
+                    items[k] = items[j];
                     k = j;
                     if {
                         let _old = j;
-                        j = j.wrapping_sub(1 as (usize));
+                        j = j.wrapping_sub(1);
                         _old
                     } == 0
                     {
@@ -101,9 +101,9 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
                         }
                     }
                 }
-                items[(k as (usize))] = tmp;
+                items[k] = tmp;
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     } else {
         let mut g: i32 = if n < 57usize { 2i32 } else { 0i32 };
@@ -115,19 +115,17 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
                 while i < n {
                     {
                         let mut j: usize = i;
-                        let mut tmp: HuffmanTree = items[(i as (usize))];
-                        while j >= gap
-                            && (comparator
-                                .Cmp(&mut tmp, &mut items[(j.wrapping_sub(gap) as (usize))]))
+                        let mut tmp: HuffmanTree = items[i];
+                        while j >= gap && comparator.Cmp(&mut tmp, &mut items[j.wrapping_sub(gap)])
                         {
                             {
-                                items[(j as (usize))] = items[(j.wrapping_sub(gap) as (usize))];
+                                items[j] = items[j.wrapping_sub(gap)];
                             }
                             j = j.wrapping_sub(gap);
                         }
-                        items[(j as (usize))] = tmp;
+                        items[j] = tmp;
                     }
-                    i = i.wrapping_add(1 as (usize));
+                    i = i.wrapping_add(1);
                 }
             }
             g += 1;
@@ -173,15 +171,15 @@ pub fn BrotliCreateHuffmanTree(
             let mut k: usize;
             i = length;
             while i != 0usize {
-                i = i.wrapping_sub(1 as (usize));
-                if data[(i as (usize))] != 0 {
-                    let count: u32 = brotli_max_uint32_t(data[(i as (usize))], count_limit);
+                i = i.wrapping_sub(1);
+                if data[i] != 0 {
+                    let count: u32 = brotli_max_uint32_t(data[i], count_limit);
                     InitHuffmanTree(
                         &mut tree[({
                             let _old = n;
-                            n = n.wrapping_add(1 as (usize));
+                            n = n.wrapping_add(1);
                             _old
-                        } as (usize))],
+                        })],
                         count,
                         -1i32 as (i16),
                         i as (i16),
@@ -189,7 +187,7 @@ pub fn BrotliCreateHuffmanTree(
                 }
             }
             if n == 1usize {
-                depth[((tree[(0usize)]).index_right_or_value_ as (usize))] = 1i32 as (u8);
+                depth[tree[0].index_right_or_value_ as usize] = 1;
                 {
                     {
                         break 'break1;
@@ -197,8 +195,8 @@ pub fn BrotliCreateHuffmanTree(
                 }
             }
             SortHuffmanTreeItems(tree, n, SortHuffmanTree {});
-            tree[(n as (usize))] = sentinel;
-            tree[(n.wrapping_add(1usize) as (usize))] = sentinel;
+            tree[n] = sentinel;
+            tree[n.wrapping_add(1)] = sentinel;
             i = 0usize;
             j = n.wrapping_add(1usize);
             k = n.wrapping_sub(1usize);
@@ -206,31 +204,31 @@ pub fn BrotliCreateHuffmanTree(
                 {
                     let left: usize;
                     let right: usize;
-                    if (tree[(i as (usize))]).total_count_ <= (tree[(j as (usize))]).total_count_ {
+                    if tree[i].total_count_ <= tree[j].total_count_ {
                         left = i;
-                        i = i.wrapping_add(1 as (usize));
+                        i = i.wrapping_add(1);
                     } else {
                         left = j;
-                        j = j.wrapping_add(1 as (usize));
+                        j = j.wrapping_add(1);
                     }
-                    if (tree[(i as (usize))]).total_count_ <= (tree[(j as (usize))]).total_count_ {
+                    if tree[i].total_count_ <= tree[j].total_count_ {
                         right = i;
-                        i = i.wrapping_add(1 as (usize));
+                        i = i.wrapping_add(1);
                     } else {
                         right = j;
-                        j = j.wrapping_add(1 as (usize));
+                        j = j.wrapping_add(1);
                     }
                     {
                         let j_end: usize = (2usize).wrapping_mul(n).wrapping_sub(k);
-                        (tree[(j_end as (usize))]).total_count_ = (tree[(left as (usize))])
+                        tree[j_end].total_count_ = tree[left]
                             .total_count_
-                            .wrapping_add((tree[(right as (usize))]).total_count_);
-                        (tree[(j_end as (usize))]).index_left_ = left as (i16);
-                        (tree[(j_end as (usize))]).index_right_or_value_ = right as (i16);
-                        tree[(j_end.wrapping_add(1usize) as (usize))] = sentinel;
+                            .wrapping_add(tree[right].total_count_);
+                        tree[j_end].index_left_ = left as i16;
+                        tree[j_end].index_right_or_value_ = right as i16;
+                        tree[j_end.wrapping_add(1)] = sentinel;
                     }
                 }
-                k = k.wrapping_sub(1 as (usize));
+                k = k.wrapping_sub(1);
             }
             if BrotliSetDepth(
                 (2usize).wrapping_mul(n).wrapping_sub(1usize) as (i32),
@@ -260,17 +258,17 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     i = 0usize;
     while i < length {
         {
-            if counts[(i as (usize))] != 0 {
-                nonzero_count = nonzero_count.wrapping_add(1 as (usize));
+            if counts[i] != 0 {
+                nonzero_count = nonzero_count.wrapping_add(1);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     if nonzero_count < 16usize {
         return;
     }
-    while length != 0usize && (counts[(length.wrapping_sub(1usize) as (usize))] == 0u32) {
-        length = length.wrapping_sub(1 as (usize));
+    while length != 0 && counts[length.wrapping_sub(1)] == 0 {
+        length = length.wrapping_sub(1);
     }
     if length == 0usize {
         return;
@@ -281,14 +279,14 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
         i = 0usize;
         while i < length {
             {
-                if counts[(i as (usize))] != 0u32 {
-                    nonzeros = nonzeros.wrapping_add(1 as (usize));
-                    if smallest_nonzero > counts[(i as (usize))] {
-                        smallest_nonzero = counts[(i as (usize))];
+                if counts[i] != 0 {
+                    nonzeros = nonzeros.wrapping_add(1);
+                    if smallest_nonzero > counts[i] {
+                        smallest_nonzero = counts[i];
                     }
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         if nonzeros < 5usize {
             return;
@@ -299,14 +297,14 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 i = 1usize;
                 while i < length.wrapping_sub(1usize) {
                     {
-                        if counts[(i.wrapping_sub(1usize) as (usize))] != 0u32
-                            && (counts[(i as (usize))] == 0u32)
-                            && (counts[(i.wrapping_add(1usize) as (usize))] != 0u32)
+                        if counts[i.wrapping_sub(1)] != 0
+                            && counts[i] == 0
+                            && counts[i.wrapping_add(1)] != 0
                         {
-                            counts[(i as (usize))] = 1u32;
+                            counts[i] = 1;
                         }
                     }
-                    i = i.wrapping_add(1 as (usize));
+                    i = i.wrapping_add(1);
                 }
             }
         }
@@ -318,41 +316,34 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
         *rle_item = 0;
     }
     {
-        let mut symbol: u32 = counts[(0usize)];
+        let mut symbol: u32 = counts[0];
         let mut step: usize = 0usize;
         i = 0usize;
         while i <= length {
             {
-                if i == length || counts[(i as (usize))] != symbol {
+                if i == length || counts[i] != symbol {
                     if symbol == 0u32 && (step >= 5usize) || symbol != 0u32 && (step >= 7usize) {
                         let mut k: usize;
                         k = 0usize;
                         while k < step {
-                            {
-                                good_for_rle[(i.wrapping_sub(k).wrapping_sub(1usize) as (usize))] =
-                                    1i32 as (u8);
-                            }
-                            k = k.wrapping_add(1 as (usize));
+                            good_for_rle[i.wrapping_sub(k).wrapping_sub(1)] = 1;
+                            k = k.wrapping_add(1);
                         }
                     }
                     step = 1usize;
                     if i != length {
-                        symbol = counts[(i as (usize))];
+                        symbol = counts[i];
                     }
                 } else {
-                    step = step.wrapping_add(1 as (usize));
+                    step = step.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     stride = 0usize;
     limit = (256u32)
-        .wrapping_mul(
-            (counts[(0usize)])
-                .wrapping_add(counts[(1usize)])
-                .wrapping_add(counts[(2usize)]),
-        )
+        .wrapping_mul(counts[0].wrapping_add(counts[1]).wrapping_add(counts[2]))
         .wrapping_div(3u32)
         .wrapping_add(420u32) as (usize);
     sum = 0usize;
@@ -360,9 +351,9 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     while i <= length {
         {
             if i == length
-                || good_for_rle[(i as (usize))] != 0
-                || i != 0usize && (good_for_rle[(i.wrapping_sub(1usize) as (usize))] != 0)
-                || ((256u32).wrapping_mul(counts[(i as (usize))]) as (usize))
+                || good_for_rle[i] != 0
+                || i != 0 && good_for_rle[i.wrapping_sub(1)] != 0
+                || ((256u32).wrapping_mul(counts[i]) as usize)
                     .wrapping_sub(limit)
                     .wrapping_add(streak_limit)
                     >= (2usize).wrapping_mul(streak_limit)
@@ -380,11 +371,8 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                     }
                     k = 0usize;
                     while k < stride {
-                        {
-                            counts[(i.wrapping_sub(k).wrapping_sub(1usize) as (usize))] =
-                                count as (u32);
-                        }
-                        k = k.wrapping_add(1 as (usize));
+                        counts[i.wrapping_sub(k).wrapping_sub(1)] = count as u32;
+                        k = k.wrapping_add(1);
                     }
                 }
                 stride = 0usize;
@@ -392,21 +380,21 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 if i < length.wrapping_sub(2usize) {
                     limit = (256u32)
                         .wrapping_mul(
-                            (counts[(i as (usize))])
-                                .wrapping_add(counts[(i.wrapping_add(1usize) as (usize))])
-                                .wrapping_add(counts[(i.wrapping_add(2usize) as (usize))]),
+                            counts[i]
+                                .wrapping_add(counts[i.wrapping_add(1)])
+                                .wrapping_add(counts[i.wrapping_add(2)]),
                         )
                         .wrapping_div(3u32)
                         .wrapping_add(420u32) as (usize);
                 } else if i < length {
-                    limit = (256u32).wrapping_mul(counts[(i as (usize))]) as (usize);
+                    limit = (256u32).wrapping_mul(counts[i]) as usize;
                 } else {
                     limit = 0usize;
                 }
             }
-            stride = stride.wrapping_add(1 as (usize));
+            stride = stride.wrapping_add(1);
             if i != length {
-                sum = sum.wrapping_add(counts[(i as (usize))] as (usize));
+                sum = sum.wrapping_add(counts[i] as usize);
                 if stride >= 4usize {
                     limit = (256usize)
                         .wrapping_mul(sum)
@@ -418,7 +406,7 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -435,23 +423,21 @@ pub fn DecideOverRleUse(
     let mut i: usize;
     i = 0usize;
     while i < length {
-        let value: u8 = depth[(i as (usize))];
+        let value = depth[i];
         let mut reps: usize = 1usize;
         let mut k: usize;
         k = i.wrapping_add(1usize);
-        while k < length && (depth[(k as (usize))] as (i32) == value as (i32)) {
-            {
-                reps = reps.wrapping_add(1 as (usize));
-            }
-            k = k.wrapping_add(1 as (usize));
+        while k < length && ((depth[k] as i32) == (value as i32)) {
+            reps = reps.wrapping_add(1);
+            k = k.wrapping_add(1);
         }
         if reps >= 3usize && (value as (i32) == 0i32) {
             total_reps_zero = total_reps_zero.wrapping_add(reps);
-            count_reps_zero = count_reps_zero.wrapping_add(1 as (usize));
+            count_reps_zero = count_reps_zero.wrapping_add(1);
         }
         if reps >= 4usize && (value as (i32) != 0i32) {
             total_reps_non_zero = total_reps_non_zero.wrapping_add(reps);
-            count_reps_non_zero = count_reps_non_zero.wrapping_add(1 as (usize));
+            count_reps_non_zero = count_reps_non_zero.wrapping_add(1);
         }
         i = i.wrapping_add(reps);
     }
@@ -468,11 +454,11 @@ pub fn DecideOverRleUse(
 }
 
 fn Reverse(v: &mut [u8], mut start: usize, mut end: usize) {
-    end = end.wrapping_sub(1 as (usize));
+    end = end.wrapping_sub(1);
     while start < end {
-        v.swap((start as (usize)), (end as (usize)));
-        start = start.wrapping_add(1 as (usize));
-        end = end.wrapping_sub(1 as (usize));
+        v.swap(start, end);
+        start = start.wrapping_add(1);
+        end = end.wrapping_sub(1);
     }
 }
 
@@ -486,42 +472,42 @@ fn BrotliWriteHuffmanTreeRepetitions(
 ) {
     0i32;
     if previous_value as (i32) != value as (i32) {
-        tree[(*tree_size as (usize))] = value;
-        extra_bits_data[(*tree_size as (usize))] = 0i32 as (u8);
-        *tree_size = (*tree_size).wrapping_add(1 as (usize));
-        repetitions = repetitions.wrapping_sub(1 as (usize));
+        tree[*tree_size] = value;
+        extra_bits_data[*tree_size] = 0;
+        *tree_size = tree_size.wrapping_add(1);
+        repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions == 7usize {
-        tree[(*tree_size as (usize))] = value;
-        extra_bits_data[(*tree_size as (usize))] = 0i32 as (u8);
-        *tree_size = (*tree_size).wrapping_add(1 as (usize));
-        repetitions = repetitions.wrapping_sub(1 as (usize));
+        tree[*tree_size] = value;
+        extra_bits_data[*tree_size] = 0;
+        *tree_size = tree_size.wrapping_add(1);
+        repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions < 3usize {
         let mut i: usize;
         i = 0usize;
         while i < repetitions {
             {
-                tree[(*tree_size as (usize))] = value;
-                extra_bits_data[(*tree_size as (usize))] = 0i32 as (u8);
-                *tree_size = (*tree_size).wrapping_add(1 as (usize));
+                tree[*tree_size] = value;
+                extra_bits_data[*tree_size] = 0;
+                *tree_size = (*tree_size).wrapping_add(1);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     } else {
         let start: usize = *tree_size;
         repetitions = repetitions.wrapping_sub(3usize);
         while 1i32 != 0 {
-            tree[(*tree_size as (usize))] = 16i32 as (u8);
-            extra_bits_data[(*tree_size as (usize))] = (repetitions & 0x3usize) as (u8);
-            *tree_size = (*tree_size).wrapping_add(1 as (usize));
+            tree[*tree_size] = 16;
+            extra_bits_data[*tree_size] = (repetitions & 0x3usize) as u8;
+            *tree_size = (*tree_size).wrapping_add(1);
             repetitions >>= 2i32;
             if repetitions == 0usize {
                 {
                     break;
                 }
             }
-            repetitions = repetitions.wrapping_sub(1 as (usize));
+            repetitions = repetitions.wrapping_sub(1);
         }
         Reverse(tree, start, *tree_size);
         Reverse(extra_bits_data, start, *tree_size);
@@ -535,36 +521,36 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
     extra_bits_data: &mut [u8],
 ) {
     if repetitions == 11usize {
-        tree[(*tree_size as (usize))] = 0i32 as (u8);
-        extra_bits_data[(*tree_size as (usize))] = 0i32 as (u8);
-        *tree_size = (*tree_size).wrapping_add(1 as (usize));
-        repetitions = repetitions.wrapping_sub(1 as (usize));
+        tree[*tree_size] = 0;
+        extra_bits_data[*tree_size] = 0;
+        *tree_size = (*tree_size).wrapping_add(1);
+        repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions < 3usize {
         let mut i: usize;
         i = 0usize;
         while i < repetitions {
             {
-                tree[(*tree_size as (usize))] = 0i32 as (u8);
-                extra_bits_data[(*tree_size as (usize))] = 0i32 as (u8);
-                *tree_size = (*tree_size).wrapping_add(1 as (usize));
+                tree[*tree_size] = 0;
+                extra_bits_data[*tree_size] = 0;
+                *tree_size = (*tree_size).wrapping_add(1);
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     } else {
         let start: usize = *tree_size;
         repetitions = repetitions.wrapping_sub(3usize);
         while 1i32 != 0 {
-            tree[(*tree_size as (usize))] = 17i32 as (u8);
-            extra_bits_data[(*tree_size as (usize))] = (repetitions & 0x7usize) as (u8);
-            *tree_size = (*tree_size).wrapping_add(1 as (usize));
+            tree[*tree_size] = 17;
+            extra_bits_data[*tree_size] = (repetitions & 0x7usize) as u8;
+            *tree_size = (*tree_size).wrapping_add(1);
             repetitions >>= 3i32;
             if repetitions == 0usize {
                 {
                     break;
                 }
             }
-            repetitions = repetitions.wrapping_sub(1 as (usize));
+            repetitions = repetitions.wrapping_sub(1);
         }
         Reverse(tree, start, *tree_size);
         Reverse(extra_bits_data, start, *tree_size);
@@ -586,13 +572,13 @@ pub fn BrotliWriteHuffmanTree(
     i = 0usize;
     'break27: while i < length {
         {
-            if depth[(length.wrapping_sub(i).wrapping_sub(1usize) as (usize))] as (i32) == 0i32 {
-                new_length = new_length.wrapping_sub(1 as (usize));
+            if depth[length.wrapping_sub(i).wrapping_sub(1)] == 0 {
+                new_length = new_length.wrapping_sub(1);
             } else {
                 break 'break27;
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     if length > 50usize {
         DecideOverRleUse(
@@ -604,18 +590,16 @@ pub fn BrotliWriteHuffmanTree(
     }
     i = 0usize;
     while i < new_length {
-        let value: u8 = depth[(i as (usize))];
+        let value: u8 = depth[i];
         let mut reps: usize = 1usize;
         if value as (i32) != 0i32 && (use_rle_for_non_zero != 0)
             || value as (i32) == 0i32 && (use_rle_for_zero != 0)
         {
             let mut k: usize;
             k = i.wrapping_add(1usize);
-            while k < new_length && (depth[(k as (usize))] as (i32) == value as (i32)) {
-                {
-                    reps = reps.wrapping_add(1 as (usize));
-                }
-                k = k.wrapping_add(1 as (usize));
+            while k < new_length && (depth[k] as (i32) == value as (i32)) {
+                reps = reps.wrapping_add(1);
+                k = k.wrapping_add(1);
             }
         }
         if value as (i32) == 0i32 {
@@ -667,34 +651,34 @@ pub fn BrotliConvertBitDepthsToSymbols(depth: &[u8], len: usize, bits: &mut [u16
     while i < len {
         {
             let _rhs = 1;
-            let _lhs = &mut bl_count[depth[(i as (usize))] as (usize)];
+            let _lhs = &mut bl_count[depth[i] as usize];
             *_lhs = (*_lhs as (i32) + _rhs) as (u16);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
-    bl_count[0usize] = 0i32 as (u16);
-    next_code[0usize] = 0i32 as (u16);
+    bl_count[0] = 0;
+    next_code[0] = 0;
     i = 1usize;
     while i < MAX_HUFFMAN_BITS {
         {
             code = (code + bl_count[i.wrapping_sub(1usize)] as (i32)) << 1i32;
             next_code[i] = code as (u16);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < len {
         {
-            if depth[(i as (usize))] != 0 {
-                bits[(i as (usize))] = BrotliReverseBits(depth[(i as (usize))] as (usize), {
+            if depth[i] != 0 {
+                bits[i] = BrotliReverseBits(depth[i] as usize, {
                     let _rhs = 1;
-                    let _lhs = &mut next_code[depth[(i as (usize))] as (usize)];
+                    let _lhs = &mut next_code[depth[i] as usize];
                     let _old = *_lhs;
                     *_lhs = (*_lhs as (i32) + _rhs) as (u16);
                     _old
                 });
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -356,7 +356,7 @@ fn InitBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32
     xself.idx_ = 0i32 as (usize);
     xself.type_ = 0i32 as (usize);
     xself.length_ = if !split.lengths.slice().is_empty() {
-        split.lengths.slice()[0] as u32
+        split.lengths.slice()[0]
     } else {
         0i32 as (u32)
     } as (usize);
@@ -365,11 +365,11 @@ fn BlockSplitIteratorNext<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32
     xself: &mut BlockSplitIterator<Alloc>,
 ) {
     if xself.length_ == 0i32 as (usize) {
-        xself.idx_ = xself.idx_.wrapping_add(1 as (usize));
-        xself.type_ = xself.split_.types.slice()[xself.idx_ as (usize)] as (usize);
-        xself.length_ = xself.split_.lengths.slice()[xself.idx_ as (usize)] as (usize);
+        xself.idx_ = xself.idx_.wrapping_add(1);
+        xself.type_ = xself.split_.types.slice()[xself.idx_] as usize;
+        xself.length_ = xself.split_.lengths.slice()[xself.idx_] as usize;
     }
-    xself.length_ = xself.length_.wrapping_sub(1 as (usize));
+    xself.length_ = xself.length_.wrapping_sub(1);
 }
 pub fn HistogramAddItem<HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> + CostAccessors>(
     xself: &mut HistogramType,
@@ -381,8 +381,8 @@ pub fn HistogramAddItem<HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> 
         let val = (*_lhs).wrapping_add(_rhs as (u32));
         *_lhs = val;
     }
-    let new_count = (*xself).total_count().wrapping_add(1 as (usize));
-    (*xself).set_total_count(new_count);
+    let new_count = xself.total_count().wrapping_add(1);
+    xself.set_total_count(new_count);
 }
 pub fn HistogramAddVector<
     HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> + CostAccessors,
@@ -507,11 +507,11 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
     i = 0usize;
     while i < num_commands {
         {
-            let cmd = &cmds[(i as (usize))];
+            let cmd = &cmds[i];
             let mut j: usize;
             BlockSplitIteratorNext(&mut insert_and_copy_it);
             HistogramAddItem(
-                &mut insert_and_copy_histograms[(insert_and_copy_it.type_ as (usize))],
+                &mut insert_and_copy_histograms[insert_and_copy_it.type_],
                 cmd.cmd_prefix_ as (usize),
             );
             j = cmd.insert_len_ as (usize);
@@ -522,37 +522,37 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
                         (literal_it.type_ << 6i32).wrapping_add(Context(
                             prev_byte,
                             prev_byte2,
-                            context_modes[(literal_it.type_ as (usize))],
+                            context_modes[literal_it.type_],
                         )
                             as (usize))
                     } else {
                         literal_it.type_
                     };
                     HistogramAddItem(
-                        &mut literal_histograms[(context as (usize))],
-                        ringbuffer[((pos & mask) as (usize))] as (usize),
+                        &mut literal_histograms[context],
+                        ringbuffer[pos & mask] as usize,
                     );
                     prev_byte2 = prev_byte;
-                    prev_byte = ringbuffer[((pos & mask) as (usize))];
-                    pos = pos.wrapping_add(1 as (usize));
+                    prev_byte = ringbuffer[pos & mask];
+                    pos = pos.wrapping_add(1);
                 }
-                j = j.wrapping_sub(1 as (usize));
+                j = j.wrapping_sub(1);
             }
             pos = pos.wrapping_add(CommandCopyLen(cmd) as (usize));
             if CommandCopyLen(cmd) != 0 {
-                prev_byte2 = ringbuffer[((pos.wrapping_sub(2usize) & mask) as (usize))];
-                prev_byte = ringbuffer[((pos.wrapping_sub(1usize) & mask) as (usize))];
+                prev_byte2 = ringbuffer[pos.wrapping_sub(2) & mask];
+                prev_byte = ringbuffer[pos.wrapping_sub(1) & mask];
                 if cmd.cmd_prefix_ as (i32) >= 128i32 {
                     BlockSplitIteratorNext(&mut dist_it);
                     let context: usize = (dist_it.type_ << 2i32)
                         .wrapping_add(CommandDistanceContext(cmd) as (usize));
                     HistogramAddItem(
-                        &mut copy_dist_histograms[(context as (usize))],
+                        &mut copy_dist_histograms[context],
                         cmd.dist_prefix_ as (usize) & 0x3ff,
                     );
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -32,7 +32,7 @@ fn DecideMultiByteStatsLevel(pos: usize, len: usize, mask: usize, data: &[u8]) -
     i = 0usize;
     while i < len {
         {
-            let c: usize = data[((pos.wrapping_add(i) & mask) as (usize))] as (usize);
+            let c: usize = data[pos.wrapping_add(i) & mask] as usize;
             {
                 let _rhs = 1;
                 let _lhs = &mut counts[UTF8Position(last_c, c, 2usize)];
@@ -40,12 +40,12 @@ fn DecideMultiByteStatsLevel(pos: usize, len: usize, mask: usize, data: &[u8]) -
             }
             last_c = c;
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
-    if counts[2usize] < 500usize {
+    if counts[2] < 500 {
         max_utf8 = 1usize;
     }
-    if counts[1usize].wrapping_add(counts[2usize]) < 25usize {
+    if counts[1].wrapping_add(counts[2]) < 25 {
         max_utf8 = 0usize;
     }
     max_utf8
@@ -70,7 +70,7 @@ fn EstimateBitCostsForLiteralsUTF8(
         i = 0usize;
         while i < in_window {
             {
-                let c: usize = data[((pos.wrapping_add(i) & mask) as (usize))] as (usize);
+                let c = data[pos.wrapping_add(i) & mask] as usize;
                 {
                     let _rhs = 1;
                     let _lhs = &mut histogram[utf8_pos][c];
@@ -84,7 +84,7 @@ fn EstimateBitCostsForLiteralsUTF8(
                 utf8_pos = UTF8Position(last_c, c, max_utf8);
                 last_c = c;
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
     i = 0usize;
@@ -94,27 +94,26 @@ fn EstimateBitCostsForLiteralsUTF8(
                 let c: usize = (if i < window_half.wrapping_add(1usize) {
                     0i32
                 } else {
-                    data[((pos
+                    data[pos
                         .wrapping_add(i)
                         .wrapping_sub(window_half)
                         .wrapping_sub(1usize)
-                        & mask) as (usize))] as (i32)
+                        & mask] as i32
                 }) as (usize);
                 let last_c: usize = (if i < window_half.wrapping_add(2usize) {
                     0i32
                 } else {
-                    data[((pos
+                    data[pos
                         .wrapping_add(i)
                         .wrapping_sub(window_half)
                         .wrapping_sub(2usize)
-                        & mask) as (usize))] as (i32)
-                }) as (usize);
+                        & mask] as i32
+                }) as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
                 {
                     let _rhs = 1;
-                    let _lhs = &mut histogram[utf8_pos2][data
-                        [((pos.wrapping_add(i).wrapping_sub(window_half) & mask) as (usize))]
-                        as (usize)];
+                    let _lhs = &mut histogram[utf8_pos2]
+                        [data[pos.wrapping_add(i).wrapping_sub(window_half) & mask] as usize];
                     *_lhs = (*_lhs).wrapping_sub(_rhs as (usize));
                 }
                 {
@@ -124,22 +123,21 @@ fn EstimateBitCostsForLiteralsUTF8(
                 }
             }
             if i.wrapping_add(window_half) < len {
-                let c: usize = data[((pos
+                let c = data[pos
                     .wrapping_add(i)
                     .wrapping_add(window_half)
                     .wrapping_sub(1usize)
-                    & mask) as (usize))] as (usize);
-                let last_c: usize = data[((pos
+                    & mask] as usize;
+                let last_c = data[pos
                     .wrapping_add(i)
                     .wrapping_add(window_half)
                     .wrapping_sub(2usize)
-                    & mask) as (usize))] as (usize);
+                    & mask] as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
                 {
                     let _rhs = 1;
-                    let _lhs = &mut histogram[utf8_pos2][data
-                        [((pos.wrapping_add(i).wrapping_add(window_half) & mask) as (usize))]
-                        as (usize)];
+                    let _lhs = &mut histogram[utf8_pos2]
+                        [data[pos.wrapping_add(i).wrapping_add(window_half) & mask] as usize];
                     *_lhs = (*_lhs).wrapping_add(_rhs as (usize));
                 }
                 {
@@ -152,17 +150,16 @@ fn EstimateBitCostsForLiteralsUTF8(
                 let c: usize = (if i < 1usize {
                     0i32
                 } else {
-                    data[((pos.wrapping_add(i).wrapping_sub(1usize) & mask) as (usize))] as (i32)
+                    data[pos.wrapping_add(i).wrapping_sub(1) & mask] as i32
                 }) as (usize);
                 let last_c: usize = (if i < 2usize {
                     0i32
                 } else {
-                    data[((pos.wrapping_add(i).wrapping_sub(2usize) & mask) as (usize))] as (i32)
+                    data[pos.wrapping_add(i).wrapping_sub(2) & mask] as i32
                 }) as (usize);
                 let utf8_pos: usize = UTF8Position(last_c, c, max_utf8);
                 let masked_pos: usize = pos.wrapping_add(i) & mask;
-                let mut histo: usize =
-                    histogram[utf8_pos][data[(masked_pos as (usize))] as (usize)];
+                let mut histo: usize = histogram[utf8_pos][data[masked_pos] as usize];
                 //precision is vital here: lets keep double precision
                 let mut lit_cost: f64;
                 if histo == 0usize {
@@ -178,10 +175,10 @@ fn EstimateBitCostsForLiteralsUTF8(
                 if i < 2000usize {
                     lit_cost += (0.7 - (2000usize).wrapping_sub(i) as (f64) / 2000.0 * 0.35);
                 }
-                cost[(i as (usize))] = lit_cost as (super::util::floatX);
+                cost[i] = lit_cost as (super::util::floatX);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 
@@ -204,11 +201,10 @@ pub fn BrotliEstimateBitCostsForLiterals(
         while i < in_window {
             {
                 let _rhs = 1;
-                let _lhs =
-                    &mut histogram[data[((pos.wrapping_add(i) & mask) as (usize))] as (usize)];
+                let _lhs = &mut histogram[data[pos.wrapping_add(i) & mask] as usize];
                 *_lhs = (*_lhs).wrapping_add(_rhs as (usize));
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         i = 0usize;
         while i < len {
@@ -217,24 +213,22 @@ pub fn BrotliEstimateBitCostsForLiterals(
                 if i >= window_half {
                     {
                         let _rhs = 1;
-                        let _lhs = &mut histogram[data
-                            [((pos.wrapping_add(i).wrapping_sub(window_half) & mask) as (usize))]
-                            as (usize)];
+                        let _lhs = &mut histogram
+                            [data[pos.wrapping_add(i).wrapping_sub(window_half) & mask] as usize];
                         *_lhs = (*_lhs).wrapping_sub(_rhs as (usize));
                     }
-                    in_window = in_window.wrapping_sub(1 as (usize));
+                    in_window = in_window.wrapping_sub(1);
                 }
                 if i.wrapping_add(window_half) < len {
                     {
                         let _rhs = 1;
-                        let _lhs = &mut histogram[data
-                            [((pos.wrapping_add(i).wrapping_add(window_half) & mask) as (usize))]
-                            as (usize)];
+                        let _lhs = &mut histogram
+                            [data[pos.wrapping_add(i).wrapping_add(window_half) & mask] as usize];
                         *_lhs = (*_lhs).wrapping_add(_rhs as (usize));
                     }
-                    in_window = in_window.wrapping_add(1 as (usize));
+                    in_window = in_window.wrapping_add(1);
                 }
-                histo = histogram[data[((pos.wrapping_add(i) & mask) as (usize))] as (usize)];
+                histo = histogram[data[pos.wrapping_add(i) & mask] as usize];
                 if histo == 0usize {
                     histo = 1usize;
                 }
@@ -247,10 +241,10 @@ pub fn BrotliEstimateBitCostsForLiterals(
                         lit_cost *= 0.5;
                         lit_cost += 0.5;
                     }
-                    cost[(i as (usize))] = lit_cost as (super::util::floatX);
+                    cost[i] = lit_cost as (super::util::floatX);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
     }
 }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -167,7 +167,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
                 let ndirect = ndirect_msb << npostfix;
 
                 let mut dist_cost: f64 = 0.0;
-                BrotliInitDistanceParams(&mut new_params, npostfix as u32, ndirect as u32);
+                BrotliInitDistanceParams(&mut new_params, npostfix as u32, ndirect);
                 if npostfix as u32 == orig_params.dist.distance_postfix_bits
                     && ndirect == orig_params.dist.num_direct_distance_codes
                 {
@@ -281,14 +281,13 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         i = mb.literal_split.num_types;
         while i != 0usize {
             let mut j: usize = 0usize;
-            i = i.wrapping_sub(1 as (usize));
+            i = i.wrapping_sub(1);
             while j < (1i32 << 6i32) as (usize) {
                 {
-                    let val = mb.literal_context_map.slice()[(i as (usize))];
-                    mb.literal_context_map.slice_mut()[((i << 6i32).wrapping_add(j) as (usize))] =
-                        val;
+                    let val = mb.literal_context_map.slice()[i];
+                    mb.literal_context_map.slice_mut()[(i << 6i32).wrapping_add(j)] = val;
                 }
-                j = j.wrapping_add(1 as (usize));
+                j = j.wrapping_add(1);
             }
         }
     }
@@ -406,9 +405,7 @@ fn InitBlockSplitter<
     histograms: &mut <Alloc as Allocator<HistogramType>>::AllocatedMemory,
     histograms_size: &mut usize,
 ) -> BlockSplitter {
-    let max_num_blocks: usize = num_symbols
-        .wrapping_div(min_block_size)
-        .wrapping_add(1usize);
+    let max_num_blocks: usize = num_symbols.wrapping_div(min_block_size).wrapping_add(1);
     let max_num_types: usize = brotli_min_size_t(max_num_blocks, (256i32 + 1i32) as (usize));
     let mut xself = BlockSplitter {
         last_entropy_: [0.0 as super::util::floatX; 2],
@@ -433,7 +430,7 @@ fn InitBlockSplitter<
             };
             let mut new_array: <Alloc as Allocator<u8>>::AllocatedMemory;
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             if (!split.types.slice().is_empty()) {
@@ -454,7 +451,7 @@ fn InitBlockSplitter<
                 split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..split.lengths.slice().len()]
@@ -490,9 +487,7 @@ fn InitContextBlockSplitter<
     histograms: &mut <Alloc as Allocator<HistogramLiteral>>::AllocatedMemory,
     histograms_size: &mut usize,
 ) -> ContextBlockSplitter {
-    let max_num_blocks: usize = num_symbols
-        .wrapping_div(min_block_size)
-        .wrapping_add(1usize);
+    let max_num_blocks: usize = num_symbols.wrapping_div(min_block_size).wrapping_add(1);
 
     assert!(num_contexts <= BROTLI_MAX_STATIC_CONTEXTS);
     let mut xself = ContextBlockSplitter {
@@ -511,7 +506,7 @@ fn InitContextBlockSplitter<
         last_entropy_: [0.0 as super::util::floatX; 2 * BROTLI_MAX_STATIC_CONTEXTS],
     };
     let max_num_types: usize =
-        brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1usize));
+        brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1));
     {
         if split.types.slice().len() < max_num_blocks {
             let mut _new_size: usize = if split.types.slice().is_empty() {
@@ -520,7 +515,7 @@ fn InitContextBlockSplitter<
                 split.types.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             if (!split.types.slice().is_empty()) {
@@ -541,7 +536,7 @@ fn InitContextBlockSplitter<
                 split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             if (!split.lengths.slice().is_empty()) {
@@ -558,7 +553,7 @@ fn InitContextBlockSplitter<
     *histograms_size = max_num_types.wrapping_mul(num_contexts);
     *histograms = <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, *histograms_size);
     //(*xself).histograms_ = *histograms;
-    ClearHistograms(&mut histograms.slice_mut()[0usize..], num_contexts);
+    ClearHistograms(&mut histograms.slice_mut()[0..], num_contexts);
     xself.last_histogram_ix_[0] = 0;
     xself.last_histogram_ix_[1] = 0;
     xself
@@ -576,21 +571,20 @@ fn BlockSplitterFinishBlock<
 ) {
     xself.block_size_ = brotli_max_size_t(xself.block_size_, xself.min_block_size_);
     if xself.num_blocks_ == 0usize {
-        split.lengths.slice_mut()[(0usize)] = xself.block_size_ as (u32);
-        split.types.slice_mut()[(0usize)] = 0i32 as (u8);
-        xself.last_entropy_[(0usize)] =
-            BitsEntropy((histograms[(0usize)]).slice(), xself.alphabet_size_);
-        xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
-        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
-        split.num_types = split.num_types.wrapping_add(1 as (usize));
-        xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1 as (usize));
+        split.lengths.slice_mut()[0] = xself.block_size_ as u32;
+        split.types.slice_mut()[0] = 0;
+        xself.last_entropy_[0] = BitsEntropy(histograms[0].slice(), xself.alphabet_size_);
+        xself.last_entropy_[1] = xself.last_entropy_[0];
+        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
+        split.num_types = split.num_types.wrapping_add(1);
+        xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1);
         if xself.curr_histogram_ix_ < *histograms_size {
-            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
+            HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
         }
         xself.block_size_ = 0usize;
     } else if xself.block_size_ > 0usize {
         let entropy: super::util::floatX = BitsEntropy(
-            (histograms[(xself.curr_histogram_ix_ as (usize))]).slice(),
+            histograms[xself.curr_histogram_ix_].slice(),
             xself.alphabet_size_,
         );
         let mut combined_histo: [HistogramType; 2] = [
@@ -605,69 +599,63 @@ fn BlockSplitterFinishBlock<
         for j in 0..2 {
             {
                 let last_histogram_ix: usize = xself.last_histogram_ix_[j];
-                HistogramAddHistogram(
-                    &mut combined_histo[j],
-                    &histograms[(last_histogram_ix as (usize))],
-                );
+                HistogramAddHistogram(&mut combined_histo[j], &histograms[last_histogram_ix]);
                 combined_entropy[j] = BitsEntropy(
                     &mut combined_histo[j].slice_mut()[0usize..],
                     xself.alphabet_size_,
                 );
-                diff[j] = combined_entropy[j] - entropy - xself.last_entropy_[(j as (usize))];
+                diff[j] = combined_entropy[j] - entropy - xself.last_entropy_[j];
             }
         }
-        if split.num_types < 256usize
-            && (diff[0usize] > xself.split_threshold_)
-            && (diff[1usize] > xself.split_threshold_)
+        if split.num_types < 256
+            && diff[0] > xself.split_threshold_
+            && diff[1] > xself.split_threshold_
         {
-            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
-            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = split.num_types as (u8);
-            xself.last_histogram_ix_[1usize] = xself.last_histogram_ix_[0usize];
-            xself.last_histogram_ix_[0usize] = split.num_types as (u8) as (usize);
-            xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
-            xself.last_entropy_[(0usize)] = entropy;
-            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
-            split.num_types = split.num_types.wrapping_add(1 as (usize));
-            xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1 as (usize));
+            split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
+            split.types.slice_mut()[xself.num_blocks_] = split.num_types as u8;
+            xself.last_histogram_ix_[1] = xself.last_histogram_ix_[0];
+            xself.last_histogram_ix_[0] = split.num_types as u8 as usize;
+            xself.last_entropy_[1] = xself.last_entropy_[0];
+            xself.last_entropy_[0] = entropy;
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
+            split.num_types = split.num_types.wrapping_add(1);
+            xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1);
             if xself.curr_histogram_ix_ < *histograms_size {
-                HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
+                HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
             }
             xself.block_size_ = 0usize;
             xself.merge_last_count_ = 0usize;
             xself.target_block_size_ = xself.min_block_size_;
-        } else if diff[1usize] < diff[0usize] - 20.0 as super::util::floatX {
-            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
-            split.types.slice_mut()[(xself.num_blocks_ as (usize))] =
-                split.types.slice()[(xself.num_blocks_.wrapping_sub(2usize) as (usize))]; //FIXME: investigate copy?
+        } else if diff[1] < diff[0] - 20.0 as super::util::floatX {
+            split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
+            split.types.slice_mut()[xself.num_blocks_] =
+                split.types.slice()[(xself.num_blocks_.wrapping_sub(2))]; //FIXME: investigate copy?
             {
-                xself.last_histogram_ix_.swap(0usize, 1usize);
+                xself.last_histogram_ix_.swap(0, 1);
             }
-            histograms[(xself.last_histogram_ix_[0usize] as (usize))] =
-                combined_histo[1usize].clone();
-            xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
-            xself.last_entropy_[(0usize)] = combined_entropy[1usize];
-            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            histograms[xself.last_histogram_ix_[0]] = combined_histo[1].clone();
+            xself.last_entropy_[1] = xself.last_entropy_[0];
+            xself.last_entropy_[0] = combined_entropy[1];
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
             xself.block_size_ = 0usize;
-            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
+            HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
             xself.merge_last_count_ = 0usize;
             xself.target_block_size_ = xself.min_block_size_;
         } else {
             {
-                let _rhs = xself.block_size_ as (u32);
-                let _lhs = &mut split.lengths.slice_mut()
-                    [(xself.num_blocks_.wrapping_sub(1usize) as (usize))];
-                *_lhs = (*_lhs).wrapping_add(_rhs);
+                let _rhs = xself.block_size_ as u32;
+                let _lhs = &mut split.lengths.slice_mut()[(xself.num_blocks_.wrapping_sub(1))];
+                *_lhs = _lhs.wrapping_add(_rhs);
             }
-            histograms[(xself.last_histogram_ix_[0usize] as (usize))] =
-                combined_histo[0usize].clone();
-            xself.last_entropy_[(0usize)] = combined_entropy[0usize];
+            histograms[xself.last_histogram_ix_[0]] = combined_histo[0].clone();
+            xself.last_entropy_[0] = combined_entropy[0];
             if split.num_types == 1usize {
-                xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
+                xself.last_entropy_[1] = xself.last_entropy_[0];
             }
             xself.block_size_ = 0usize;
-            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
+            HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
             if {
-                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1 as (usize));
+                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1);
                 xself.merge_last_count_
             } > 1usize
             {
@@ -700,24 +688,22 @@ fn ContextBlockSplitterFinishBlock<
     }
     if xself.num_blocks_ == 0usize {
         let mut i: usize;
-        split.lengths.slice_mut()[(0usize)] = xself.block_size_ as (u32);
-        split.types.slice_mut()[(0usize)] = 0i32 as (u8);
+        split.lengths.slice_mut()[0] = xself.block_size_ as u32;
+        split.types.slice_mut()[0] = 0;
         i = 0usize;
         while i < num_contexts {
             {
-                xself.last_entropy_[(i as (usize))] =
-                    BitsEntropy((histograms[(i as (usize))]).slice(), xself.alphabet_size_);
-                xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                    xself.last_entropy_[(i as (usize))];
+                xself.last_entropy_[i] = BitsEntropy(histograms[i].slice(), xself.alphabet_size_);
+                xself.last_entropy_[(num_contexts.wrapping_add(i))] = xself.last_entropy_[i];
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
-        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
-        split.num_types = split.num_types.wrapping_add(1 as (usize));
+        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
+        split.num_types = split.num_types.wrapping_add(1);
         xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(num_contexts);
         if xself.curr_histogram_ix_ < *histograms_size {
             ClearHistograms(
-                &mut histograms[(xself.curr_histogram_ix_ as (usize))..],
+                &mut histograms[xself.curr_histogram_ix_..],
                 xself.num_contexts_,
             );
         }
@@ -733,119 +719,104 @@ fn ContextBlockSplitterFinishBlock<
             {
                 let curr_histo_ix: usize = xself.curr_histogram_ix_.wrapping_add(i);
                 let mut j: usize;
-                entropy[i] = BitsEntropy(
-                    (histograms[(curr_histo_ix as (usize))]).slice(),
-                    xself.alphabet_size_,
-                );
+                entropy[i] = BitsEntropy((histograms[curr_histo_ix]).slice(), xself.alphabet_size_);
                 j = 0usize;
                 while j < 2usize {
                     {
                         let jx: usize = j.wrapping_mul(num_contexts).wrapping_add(i);
                         let last_histogram_ix: usize = xself.last_histogram_ix_[j].wrapping_add(i);
-                        combined_histo.slice_mut()[jx] =
-                            histograms[(curr_histo_ix as (usize))].clone();
+                        combined_histo.slice_mut()[jx] = histograms[curr_histo_ix].clone();
                         HistogramAddHistogram(
                             &mut combined_histo.slice_mut()[jx],
-                            &mut histograms[(last_histogram_ix as (usize))],
+                            &mut histograms[last_histogram_ix],
                         );
                         combined_entropy[jx] =
                             BitsEntropy(combined_histo.slice()[jx].slice(), xself.alphabet_size_);
                         {
-                            let _rhs = combined_entropy[jx]
-                                - entropy[i]
-                                - xself.last_entropy_[(jx as (usize))];
+                            let _rhs = combined_entropy[jx] - entropy[i] - xself.last_entropy_[jx];
                             let _lhs = &mut diff[j];
                             *_lhs += _rhs;
                         }
                     }
-                    j = j.wrapping_add(1 as (usize));
+                    j = j.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as (usize));
+            i = i.wrapping_add(1);
         }
         if split.num_types < xself.max_block_types_
-            && (diff[0usize] > xself.split_threshold_)
-            && (diff[1usize] > xself.split_threshold_)
+            && diff[0] > xself.split_threshold_
+            && diff[1] > xself.split_threshold_
         {
-            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
-            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = split.num_types as (u8);
-            xself.last_histogram_ix_[1usize] = xself.last_histogram_ix_[0usize];
-            xself.last_histogram_ix_[0usize] = split.num_types.wrapping_mul(num_contexts);
+            split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
+            split.types.slice_mut()[xself.num_blocks_] = split.num_types as u8;
+            xself.last_histogram_ix_[1] = xself.last_histogram_ix_[0];
+            xself.last_histogram_ix_[0] = split.num_types.wrapping_mul(num_contexts);
             i = 0usize;
             while i < num_contexts {
                 {
-                    xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                        xself.last_entropy_[(i as (usize))];
-                    xself.last_entropy_[(i as (usize))] = entropy[i];
+                    xself.last_entropy_[num_contexts.wrapping_add(i)] = xself.last_entropy_[i];
+                    xself.last_entropy_[i] = entropy[i];
                 }
-                i = i.wrapping_add(1 as (usize));
+                i = i.wrapping_add(1);
             }
-            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
-            split.num_types = split.num_types.wrapping_add(1 as (usize));
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
+            split.num_types = split.num_types.wrapping_add(1);
             xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(num_contexts);
             if xself.curr_histogram_ix_ < *histograms_size {
                 ClearHistograms(
-                    &mut histograms[(xself.curr_histogram_ix_ as (usize))..],
+                    &mut histograms[xself.curr_histogram_ix_..],
                     xself.num_contexts_,
                 );
             }
             xself.block_size_ = 0usize;
             xself.merge_last_count_ = 0usize;
             xself.target_block_size_ = xself.min_block_size_;
-        } else if diff[1usize] < diff[0usize] - 20.0 as super::util::floatX {
-            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
-            let nbm2 = split.types.slice()[(xself.num_blocks_.wrapping_sub(2usize) as (usize))];
-            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = nbm2;
+        } else if diff[1] < diff[0] - 20.0 as super::util::floatX {
+            split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
+            let nbm2 = split.types.slice()[xself.num_blocks_.wrapping_sub(2)];
+            split.types.slice_mut()[xself.num_blocks_] = nbm2;
 
             {
-                xself.last_histogram_ix_.swap(0usize, 1usize);
+                xself.last_histogram_ix_.swap(0, 1);
             }
             i = 0usize;
             while i < num_contexts {
                 {
-                    histograms[(xself.last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
+                    histograms[xself.last_histogram_ix_[0].wrapping_add(i)] =
                         combined_histo.slice()[num_contexts.wrapping_add(i)].clone();
-                    xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                        xself.last_entropy_[(i as (usize))];
-                    xself.last_entropy_[(i as (usize))] =
-                        combined_entropy[num_contexts.wrapping_add(i)];
-                    HistogramClear(
-                        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(i) as (usize))],
-                    );
+                    xself.last_entropy_[num_contexts.wrapping_add(i)] = xself.last_entropy_[i];
+                    xself.last_entropy_[i] = combined_entropy[num_contexts.wrapping_add(i)];
+                    HistogramClear(&mut histograms[xself.curr_histogram_ix_.wrapping_add(i)]);
                 }
-                i = i.wrapping_add(1 as (usize));
+                i = i.wrapping_add(1);
             }
-            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
             xself.block_size_ = 0usize;
             xself.merge_last_count_ = 0usize;
             xself.target_block_size_ = xself.min_block_size_;
         } else {
             {
                 let _rhs = xself.block_size_ as (u32);
-                let _lhs = &mut split.lengths.slice_mut()
-                    [(xself.num_blocks_.wrapping_sub(1usize) as (usize))];
+                let _lhs = &mut split.lengths.slice_mut()[xself.num_blocks_.wrapping_sub(1)];
                 let old_split_length = *_lhs;
                 *_lhs = old_split_length.wrapping_add(_rhs);
             }
             i = 0usize;
             while i < num_contexts {
                 {
-                    histograms[(xself.last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
+                    histograms[xself.last_histogram_ix_[0].wrapping_add(i)] =
                         combined_histo.slice()[i].clone();
-                    xself.last_entropy_[(i as (usize))] = combined_entropy[i];
+                    xself.last_entropy_[i] = combined_entropy[i];
                     if split.num_types == 1usize {
-                        xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                            xself.last_entropy_[(i as (usize))];
+                        xself.last_entropy_[num_contexts.wrapping_add(i)] = xself.last_entropy_[i];
                     }
-                    HistogramClear(
-                        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(i) as (usize))],
-                    );
+                    HistogramClear(&mut histograms[(xself.curr_histogram_ix_.wrapping_add(i))]);
                 }
-                i = i.wrapping_add(1 as (usize));
+                i = i.wrapping_add(1);
             }
             xself.block_size_ = 0usize;
             if {
-                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1 as (usize));
+                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1);
                 xself.merge_last_count_
             } > 1usize
             {
@@ -871,11 +842,8 @@ fn BlockSplitterAddSymbol<
     histograms_size: &mut usize,
     symbol: usize,
 ) {
-    HistogramAddItem(
-        &mut histograms[(xself.curr_histogram_ix_ as (usize))],
-        symbol,
-    );
-    xself.block_size_ = xself.block_size_.wrapping_add(1 as (usize));
+    HistogramAddItem(&mut histograms[xself.curr_histogram_ix_], symbol);
+    xself.block_size_ = xself.block_size_.wrapping_add(1);
     if xself.block_size_ == xself.target_block_size_ {
         BlockSplitterFinishBlock(xself, split, histograms, histograms_size, 0i32);
     }
@@ -893,10 +861,10 @@ fn ContextBlockSplitterAddSymbol<
     context: usize,
 ) {
     HistogramAddItem(
-        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(context) as (usize))],
+        &mut histograms[xself.curr_histogram_ix_.wrapping_add(context)],
         symbol,
     );
-    xself.block_size_ = xself.block_size_.wrapping_add(1 as (usize));
+    xself.block_size_ = xself.block_size_.wrapping_add(1);
     if xself.block_size_ == xself.target_block_size_ {
         ContextBlockSplitterFinishBlock(xself, m, split, histograms, histograms_size, 0i32);
     }
@@ -930,13 +898,13 @@ fn MapStaticContexts<
             j = 0usize;
             while j < (1u32 << 6i32) as (usize) {
                 {
-                    mb.literal_context_map.slice_mut()[((i << 6i32).wrapping_add(j) as (usize))] =
-                        offset.wrapping_add(static_context_map[(j as (usize))]);
+                    mb.literal_context_map.slice_mut()[(i << 6).wrapping_add(j)] =
+                        offset.wrapping_add(static_context_map[j]);
                 }
-                j = j.wrapping_add(1 as (usize));
+                j = j.wrapping_add(1);
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }
 pub fn BrotliBuildMetaBlockGreedyInternal<
@@ -967,10 +935,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
     i = 0usize;
     while i < n_commands {
         {
-            num_literals =
-                num_literals.wrapping_add((commands[(i as (usize))]).insert_len_ as (usize));
+            num_literals = num_literals.wrapping_add(commands[i].insert_len_ as usize);
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     lit_blocks = if num_contexts == 1usize {
         LitBlocks::plain(InitBlockSplitter::<HistogramLiteral, Alloc>(
@@ -1020,7 +987,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))];
+            let cmd = commands[i];
             let mut j: usize;
             BlockSplitterAddSymbol(
                 &mut cmd_blocks,
@@ -1032,7 +999,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             j = cmd.insert_len_ as (usize);
             while j != 0usize {
                 {
-                    let literal: u8 = ringbuffer[((pos & mask) as (usize))];
+                    let literal: u8 = ringbuffer[pos & mask];
                     match (&mut lit_blocks) {
                         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterAddSymbol(
                             lit_blocks_plain,
@@ -1051,20 +1018,20 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                                 mb.literal_histograms.slice_mut(),
                                 &mut mb.literal_histograms_size,
                                 literal as (usize),
-                                static_context_map[(context as (usize))] as (usize),
+                                static_context_map[context] as usize,
                             );
                         }
                     }
                     prev_byte2 = prev_byte;
                     prev_byte = literal;
-                    pos = pos.wrapping_add(1 as (usize));
+                    pos = pos.wrapping_add(1);
                 }
-                j = j.wrapping_sub(1 as (usize));
+                j = j.wrapping_sub(1);
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as (usize));
             if CommandCopyLen(&cmd) != 0 {
-                prev_byte2 = ringbuffer[((pos.wrapping_sub(2usize) & mask) as (usize))];
-                prev_byte = ringbuffer[((pos.wrapping_sub(1usize) & mask) as (usize))];
+                prev_byte2 = ringbuffer[pos.wrapping_sub(2) & mask];
+                prev_byte = ringbuffer[pos.wrapping_sub(1) & mask];
                 if cmd.cmd_prefix_ as (i32) >= 128i32 {
                     BlockSplitterAddSymbol(
                         &mut dist_blocks,
@@ -1076,7 +1043,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                 }
             }
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     match (&mut lit_blocks) {
         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterFinishBlock(
@@ -1184,32 +1151,32 @@ pub fn BrotliOptimizeHistograms<
         {
             BrotliOptimizeHuffmanCountsForRle(
                 256usize,
-                mb.literal_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.literal_histograms.slice_mut()[i].slice_mut(),
                 &mut good_for_rle[..],
             );
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < mb.command_histograms_size {
         {
             BrotliOptimizeHuffmanCountsForRle(
                 704usize,
-                mb.command_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.command_histograms.slice_mut()[i].slice_mut(),
                 &mut good_for_rle[..],
             );
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < mb.distance_histograms_size {
         {
             BrotliOptimizeHuffmanCountsForRle(
                 num_distance_codes,
-                mb.distance_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.distance_histograms.slice_mut()[i].slice_mut(),
                 &mut good_for_rle[..],
             );
         }
-        i = i.wrapping_add(1 as (usize));
+        i = i.wrapping_add(1);
     }
 }

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -106,12 +106,9 @@ fn stride_lookup_lin(
     high_nibble: Option<u8>,
 ) -> usize {
     if let Some(nibble) = high_nibble {
-        1 + 2
-            * (actual_context as usize
-                | ((stride_byte as usize & 0xf) << 8)
-                | ((nibble as usize) << 12))
+        1 + 2 * (actual_context | ((stride_byte as usize & 0xf) << 8) | ((nibble as usize) << 12))
     } else {
-        2 * (actual_context as usize | ((stride_byte as usize) << 8))
+        2 * (actual_context | ((stride_byte as usize) << 8))
     }
 }
 pub struct Stride1Prior {}
@@ -253,7 +250,7 @@ impl Prior for CMPrior {
         if let Some(nibble) = high_nibble {
             (nibble as usize + 1) + 17 * actual_context
         } else {
-            17 * actual_context as usize
+            17 * actual_context
         }
     }
     #[inline(always)]
@@ -296,7 +293,7 @@ impl Prior for SlowCMPrior {
         if let Some(nibble) = high_nibble {
             (nibble as usize + 1) + 17 * actual_context
         } else {
-            17 * actual_context as usize
+            17 * actual_context
         }
     }
     #[inline]
@@ -317,11 +314,9 @@ impl Prior for AdvPrior {
     ) -> usize {
         if let Some(nibble) = high_nibble {
             65536
-                + ((actual_context as usize)
-                    | ((stride_byte as usize) << 8)
-                    | ((nibble as usize & 0xf) << 16))
+                + (actual_context | ((stride_byte as usize) << 8) | ((nibble as usize & 0xf) << 16))
         } else {
-            (actual_context as usize) | ((stride_byte as usize & 0xf0) << 8)
+            actual_context | ((stride_byte as usize & 0xf0) << 8)
         }
     }
     #[inline(always)]

--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -152,12 +152,12 @@ impl<ErrType, R: CustomRead<ErrType>, BufferType: SliceWrapperMut<u8>, Alloc: Br
         BrotliEncoderSetParameter(
             &mut ret.state.0,
             BrotliEncoderParameter::BROTLI_PARAM_QUALITY,
-            q as (u32),
+            q,
         );
         BrotliEncoderSetParameter(
             &mut ret.state.0,
             BrotliEncoderParameter::BROTLI_PARAM_LGWIN,
-            lgwin as (u32),
+            lgwin,
         );
 
         ret

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -365,14 +365,14 @@ pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_leng
                 0i32
             }
         } else if w.transform() as (i32) == 10i32 {
-            if !!(dict[(0usize)] as (i32) >= b'a' as (i32)
-                && (dict[(0usize)] as (i32) <= b'z' as (i32))
-                && (dict[(0usize)] as (i32) ^ 32i32 == data[(0usize)] as (i32))
-                && (FindMatchLengthWithLimit(
+            if (dict[0] as i32) >= (b'a' as i32)
+                && (dict[0] as i32) <= (b'z' as i32)
+                && (dict[0] as i32) ^ 32i32 == (data[0] as i32)
+                && FindMatchLengthWithLimit(
                     dict.split_at(1).1,
                     data.split_at(1).1,
                     (w.len() as (u32)).wrapping_sub(1u32) as (usize),
-                ) == (w.len() as (u32)).wrapping_sub(1u32) as (usize)))
+                ) == (w.len() as (u32)).wrapping_sub(1u32) as (usize)
             {
                 1i32
             } else {
@@ -383,17 +383,15 @@ pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_leng
             i = 0usize;
             while i < w.len() as (usize) {
                 {
-                    if dict[(i as (usize))] as (i32) >= b'a' as (i32)
-                        && (dict[(i as (usize))] as (i32) <= b'z' as (i32))
-                    {
-                        if dict[(i as (usize))] as (i32) ^ 32i32 != data[(i as (usize))] as (i32) {
+                    if dict[i] as (i32) >= b'a' as (i32) && (dict[i] as (i32) <= b'z' as (i32)) {
+                        if dict[i] as (i32) ^ 32i32 != data[i] as (i32) {
                             return 0i32;
                         }
-                    } else if dict[(i as (usize))] as (i32) != data[(i as (usize))] as (i32) {
+                    } else if dict[i] as (i32) != data[i] as (i32) {
                         return 0i32;
                     }
                 }
-                i = i.wrapping_add(1 as (usize));
+                i = i.wrapping_add(1);
             }
             1i32
         }
@@ -412,7 +410,7 @@ fn brotli_min_uint32_t(a: u32, b: u32) -> u32 {
 #[allow(unused)]
 fn AddMatch(distance: usize, len: usize, len_code: usize, mut matches: &mut [u32]) {
     let match_: u32 = (distance << 5i32).wrapping_add(len_code) as (u32);
-    matches[len as (usize)] = brotli_min_uint32_t(matches[len as (usize)], match_);
+    matches[len] = brotli_min_uint32_t(matches[len], match_);
 }
 
 #[allow(unused)]
@@ -465,7 +463,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         while end == 0 {
             let mut w: DictWord = kStaticDictionaryWords[{
                 let _old = offset;
-                offset = offset.wrapping_add(1 as (usize));
+                offset = offset.wrapping_add(1);
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
@@ -528,7 +526,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         );
                         has_found_match = 1i32;
                     }
-                    len = len.wrapping_add(1 as (usize));
+                    len = len.wrapping_add(1);
                 }
                 if matchlen < l || l.wrapping_add(6usize) >= max_length {
                     {
@@ -536,11 +534,11 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     }
                 }
                 let s: &[u8] = data.split_at(l as (usize)).1;
-                if s[(0usize)] as (i32) == b' ' as (i32) {
+                if s[0] as (i32) == b' ' as (i32) {
                     //eprint!("Edding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(id.wrapping_add(n), l.wrapping_add(1usize), l, matches);
-                    if s[(1usize)] as (i32) == b'a' as (i32) {
-                        if s[(2usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b'a' as (i32) {
+                        if s[2] as (i32) == b' ' as (i32) {
                             //eprint!("Fdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((28usize).wrapping_mul(n)),
@@ -548,8 +546,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 l,
                                 matches,
                             );
-                        } else if s[(2usize)] as (i32) == b's' as (i32) {
-                            if s[(3usize)] as (i32) == b' ' as (i32) {
+                        } else if s[2] as (i32) == b's' as (i32) {
+                            if s[3] as (i32) == b' ' as (i32) {
                                 //eprint!("Gdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((46usize).wrapping_mul(n)),
@@ -558,8 +556,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b't' as (i32) {
-                            if s[(3usize)] as (i32) == b' ' as (i32) {
+                        } else if s[2] as (i32) == b't' as (i32) {
+                            if s[3] as (i32) == b' ' as (i32) {
                                 //eprint!("Hdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((60usize).wrapping_mul(n)),
@@ -568,9 +566,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b'n' as (i32)
-                            && s[(3usize)] as (i32) == b'd' as (i32)
-                            && (s[(4usize)] as (i32) == b' ' as (i32))
+                        } else if s[2] as (i32) == b'n' as (i32)
+                            && s[3] as (i32) == b'd' as (i32)
+                            && (s[4] as (i32) == b' ' as (i32))
                         {
                             //eprint!("Idding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
@@ -580,10 +578,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'b' as (i32) {
-                        if s[(2usize)] as (i32) == b'y' as (i32)
-                            && (s[(3usize)] as (i32) == b' ' as (i32))
-                        {
+                    } else if s[1] as (i32) == b'b' as (i32) {
+                        if s[2] as (i32) == b'y' as (i32) && (s[3] as (i32) == b' ' as (i32)) {
                             //eprint!("Jdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((38usize).wrapping_mul(n)),
@@ -592,9 +588,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'i' as (i32) {
-                        if s[(2usize)] as (i32) == b'n' as (i32) {
-                            if s[(3usize)] as (i32) == b' ' as (i32) {
+                    } else if s[1] as (i32) == b'i' as (i32) {
+                        if s[2] as (i32) == b'n' as (i32) {
+                            if s[3] as (i32) == b' ' as (i32) {
                                 //eprint!("Kdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((16usize).wrapping_mul(n)),
@@ -603,9 +599,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b's' as (i32)
-                            && s[(3usize)] as (i32) == b' ' as (i32)
-                        {
+                        } else if s[2] as (i32) == b's' as (i32) && s[3] as (i32) == b' ' as (i32) {
                             //eprint!("Ldding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((47usize).wrapping_mul(n)),
@@ -614,11 +608,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'f' as (i32) {
-                        if s[(2usize)] as (i32) == b'o' as (i32) {
-                            if s[(3usize)] as (i32) == b'r' as (i32)
-                                && (s[(4usize)] as (i32) == b' ' as (i32))
-                            {
+                    } else if s[1] as (i32) == b'f' as (i32) {
+                        if s[2] as (i32) == b'o' as (i32) {
+                            if s[3] as (i32) == b'r' as (i32) && (s[4] as (i32) == b' ' as (i32)) {
                                 //eprint!("Mdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((25usize).wrapping_mul(n)),
@@ -627,10 +619,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b'r' as (i32)
-                            && s[(3usize)] as (i32) == b'o' as (i32)
-                            && (s[(4usize)] as (i32) == b'm' as (i32))
-                            && (s[(5usize)] as (i32) == b' ' as (i32))
+                        } else if s[2] as (i32) == b'r' as (i32)
+                            && s[3] as (i32) == b'o' as (i32)
+                            && (s[4] as (i32) == b'm' as (i32))
+                            && (s[5] as (i32) == b' ' as (i32))
                         {
                             //eprint!("Ndding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
@@ -640,9 +632,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'o' as (i32) {
-                        if s[(2usize)] as (i32) == b'f' as (i32) {
-                            if s[(3usize)] as (i32) == b' ' as (i32) {
+                    } else if s[1] as (i32) == b'o' as (i32) {
+                        if s[2] as (i32) == b'f' as (i32) {
+                            if s[3] as (i32) == b' ' as (i32) {
                                 //eprint!("Odding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((8usize).wrapping_mul(n)),
@@ -651,9 +643,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b'n' as (i32)
-                            && s[(3usize)] as (i32) == b' ' as (i32)
-                        {
+                        } else if s[2] as (i32) == b'n' as (i32) && s[3] as (i32) == b' ' as (i32) {
                             //eprint!("Pdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((45usize).wrapping_mul(n)),
@@ -662,10 +652,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'n' as (i32) {
-                        if s[(2usize)] as (i32) == b'o' as (i32)
-                            && (s[(3usize)] as (i32) == b't' as (i32))
-                            && (s[(4usize)] as (i32) == b' ' as (i32))
+                    } else if s[1] as (i32) == b'n' as (i32) {
+                        if s[2] as (i32) == b'o' as (i32)
+                            && (s[3] as (i32) == b't' as (i32))
+                            && (s[4] as (i32) == b' ' as (i32))
                         {
                             //eprint!("Qdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
@@ -675,10 +665,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b't' as (i32) {
-                        if s[(2usize)] as (i32) == b'h' as (i32) {
-                            if s[(3usize)] as (i32) == b'e' as (i32) {
-                                if s[(4usize)] as (i32) == b' ' as (i32) {
+                    } else if s[1] as (i32) == b't' as (i32) {
+                        if s[2] as (i32) == b'h' as (i32) {
+                            if s[3] as (i32) == b'e' as (i32) {
+                                if s[4] as (i32) == b' ' as (i32) {
                                     //eprint!("Rdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                     AddMatch(
                                         id.wrapping_add((5usize).wrapping_mul(n)),
@@ -687,9 +677,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                         matches,
                                     );
                                 }
-                            } else if s[(3usize)] as (i32) == b'a' as (i32)
-                                && s[(4usize)] as (i32) == b't' as (i32)
-                                && (s[(5usize)] as (i32) == b' ' as (i32))
+                            } else if s[3] as (i32) == b'a' as (i32)
+                                && s[4] as (i32) == b't' as (i32)
+                                && (s[5] as (i32) == b' ' as (i32))
                             {
                                 //eprint!("Sdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
@@ -699,9 +689,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as (i32) == b'o' as (i32)
-                            && s[(3usize)] as (i32) == b' ' as (i32)
-                        {
+                        } else if s[2] as (i32) == b'o' as (i32) && s[3] as (i32) == b' ' as (i32) {
                             //eprint!("Tdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((17usize).wrapping_mul(n)),
@@ -710,11 +698,11 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'w' as (i32)
-                        && s[(2usize)] as (i32) == b'i' as (i32)
-                        && (s[(3usize)] as (i32) == b't' as (i32))
-                        && (s[(4usize)] as (i32) == b'h' as (i32))
-                        && (s[(5usize)] as (i32) == b' ' as (i32))
+                    } else if s[1] as (i32) == b'w' as (i32)
+                        && s[2] as (i32) == b'i' as (i32)
+                        && (s[3] as (i32) == b't' as (i32))
+                        && (s[4] as (i32) == b'h' as (i32))
+                        && (s[5] as (i32) == b' ' as (i32))
                     {
                         //eprint!("Udding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
@@ -724,7 +712,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'\"' as (i32) {
+                } else if s[0] as (i32) == b'\"' as (i32) {
                     //eprint!("Vdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((19usize).wrapping_mul(n)),
@@ -732,7 +720,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b'>' as (i32) {
+                    if s[1] as (i32) == b'>' as (i32) {
                         //eprint!("Wdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((21usize).wrapping_mul(n)),
@@ -741,7 +729,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'.' as (i32) {
+                } else if s[0] as (i32) == b'.' as (i32) {
                     //eprint!("Xdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((20usize).wrapping_mul(n)),
@@ -749,7 +737,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("Ydding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((31usize).wrapping_mul(n)),
@@ -757,11 +745,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                        if s[(2usize)] as (i32) == b'T' as (i32)
-                            && (s[(3usize)] as (i32) == b'h' as (i32))
-                        {
-                            if s[(4usize)] as (i32) == b'e' as (i32) {
-                                if s[(5usize)] as (i32) == b' ' as (i32) {
+                        if s[2] as (i32) == b'T' as (i32) && (s[3] as (i32) == b'h' as (i32)) {
+                            if s[4] as (i32) == b'e' as (i32) {
+                                if s[5] as (i32) == b' ' as (i32) {
                                     //eprint!("Zdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                     AddMatch(
                                         id.wrapping_add((43usize).wrapping_mul(n)),
@@ -770,9 +756,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                         matches,
                                     );
                                 }
-                            } else if s[(4usize)] as (i32) == b'i' as (i32)
-                                && s[(5usize)] as (i32) == b's' as (i32)
-                                && (s[(6usize)] as (i32) == b' ' as (i32))
+                            } else if s[4] as (i32) == b'i' as (i32)
+                                && s[5] as (i32) == b's' as (i32)
+                                && (s[6] as (i32) == b' ' as (i32))
                             {
                                 //eprint!("AAdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
@@ -784,7 +770,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             }
                         }
                     }
-                } else if s[(0usize)] as (i32) == b',' as (i32) {
+                } else if s[0] as (i32) == b',' as (i32) {
                     //eprint!("ABdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((76usize).wrapping_mul(n)),
@@ -792,7 +778,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("ACdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((14usize).wrapping_mul(n)),
@@ -801,7 +787,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'\n' as (i32) {
+                } else if s[0] as (i32) == b'\n' as (i32) {
                     //eprint!("ADdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((22usize).wrapping_mul(n)),
@@ -809,7 +795,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b'\t' as (i32) {
+                    if s[1] as (i32) == b'\t' as (i32) {
                         //eprint!("AEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((50usize).wrapping_mul(n)),
@@ -818,7 +804,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b']' as (i32) {
+                } else if s[0] as (i32) == b']' as (i32) {
                     //eprint!("AFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((24usize).wrapping_mul(n)),
@@ -826,7 +812,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'\'' as (i32) {
+                } else if s[0] as (i32) == b'\'' as (i32) {
                     //eprint!("AGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((36usize).wrapping_mul(n)),
@@ -834,7 +820,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b':' as (i32) {
+                } else if s[0] as (i32) == b':' as (i32) {
                     //eprint!("AHdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((51usize).wrapping_mul(n)),
@@ -842,7 +828,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'(' as (i32) {
+                } else if s[0] as (i32) == b'(' as (i32) {
                     //eprint!("AIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((57usize).wrapping_mul(n)),
@@ -850,8 +836,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'=' as (i32) {
-                    if s[(1usize)] as (i32) == b'\"' as (i32) {
+                } else if s[0] as (i32) == b'=' as (i32) {
+                    if s[1] as (i32) == b'\"' as (i32) {
                         //eprint!("AJdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((70usize).wrapping_mul(n)),
@@ -859,7 +845,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as (i32) == b'\'' as (i32) {
+                    } else if s[1] as (i32) == b'\'' as (i32) {
                         //eprint!("AKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((86usize).wrapping_mul(n)),
@@ -868,10 +854,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'a' as (i32) {
-                    if s[(1usize)] as (i32) == b'l' as (i32)
-                        && (s[(2usize)] as (i32) == b' ' as (i32))
-                    {
+                } else if s[0] as (i32) == b'a' as (i32) {
+                    if s[1] as (i32) == b'l' as (i32) && (s[2] as (i32) == b' ' as (i32)) {
                         //eprint!("ALdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((84usize).wrapping_mul(n)),
@@ -880,9 +864,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'e' as (i32) {
-                    if s[(1usize)] as (i32) == b'd' as (i32) {
-                        if s[(2usize)] as (i32) == b' ' as (i32) {
+                } else if s[0] as (i32) == b'e' as (i32) {
+                    if s[1] as (i32) == b'd' as (i32) {
+                        if s[2] as (i32) == b' ' as (i32) {
                             //eprint!("AMdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((53usize).wrapping_mul(n)),
@@ -891,8 +875,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'r' as (i32) {
-                        if s[(2usize)] as (i32) == b' ' as (i32) {
+                    } else if s[1] as (i32) == b'r' as (i32) {
+                        if s[2] as (i32) == b' ' as (i32) {
                             //eprint!("ANdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((82usize).wrapping_mul(n)),
@@ -901,9 +885,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b's' as (i32)
-                        && s[(2usize)] as (i32) == b't' as (i32)
-                        && (s[(3usize)] as (i32) == b' ' as (i32))
+                    } else if s[1] as (i32) == b's' as (i32)
+                        && s[2] as (i32) == b't' as (i32)
+                        && (s[3] as (i32) == b' ' as (i32))
                     {
                         //eprint!("AOdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
@@ -913,10 +897,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'f' as (i32) {
-                    if s[(1usize)] as (i32) == b'u' as (i32)
-                        && (s[(2usize)] as (i32) == b'l' as (i32))
-                        && (s[(3usize)] as (i32) == b' ' as (i32))
+                } else if s[0] as (i32) == b'f' as (i32) {
+                    if s[1] as (i32) == b'u' as (i32)
+                        && (s[2] as (i32) == b'l' as (i32))
+                        && (s[3] as (i32) == b' ' as (i32))
                     {
                         //eprint!("APdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
@@ -926,11 +910,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'i' as (i32) {
-                    if s[(1usize)] as (i32) == b'v' as (i32) {
-                        if s[(2usize)] as (i32) == b'e' as (i32)
-                            && (s[(3usize)] as (i32) == b' ' as (i32))
-                        {
+                } else if s[0] as (i32) == b'i' as (i32) {
+                    if s[1] as (i32) == b'v' as (i32) {
+                        if s[2] as (i32) == b'e' as (i32) && (s[3] as (i32) == b' ' as (i32)) {
                             //eprint!("AQdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((92usize).wrapping_mul(n)),
@@ -939,9 +921,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'z' as (i32)
-                        && s[(2usize)] as (i32) == b'e' as (i32)
-                        && (s[(3usize)] as (i32) == b' ' as (i32))
+                    } else if s[1] as (i32) == b'z' as (i32)
+                        && s[2] as (i32) == b'e' as (i32)
+                        && (s[3] as (i32) == b' ' as (i32))
                     {
                         //eprint!("ARdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
@@ -951,11 +933,11 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'l' as (i32) {
-                    if s[(1usize)] as (i32) == b'e' as (i32) {
-                        if s[(2usize)] as (i32) == b's' as (i32)
-                            && (s[(3usize)] as (i32) == b's' as (i32))
-                            && (s[(4usize)] as (i32) == b' ' as (i32))
+                } else if s[0] as (i32) == b'l' as (i32) {
+                    if s[1] as (i32) == b'e' as (i32) {
+                        if s[2] as (i32) == b's' as (i32)
+                            && (s[3] as (i32) == b's' as (i32))
+                            && (s[4] as (i32) == b' ' as (i32))
                         {
                             //eprint!("ASdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
@@ -965,9 +947,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as (i32) == b'y' as (i32)
-                        && s[(2usize)] as (i32) == b' ' as (i32)
-                    {
+                    } else if s[1] as (i32) == b'y' as (i32) && s[2] as (i32) == b' ' as (i32) {
                         //eprint!("ATdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((61usize).wrapping_mul(n)),
@@ -976,10 +956,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'o' as (i32)
-                    && s[(1usize)] as (i32) == b'u' as (i32)
-                    && (s[(2usize)] as (i32) == b's' as (i32))
-                    && (s[(3usize)] as (i32) == b' ' as (i32))
+                } else if s[0] as (i32) == b'o' as (i32)
+                    && s[1] as (i32) == b'u' as (i32)
+                    && (s[2] as (i32) == b's' as (i32))
+                    && (s[3] as (i32) == b' ' as (i32))
                 {
                     //eprint!("AUdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
@@ -1017,7 +997,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     }
                 }
                 let s: &[u8] = data.split_at(l as (usize)).1;
-                if s[(0usize)] as (i32) == b' ' as (i32) {
+                if s[0] as (i32) == b' ' as (i32) {
                     //eprint!("AWdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1028,7 +1008,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'\"' as (i32) {
+                } else if s[0] as (i32) == b'\"' as (i32) {
                     //eprint!("AXdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1039,7 +1019,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b'>' as (i32) {
+                    if s[1] as (i32) == b'>' as (i32) {
                         //eprint!("AYdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1051,7 +1031,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'.' as (i32) {
+                } else if s[0] as (i32) == b'.' as (i32) {
                     //eprint!("AZdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1062,7 +1042,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("BAdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1074,7 +1054,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b',' as (i32) {
+                } else if s[0] as (i32) == b',' as (i32) {
                     //eprint!("BBdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1085,7 +1065,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("BCdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1097,7 +1077,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'\'' as (i32) {
+                } else if s[0] as (i32) == b'\'' as (i32) {
                     //eprint!("BDdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1108,7 +1088,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'(' as (i32) {
+                } else if s[0] as (i32) == b'(' as (i32) {
                     //eprint!("BEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1119,8 +1099,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'=' as (i32) {
-                    if s[(1usize)] as (i32) == b'\"' as (i32) {
+                } else if s[0] as (i32) == b'=' as (i32) {
+                    if s[1] as (i32) == b'\"' as (i32) {
                         //eprint!("BFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1131,7 +1111,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as (i32) == b'\'' as (i32) {
+                    } else if s[1] as (i32) == b'\'' as (i32) {
                         //eprint!("BGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1148,9 +1128,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     if max_length >= 5usize
-        && (data[(0usize)] as (i32) == b' ' as (i32) || data[(0usize)] as (i32) == b'.' as (i32))
+        && (data[0] as (i32) == b' ' as (i32) || data[0] as (i32) == b'.' as (i32))
     {
-        let is_space: i32 = if !!(data[(0usize)] as (i32) == b' ' as (i32)) {
+        let is_space: i32 = if !!(data[0] as (i32) == b' ' as (i32)) {
             1i32
         } else {
             0i32
@@ -1161,7 +1141,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         while end == 0 {
             let mut w: DictWord = kStaticDictionaryWords[{
                 let _old = offset;
-                offset = offset.wrapping_add(1 as (usize));
+                offset = offset.wrapping_add(1);
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
@@ -1197,7 +1177,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     }
                 }
                 let s: &[u8] = data.split_at(l.wrapping_add(1usize) as (usize)).1;
-                if s[(0usize)] as (i32) == b' ' as (i32) {
+                if s[0] as (i32) == b' ' as (i32) {
                     //eprint!("BIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1207,7 +1187,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b'(' as (i32) {
+                } else if s[0] as (i32) == b'(' as (i32) {
                     //eprint!("BJdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1218,7 +1198,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         matches,
                     );
                 } else if is_space != 0 {
-                    if s[(0usize)] as (i32) == b',' as (i32) {
+                    if s[0] as (i32) == b',' as (i32) {
                         //eprint!("BKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((103usize).wrapping_mul(n)),
@@ -1226,7 +1206,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                        if s[(1usize)] as (i32) == b' ' as (i32) {
+                        if s[1] as (i32) == b' ' as (i32) {
                             //eprint!("BLdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((33usize).wrapping_mul(n)),
@@ -1235,7 +1215,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(0usize)] as (i32) == b'.' as (i32) {
+                    } else if s[0] as (i32) == b'.' as (i32) {
                         //eprint!("BMdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((71usize).wrapping_mul(n)),
@@ -1243,7 +1223,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                        if s[(1usize)] as (i32) == b' ' as (i32) {
+                        if s[1] as (i32) == b' ' as (i32) {
                             //eprint!("BNdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((52usize).wrapping_mul(n)),
@@ -1252,8 +1232,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 matches,
                             );
                         }
-                    } else if s[(0usize)] as (i32) == b'=' as (i32) {
-                        if s[(1usize)] as (i32) == b'\"' as (i32) {
+                    } else if s[0] as (i32) == b'=' as (i32) {
+                        if s[1] as (i32) == b'\"' as (i32) {
                             //eprint!("BOdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((81usize).wrapping_mul(n)),
@@ -1261,7 +1241,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                                 l,
                                 matches,
                             );
-                        } else if s[(1usize)] as (i32) == b'\'' as (i32) {
+                        } else if s[1] as (i32) == b'\'' as (i32) {
                             //eprint!("BPdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((98usize).wrapping_mul(n)),
@@ -1306,7 +1286,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     }
                 }
                 let s: &[u8] = data.split_at(l.wrapping_add(1)).1;
-                if s[(0usize)] as (i32) == b' ' as (i32) {
+                if s[0] as (i32) == b' ' as (i32) {
                     //eprint!("CBdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1317,7 +1297,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                } else if s[(0usize)] as (i32) == b',' as (i32) {
+                } else if s[0] as (i32) == b',' as (i32) {
                     if is_all_caps == 0 {
                         //eprint!("CCdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
@@ -1327,7 +1307,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("CDdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1339,7 +1319,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'.' as (i32) {
+                } else if s[0] as (i32) == b'.' as (i32) {
                     //eprint!("CEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
@@ -1350,7 +1330,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                         l,
                         matches,
                     );
-                    if s[(1usize)] as (i32) == b' ' as (i32) {
+                    if s[1] as (i32) == b' ' as (i32) {
                         //eprint!("CFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1362,8 +1342,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                     }
-                } else if s[(0usize)] as (i32) == b'=' as (i32) {
-                    if s[(1usize)] as (i32) == b'\"' as (i32) {
+                } else if s[0] as (i32) == b'=' as (i32) {
+                    if s[1] as (i32) == b'\"' as (i32) {
                         //eprint!("CGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1374,7 +1354,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as (i32) == b'\'' as (i32) {
+                    } else if s[1] as (i32) == b'\'' as (i32) {
                         //eprint!("CHdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
@@ -1391,11 +1371,11 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     if max_length >= 6usize
-        && (data[(1usize)] as (i32) == b' ' as (i32)
-            && (data[(0usize)] as (i32) == b'e' as (i32)
-                || data[(0usize)] as (i32) == b's' as (i32)
-                || data[(0usize)] as (i32) == b',' as (i32))
-            || data[(0usize)] as (i32) == 0xc2i32 && (data[(1usize)] as (i32) == 0xa0i32))
+        && (data[1] as (i32) == b' ' as (i32)
+            && (data[0] as (i32) == b'e' as (i32)
+                || data[0] as (i32) == b's' as (i32)
+                || data[0] as (i32) == b',' as (i32))
+            || data[0] as (i32) == 0xc2i32 && (data[1] as (i32) == 0xa0i32))
     {
         let mut offset: usize =
             kStaticDictionaryBuckets[Hash(data.split_at(2).1) as (usize)] as (usize);
@@ -1403,7 +1383,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         while end == 0 {
             let mut w: DictWord = kStaticDictionaryWords[{
                 let _old = offset;
-                offset = offset.wrapping_add(1 as (usize));
+                offset = offset.wrapping_add(1);
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
@@ -1419,7 +1399,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     max_length.wrapping_sub(2usize),
                 ) != 0)
             {
-                if data[(0usize)] as (i32) == 0xc2i32 {
+                if data[0] as (i32) == 0xc2i32 {
                     //eprint!("CIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add((102usize).wrapping_mul(n)),
@@ -1431,9 +1411,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 } else if l.wrapping_add(2usize) < max_length
                     && (data[(l.wrapping_add(2usize) as (usize))] as (i32) == b' ' as (i32))
                 {
-                    let t: usize = (if data[(0usize)] as (i32) == b'e' as (i32) {
+                    let t: usize = (if data[0] as (i32) == b'e' as (i32) {
                         18i32
-                    } else if data[(0usize)] as (i32) == b's' as (i32) {
+                    } else if data[0] as (i32) == b's' as (i32) {
                         7i32
                     } else {
                         13i32
@@ -1451,16 +1431,16 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     if max_length >= 9usize
-        && (data[(0usize)] as (i32) == b' ' as (i32)
-            && (data[(1usize)] as (i32) == b't' as (i32))
-            && (data[(2usize)] as (i32) == b'h' as (i32))
-            && (data[(3usize)] as (i32) == b'e' as (i32))
-            && (data[(4usize)] as (i32) == b' ' as (i32))
-            || data[(0usize)] as (i32) == b'.' as (i32)
-                && (data[(1usize)] as (i32) == b'c' as (i32))
-                && (data[(2usize)] as (i32) == b'o' as (i32))
-                && (data[(3usize)] as (i32) == b'm' as (i32))
-                && (data[(4usize)] as (i32) == b'/' as (i32)))
+        && (data[0] as (i32) == b' ' as (i32)
+            && (data[1] as (i32) == b't' as (i32))
+            && (data[2] as (i32) == b'h' as (i32))
+            && (data[3] as (i32) == b'e' as (i32))
+            && (data[4] as (i32) == b' ' as (i32))
+            || data[0] as (i32) == b'.' as (i32)
+                && (data[1] as (i32) == b'c' as (i32))
+                && (data[2] as (i32) == b'o' as (i32))
+                && (data[3] as (i32) == b'm' as (i32))
+                && (data[4] as (i32) == b'/' as (i32)))
     {
         let mut offset: usize =
             kStaticDictionaryBuckets[Hash(data.split_at(5).1) as (usize)] as (usize);
@@ -1468,7 +1448,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         while end == 0 {
             let mut w: DictWord = kStaticDictionaryWords[{
                 let _old = offset;
-                offset = offset.wrapping_add(1 as (usize));
+                offset = offset.wrapping_add(1);
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
@@ -1487,7 +1467,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 //eprint!("CKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                 AddMatch(
                     id.wrapping_add(
-                        (if data[(0usize)] as (i32) == b' ' as (i32) {
+                        (if data[0] as (i32) == b' ' as (i32) {
                             41i32
                         } else {
                             72i32
@@ -1501,12 +1481,12 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 has_found_match = 1i32;
                 if l.wrapping_add(5usize) < max_length {
                     let s: &[u8] = data.split_at(l.wrapping_add(5usize) as (usize)).1;
-                    if data[(0usize)] as (i32) == b' ' as (i32)
+                    if data[0] as (i32) == b' ' as (i32)
                         && l.wrapping_add(8usize) < max_length
-                        && (s[(0usize)] as (i32) == b' ' as (i32))
-                        && (s[(1usize)] as (i32) == b'o' as (i32))
-                        && (s[(2usize)] as (i32) == b'f' as (i32))
-                        && (s[(3usize)] as (i32) == b' ' as (i32))
+                        && (s[0] as (i32) == b' ' as (i32))
+                        && (s[1] as (i32) == b'o' as (i32))
+                        && (s[2] as (i32) == b'f' as (i32))
+                        && (s[3] as (i32) == b' ' as (i32))
                     {
                         //eprint!("CLdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
@@ -1516,10 +1496,10 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                             matches,
                         );
                         if l.wrapping_add(12usize) < max_length
-                            && (s[(4usize)] as (i32) == b't' as (i32))
-                            && (s[(5usize)] as (i32) == b'h' as (i32))
-                            && (s[(6usize)] as (i32) == b'e' as (i32))
-                            && (s[(7usize)] as (i32) == b' ' as (i32))
+                            && (s[4] as (i32) == b't' as (i32))
+                            && (s[5] as (i32) == b'h' as (i32))
+                            && (s[6] as (i32) == b'e' as (i32))
+                            && (s[7] as (i32) == b' ' as (i32))
                         {
                             //eprint!("BQdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -23,12 +23,9 @@ fn stride_lookup_lin(
     high_nibble: Option<u8>,
 ) -> usize {
     if let Some(nibble) = high_nibble {
-        1 + 2
-            * (actual_context as usize
-                | ((stride_byte as usize & 0xf) << 8)
-                | ((nibble as usize) << 12))
+        1 + 2 * (actual_context | ((stride_byte as usize & 0xf) << 8) | ((nibble as usize) << 12))
     } else {
-        2 * (actual_context as usize | ((stride_byte as usize) << 8))
+        2 * (actual_context | ((stride_byte as usize) << 8))
     }
 }
 

--- a/src/enc/utf8_util.rs
+++ b/src/enc/utf8_util.rs
@@ -61,7 +61,7 @@ pub fn BrotliIsMostlyUTF8(
         let mut symbol: i32 = 0;
         let bytes_read: usize = BrotliParseAsUTF8(
             &mut symbol,
-            &data[((pos.wrapping_add(i) & mask) as (usize))..],
+            &data[(pos.wrapping_add(i) & mask)..],
             length.wrapping_sub(i),
         );
         i = i.wrapping_add(bytes_read);

--- a/src/enc/util.rs
+++ b/src/enc/util.rs
@@ -377,7 +377,7 @@ pub fn FastPow2(v: super::util::floatX) -> super::util::floatX {
 
 #[inline(always)]
 pub fn Log2FloorNonZero(v: u64) -> u32 {
-    (63u32 ^ v.leading_zeros()) as u32
+    63u32 ^ v.leading_zeros()
 }
 
 mod test {
@@ -388,7 +388,7 @@ mod test {
             n
         } != 0
         {
-            result = result.wrapping_add(1 as (u32));
+            result = result.wrapping_add(1);
         }
         result
     }

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -162,12 +162,12 @@ impl<ErrType, W: CustomWrite<ErrType>, BufferType: SliceWrapperMut<u8>, Alloc: B
         BrotliEncoderSetParameter(
             &mut ret.state,
             BrotliEncoderParameter::BROTLI_PARAM_QUALITY,
-            q as (u32),
+            q,
         );
         BrotliEncoderSetParameter(
             &mut ret.state,
             BrotliEncoderParameter::BROTLI_PARAM_LGWIN,
-            lgwin as (u32),
+            lgwin,
         );
 
         ret


### PR DESCRIPTION
* https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_cast
* https://rust-lang.github.io/rust-clippy/master/index.html#/double_parens
* https://rust-lang.github.io/rust-clippy/master/index.html#/needless_parens_on_range_literals

Additionally, a few manual but related changes (some to avoid merge conflicts)
* ignored `clippy::excessive_precision` in utils because of a huge number of false positives 
* replaced `[(identifier_or_const)]` with `[identifier_or_const]`, e.g. `[(0)]` with `[0]` and `[(foo)]` with `[foo]`
  * `\[\(([a-z0-9_]+)\)\]` into `[$1]`
* replaced `[number_type]` with `[number]`, e.g. `[0usize]` with `[0]`
  * `\[([0-9]+)_?[a-z][a-z0-9]+\]` into `[$1]`

```
cargo clippy -- -A clippy::all -W clippy::unnecessary_cast
cargo clippy -- -A clippy::all -W clippy::double_parens
cargo clippy --fix -- -A clippy::all -W clippy::needless_parens_on_range_literals
```