### PR TITLE
Auto-fixed explicit-auto-deref

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -74,13 +74,13 @@ impl<T> ops::IndexMut<usize> for Rebox<T> {
 
 impl<T> alloc_no_stdlib::SliceWrapper<T> for Rebox<T> {
     fn slice(&self) -> &[T] {
-        &*self.b
+        &self.b
     }
 }
 
 impl<T> alloc_no_stdlib::SliceWrapperMut<T> for Rebox<T> {
     fn slice_mut(&mut self) -> &mut [T] {
-        &mut *self.b
+        &mut self.b
     }
 }
 #[derive(Clone, Copy, Default)]

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -278,10 +278,7 @@ where
     }
     #[inline(always)]
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        let max_backward: usize = (*self)
-            .window_mask_
-            .wrapping_sub(16usize)
-            .wrapping_add(1usize);
+        let max_backward: usize = self.window_mask_.wrapping_sub(16usize).wrapping_add(1usize);
         StoreAndFindMatchesH10(
             self,
             data,
@@ -454,14 +451,14 @@ where
     };
     let key = xself.HashBytes(&data[(cur_ix_masked as (usize))..]);
     let forest: &mut [u32] = xself.forest.slice_mut();
-    let mut prev_ix: usize = (*xself).buckets_.slice()[key] as (usize);
+    let mut prev_ix: usize = xself.buckets_.slice()[key] as (usize);
     let mut node_left: usize = LeftChildIndexH10!(xself, cur_ix);
     let mut node_right: usize = RightChildIndexH10!(xself, cur_ix);
     let mut best_len_left: usize = 0usize;
     let mut best_len_right: usize = 0usize;
     let mut depth_remaining: usize;
     if should_reroot_tree != 0 {
-        (*xself).buckets_.slice_mut()[(key as (usize))] = cur_ix as (u32);
+        xself.buckets_.slice_mut()[(key as (usize))] = cur_ix as (u32);
     }
     depth_remaining = 64usize;
     'break16: loop {
@@ -470,8 +467,8 @@ where
             let prev_ix_masked: usize = prev_ix & ring_buffer_mask;
             if backward == 0usize || backward > max_backward || depth_remaining == 0usize {
                 if should_reroot_tree != 0 {
-                    forest[(node_left as (usize))] = (*xself).invalid_pos_;
-                    forest[(node_right as (usize))] = (*xself).invalid_pos_;
+                    forest[(node_left as (usize))] = xself.invalid_pos_;
+                    forest[(node_right as (usize))] = xself.invalid_pos_;
                 }
                 break 'break16;
             }

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -68,17 +68,17 @@ pub fn BrotliInitZopfliNodes(array: &mut [ZopfliNode], length: usize) {
 
 #[inline(always)]
 fn ZopfliNodeCopyLength(xself: &ZopfliNode) -> u32 {
-    (*xself).length & 0x1ffffffu32
+    xself.length & 0x1ffffffu32
 }
 
 #[inline(always)]
 fn ZopfliNodeCopyDistance(xself: &ZopfliNode) -> u32 {
-    (*xself).distance
+    xself.distance
 }
 
 #[inline(always)]
 fn ZopfliNodeLengthCode(xself: &ZopfliNode) -> u32 {
-    let modifier: u32 = (*xself).length >> 25i32;
+    let modifier: u32 = xself.length >> 25i32;
     ZopfliNodeCopyLength(xself)
         .wrapping_add(9u32)
         .wrapping_sub(modifier)
@@ -91,7 +91,7 @@ fn brotli_min_size_t(a: usize, b: usize) -> usize {
 
 #[inline(always)]
 fn ZopfliNodeDistanceCode(xself: &ZopfliNode) -> u32 {
-    let short_code: u32 = (*xself).dcode_insert_length >> 27i32;
+    let short_code: u32 = xself.dcode_insert_length >> 27i32;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(xself)
             .wrapping_add(16u32)
@@ -124,9 +124,9 @@ pub fn BrotliZopfliCreateCommands(
         {
             let next: &ZopfliNode = &nodes[(pos.wrapping_add(offset as (usize)) as (usize))];
             let copy_length: usize = ZopfliNodeCopyLength(next) as (usize);
-            let mut insert_length: usize = ((*next).dcode_insert_length & 0x7ffffff) as (usize);
+            let mut insert_length: usize = (next.dcode_insert_length & 0x7ffffff) as (usize);
             pos = pos.wrapping_add(insert_length);
-            offset = match (*next).u {
+            offset = match next.u {
                 Union1::next(off) => off,
                 _ => 0,
             };
@@ -147,7 +147,7 @@ pub fn BrotliZopfliCreateCommands(
                 let dist_code: usize = ZopfliNodeDistanceCode(next) as (usize);
                 InitCommand(
                     &mut commands[(i as (usize))],
-                    &(*params).dist,
+                    &params.dist,
                     insert_length,
                     copy_length,
                     len_code,
@@ -170,7 +170,7 @@ pub fn BrotliZopfliCreateCommands(
 
 #[inline(always)]
 fn MaxZopfliLen(params: &BrotliEncoderParams) -> usize {
-    (if (*params).quality <= 10i32 {
+    (if params.quality <= 10i32 {
         150i32
     } else {
         325i32
@@ -233,12 +233,12 @@ fn InitZopfliCostModel<AllocF: alloc::Allocator<floatX>>(
         } else {
             AllocF::AllocatedMemory::default()
         },
-        cost_dist_: if (*dist).alphabet_size > 0u32 {
+        cost_dist_: if dist.alphabet_size > 0u32 {
             m.alloc_cell(num_bytes.wrapping_add(dist.alphabet_size as usize))
         } else {
             AllocF::AllocatedMemory::default()
         },
-        distance_histogram_size: core::cmp::min((*dist).alphabet_size, 544),
+        distance_histogram_size: core::cmp::min(dist.alphabet_size, 544),
     }
 }
 fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
@@ -247,11 +247,11 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
     ringbuffer: &[u8],
     ringbuffer_mask: usize,
 ) {
-    let literal_costs = (*xself).literal_costs_.slice_mut();
+    let literal_costs = xself.literal_costs_.slice_mut();
     let mut literal_carry: floatX = 0.0;
-    let cost_dist = (*xself).cost_dist_.slice_mut();
-    let cost_cmd = &mut (*xself).cost_cmd_[..];
-    let num_bytes: usize = (*xself).num_bytes_;
+    let cost_dist = xself.cost_dist_.slice_mut();
+    let cost_cmd = &mut xself.cost_cmd_[..];
+    let num_bytes: usize = xself.num_bytes_;
     let mut i: usize;
     BrotliEstimateBitCostsForLiterals(
         position,
@@ -282,13 +282,13 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
         i = i.wrapping_add(1 as (usize));
     }
     i = 0usize;
-    while i < (*xself).distance_histogram_size as (usize) {
+    while i < xself.distance_histogram_size as (usize) {
         {
             cost_dist[(i as (usize))] = FastLog2((20u64).wrapping_add(i as (u64))) as (floatX);
         }
         i = i.wrapping_add(1 as (usize));
     }
-    (*xself).min_cost_cmd_ = FastLog2(11) as (floatX);
+    xself.min_cost_cmd_ = FastLog2(11) as (floatX);
 }
 
 #[inline(always)]
@@ -382,7 +382,7 @@ where
     let mut matches_offset = 0usize;
     let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
     let mut best_len: usize = 1usize;
-    let short_match_max_backward: usize = (if (*params).quality != 11i32 {
+    let short_match_max_backward: usize = (if params.quality != 11i32 {
         16i32
     } else {
         64i32
@@ -473,7 +473,7 @@ where
                             .wrapping_add(gap)
                             .wrapping_add((dict_id >> 5i32) as (usize))
                             .wrapping_add(1usize);
-                        if distance <= (*params).dist.max_distance {
+                        if distance <= params.dist.max_distance {
                             InitDictionaryBackwardMatch(
                                 &mut BackwardMatchMut(&mut matches[matches_offset]),
                                 distance,
@@ -498,11 +498,7 @@ fn BackwardMatchLength(xself: &BackwardMatch) -> usize {
 
 #[inline(always)]
 fn MaxZopfliCandidates(params: &BrotliEncoderParams) -> usize {
-    (if (*params).quality <= 10i32 {
-        1i32
-    } else {
-        5i32
-    }) as (usize)
+    (if params.quality <= 10i32 { 1i32 } else { 5i32 }) as (usize)
 }
 
 #[inline(always)]
@@ -537,8 +533,7 @@ fn ZopfliCostModelGetLiteralCosts<AllocF: Allocator<floatX>>(
     from: usize,
     to: usize,
 ) -> floatX {
-    (*xself).literal_costs_.slice()[(to as (usize))]
-        - (*xself).literal_costs_.slice()[(from as (usize))]
+    xself.literal_costs_.slice()[(to as (usize))] - xself.literal_costs_.slice()[(from as (usize))]
 }
 fn ComputeDistanceCache(
     pos: usize,
@@ -579,18 +574,18 @@ fn ComputeDistanceCache(
 
 #[inline(always)]
 fn StartPosQueueSize(xself: &StartPosQueue) -> usize {
-    brotli_min_size_t((*xself).idx_, 8usize)
+    brotli_min_size_t(xself.idx_, 8usize)
 }
 
 fn StartPosQueuePush(xself: &mut StartPosQueue, posdata: &PosData) {
     let mut offset: usize = !{
-        let _old = (*xself).idx_;
-        (*xself).idx_ = (*xself).idx_.wrapping_add(1 as (usize));
+        let _old = xself.idx_;
+        xself.idx_ = xself.idx_.wrapping_add(1 as (usize));
         _old
     } & 7usize;
     let len: usize = StartPosQueueSize(xself);
     let mut i: usize;
-    let q: &mut [PosData; 8] = &mut (*xself).q_;
+    let q: &mut [PosData; 8] = &mut xself.q_;
     q[(offset as (usize))] = *posdata;
     i = 1usize;
     while i < len {
@@ -649,14 +644,14 @@ fn EvaluateNode<AllocF: Allocator<floatX>>(
 
 #[inline(always)]
 fn StartPosQueueAt(xself: &StartPosQueue, k: usize) -> &PosData {
-    &(*xself).q_[((k.wrapping_sub((*xself).idx_) & 7usize) as (usize))]
+    &xself.q_[((k.wrapping_sub(xself.idx_) & 7usize) as (usize))]
 }
 
 #[inline(always)]
 fn ZopfliCostModelGetMinCostCmd<AllocF: Allocator<floatX>>(
     xself: &ZopfliCostModel<AllocF>,
 ) -> floatX {
-    (*xself).min_cost_cmd_
+    xself.min_cost_cmd_
 }
 
 #[inline(always)]
@@ -695,7 +690,7 @@ fn ZopfliCostModelGetDistanceCost<AllocF: Allocator<floatX>>(
     xself: &ZopfliCostModel<AllocF>,
     distcode: usize,
 ) -> floatX {
-    (*xself).cost_dist_.slice()[(distcode as (usize))]
+    xself.cost_dist_.slice()[(distcode as (usize))]
 }
 
 #[inline(always)]
@@ -708,7 +703,7 @@ fn ZopfliCostModelGetCommandCost<AllocF: Allocator<floatX>>(
     xself: &ZopfliCostModel<AllocF>,
     cmdcode: u16,
 ) -> floatX {
-    (*xself).cost_cmd_[(cmdcode as (usize))]
+    xself.cost_cmd_[(cmdcode as (usize))]
 }
 
 #[inline(always)]
@@ -723,11 +718,11 @@ fn UpdateZopfliNode(
     cost: floatX,
 ) {
     let next = &mut nodes[(pos.wrapping_add(len) as (usize))];
-    (*next).length =
+    next.length =
         (len | len.wrapping_add(9u32 as (usize)).wrapping_sub(len_code) << 25i32) as (u32);
-    (*next).distance = dist as (u32);
-    (*next).dcode_insert_length = pos.wrapping_sub(start_pos) as (u32) | (short_code << 27) as u32;
-    (*next).u = Union1::cost(cost);
+    next.distance = dist as (u32);
+    next.dcode_insert_length = pos.wrapping_sub(start_pos) as (u32) | (short_code << 27) as u32;
+    next.u = Union1::cost(cost);
 }
 
 #[inline(always)]
@@ -777,9 +772,9 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
     );
     {
         let posdata = StartPosQueueAt(queue, 0usize);
-        let min_cost: floatX = (*posdata).cost
+        let min_cost: floatX = posdata.cost
             + ZopfliCostModelGetMinCostCmd(model)
-            + ZopfliCostModelGetLiteralCosts(model, (*posdata).pos, pos);
+            + ZopfliCostModelGetLiteralCosts(model, posdata.pos, pos);
         min_len = ComputeMinimumCopyLength(min_cost, nodes, num_bytes, pos);
     }
     k = 0usize;
@@ -787,9 +782,9 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
         'continue28: loop {
             {
                 let posdata = StartPosQueueAt(queue, k);
-                let start: usize = (*posdata).pos;
+                let start: usize = posdata.pos;
                 let inscode: u16 = GetInsertLengthCode(pos.wrapping_sub(start));
-                let start_costdiff: floatX = (*posdata).costdiff;
+                let start_costdiff: floatX = posdata.costdiff;
                 let base_cost: floatX = start_costdiff
                     + GetInsertExtra(inscode) as (floatX)
                     + ZopfliCostModelGetLiteralCosts(model, 0usize, pos);
@@ -804,7 +799,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 distance_cache_len_minus_1 + 1,
                                 posdata.distance_cache.len()
                             );
-                            let backward: usize = ((*posdata).distance_cache
+                            let backward: usize = (posdata.distance_cache
                                 [(idx as (usize) & distance_cache_len_minus_1)]
                                 + i32::from(kDistanceCacheOffset[(j as (usize))]))
                                 as (usize);
@@ -909,8 +904,8 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                             let max_match_len: usize;
                             PrefixEncodeCopyDistance(
                                 dist_code,
-                                (*params).dist.num_direct_distance_codes as (usize),
-                                u64::from((*params).dist.distance_postfix_bits),
+                                params.dist.num_direct_distance_codes as (usize),
+                                u64::from(params.dist.distance_postfix_bits),
                                 &mut dist_symbol,
                                 &mut distextra,
                             );
@@ -986,7 +981,7 @@ fn CleanupZopfliCostModel<AllocF: Allocator<floatX>>(
 
 #[inline(always)]
 fn ZopfliNodeCommandLength(xself: &ZopfliNode) -> u32 {
-    ZopfliNodeCopyLength(xself).wrapping_add((*xself).dcode_insert_length & 0x7ffffff)
+    ZopfliNodeCopyLength(xself).wrapping_add(xself.dcode_insert_length & 0x7ffffff)
 }
 
 #[inline(always)]
@@ -1047,7 +1042,7 @@ where
     let lz_matches_offset: usize = 0usize;
     (nodes[(0usize)]).length = 0u32;
     (nodes[(0usize)]).u = Union1::cost(0.0);
-    model = InitZopfliCostModel(m, &(*params).dist, num_bytes);
+    model = InitZopfliCostModel(m, &params.dist, num_bytes);
     if !(0i32 == 0) {
         return 0usize;
     }
@@ -1159,7 +1154,7 @@ pub fn BrotliCreateZopfliBackwardReferences<
 ) where
     Buckets: PartialEq<Buckets>,
 {
-    let max_backward_limit: usize = (1usize << (*params).lgwin).wrapping_sub(16usize);
+    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16usize);
     let mut nodes: <Alloc as Allocator<ZopfliNode>>::AllocatedMemory;
     nodes = if num_bytes.wrapping_add(1usize) > 0usize {
         <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
@@ -1280,7 +1275,7 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
     let mut pos: usize = position.wrapping_sub(last_insert_len);
     let mut min_cost_cmd: floatX = kInfinity;
     let mut i: usize;
-    let cost_cmd: &mut [floatX] = &mut (*xself).cost_cmd_[..];
+    let cost_cmd: &mut [floatX] = &mut xself.cost_cmd_[..];
     i = 0usize;
     while i < num_commands {
         {
@@ -1329,9 +1324,9 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
     );
     SetCost(
         &histogram_dist[..],
-        (*xself).distance_histogram_size as (usize),
+        xself.distance_histogram_size as (usize),
         0i32,
-        (*xself).cost_dist_.slice_mut(),
+        xself.cost_dist_.slice_mut(),
     );
     i = 0usize;
     while i < 704usize {
@@ -1340,11 +1335,11 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
         }
         i = i.wrapping_add(1 as (usize));
     }
-    (*xself).min_cost_cmd_ = min_cost_cmd;
+    xself.min_cost_cmd_ = min_cost_cmd;
     {
-        let literal_costs: &mut [floatX] = (*xself).literal_costs_.slice_mut();
+        let literal_costs: &mut [floatX] = xself.literal_costs_.slice_mut();
         let mut literal_carry: floatX = 0.0;
-        let num_bytes: usize = (*xself).num_bytes_;
+        let num_bytes: usize = xself.num_bytes_;
         literal_costs[(0usize)] = 0.0 as (floatX);
         i = 0usize;
         while i < num_bytes {
@@ -1468,7 +1463,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
 ) where
     Buckets: PartialEq<Buckets>,
 {
-    let max_backward_limit: usize = (1usize << (*params).lgwin).wrapping_sub(16usize);
+    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16usize);
     let mut num_matches: <Alloc as Allocator<u32>>::AllocatedMemory = if num_bytes > 0usize {
         <Alloc as Allocator<u32>>::alloc_cell(alloc, num_bytes)
     } else {
@@ -1635,7 +1630,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     if !(0i32 == 0) {
         return;
     }
-    model = InitZopfliCostModel(alloc, &(*params).dist, num_bytes);
+    model = InitZopfliCostModel(alloc, &params.dist, num_bytes);
     if !(0i32 == 0) {
         return;
     }

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -131,7 +131,7 @@ pub struct Struct1 {
 }
 
 fn LiteralSpreeLengthForSparseSearch(params: &BrotliEncoderParams) -> usize {
-    (if (*params).quality < 9 { 64i32 } else { 512i32 }) as (usize)
+    (if params.quality < 9 { 64i32 } else { 512i32 }) as (usize)
 }
 
 fn brotli_min_size_t(a: usize, b: usize) -> usize {
@@ -360,17 +360,17 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         out: &mut HasherSearchResult,
     ) -> bool {
         let opts = self.Opts();
-        let best_len_in: usize = (*out).len;
+        let best_len_in: usize = out.len;
         let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
         let key: u32 = self.HashBytes(&data[(cur_ix_masked as (usize))..]) as u32;
         let mut compare_char: i32 =
             data[(cur_ix_masked.wrapping_add(best_len_in) as (usize))] as (i32);
-        let mut best_score: u64 = (*out).score;
+        let mut best_score: u64 = out.score;
         let mut best_len: usize = best_len_in;
         let cached_backward: usize = distance_cache[(0usize)] as (usize);
         let mut prev_ix: usize = cur_ix.wrapping_sub(cached_backward);
         let mut is_match_found: i32 = 0i32;
-        (*out).len_x_code = 0usize;
+        out.len_x_code = 0usize;
         if prev_ix < cur_ix {
             prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
             if compare_char == data[(prev_ix.wrapping_add(best_len) as (usize))] as (i32) {
@@ -382,12 +382,12 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                 if len != 0 {
                     best_score = BackwardReferenceScoreUsingLastDistance(len, opts);
                     best_len = len;
-                    (*out).len = len;
-                    (*out).distance = cached_backward;
-                    (*out).score = best_score;
+                    out.len = len;
+                    out.distance = cached_backward;
+                    out.score = best_score;
                     compare_char = data[(cur_ix_masked.wrapping_add(best_len) as (usize))] as (i32);
                     if self.buckets_.BUCKET_SWEEP() == 1i32 {
-                        (*self).buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
+                        self.buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
                         return true;
                     } else {
                         is_match_found = 1i32;
@@ -399,8 +399,8 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         if bucket_sweep == 1i32 {
             let backward: usize;
             let len: usize;
-            prev_ix = (*self).buckets_.slice()[key as (usize)] as (usize);
-            (*self).buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
+            prev_ix = self.buckets_.slice()[key as (usize)] as (usize);
+            self.buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
             backward = cur_ix.wrapping_sub(prev_ix);
             prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
             if compare_char != data[(prev_ix.wrapping_add(best_len_in) as (usize))] as (i32) {
@@ -415,9 +415,9 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                 max_length,
             );
             if len != 0 {
-                (*out).len = len;
-                (*out).distance = backward;
-                (*out).score = BackwardReferenceScore(len, backward, opts);
+                out.len = len;
+                out.distance = backward;
+                out.score = BackwardReferenceScore(len, backward, opts);
                 return true;
             }
         } else {
@@ -443,9 +443,9 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                     if best_score < score {
                         best_score = score;
                         best_len = len;
-                        (*out).len = best_len;
-                        (*out).distance = backward;
-                        (*out).score = score;
+                        out.len = best_len;
+                        out.distance = backward;
+                        out.score = score;
                         compare_char =
                             data[(cur_ix_masked.wrapping_add(best_len) as (usize))] as (i32);
                         is_match_found = 1i32;
@@ -466,7 +466,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
                 1i32,
             );
         }
-        (*self).buckets_.slice_mut()
+        self.buckets_.slice_mut()
             [(key as (usize)).wrapping_add((cur_ix >> 3).wrapping_rem(bucket_sweep as usize))] =
             cur_ix as (u32);
         is_match_found != 0
@@ -741,12 +741,12 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
         max_distance: usize,
         out: &mut HasherSearchResult,
     ) -> bool {
-        let best_len_in: usize = (*out).len;
+        let best_len_in: usize = out.len;
         let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
-        let mut best_score: u64 = (*out).score;
+        let mut best_score: u64 = out.score;
         let mut best_len: usize = best_len_in;
         let mut is_match_found: i32 = 0i32;
-        (*out).len_x_code = 0usize;
+        out.len_x_code = 0usize;
         for i in 0..H9_NUM_LAST_DISTANCES_TO_CHECK {
             let idx = kDistanceCacheIndex[i] as usize;
             let backward =
@@ -1192,16 +1192,16 @@ impl<
                     >> shift) as usize;
                 let mut num_ref0 = u32::from(num[mixed0]);
                 num[mixed0] = num_ref0.wrapping_add(1) as u16;
-                num_ref0 &= (*self).specialization.block_mask();
+                num_ref0 &= self.specialization.block_mask();
                 let mut num_ref1 = u32::from(num[mixed1]);
                 num[mixed1] = num_ref1.wrapping_add(1) as u16;
-                num_ref1 &= (*self).specialization.block_mask();
+                num_ref1 &= self.specialization.block_mask();
                 let mut num_ref2 = u32::from(num[mixed2]);
                 num[mixed2] = num_ref2.wrapping_add(1) as u16;
-                num_ref2 &= (*self).specialization.block_mask();
+                num_ref2 &= self.specialization.block_mask();
                 let mut num_ref3 = u32::from(num[mixed3]);
                 num[mixed3] = num_ref3.wrapping_add(1) as u16;
-                num_ref3 &= (*self).specialization.block_mask();
+                num_ref3 &= self.specialization.block_mask();
                 let offset0: usize =
                     (mixed0 << self.specialization.block_bits()) + num_ref0 as usize;
                 let offset1: usize =
@@ -1278,16 +1278,16 @@ impl<
                         >> shift) as usize;
                     let mut num_ref0 = u32::from(num[mixed0]);
                     num[mixed0] = num_ref0.wrapping_add(1) as u16;
-                    num_ref0 &= (*self).specialization.block_mask();
+                    num_ref0 &= self.specialization.block_mask();
                     let mut num_ref1 = u32::from(num[mixed1]);
                     num[mixed1] = num_ref1.wrapping_add(1) as u16;
-                    num_ref1 &= (*self).specialization.block_mask();
+                    num_ref1 &= self.specialization.block_mask();
                     let mut num_ref2 = u32::from(num[mixed2]);
                     num[mixed2] = num_ref2.wrapping_add(1) as u16;
-                    num_ref2 &= (*self).specialization.block_mask();
+                    num_ref2 &= self.specialization.block_mask();
                     let mut num_ref3 = u32::from(num[mixed3]);
                     num[mixed3] = num_ref3.wrapping_add(1) as u16;
-                    num_ref3 &= (*self).specialization.block_mask();
+                    num_ref3 &= self.specialization.block_mask();
                     let offset0: usize =
                         (mixed0 << self.specialization.block_bits()) + num_ref0 as usize;
                     let offset1: usize =
@@ -1366,10 +1366,10 @@ impl<
                     num[mixed1] = num_ref1.wrapping_add(1) as u16;
                     num[mixed2] = num_ref2.wrapping_add(1) as u16;
                     num[mixed3] = num_ref3.wrapping_add(1) as u16;
-                    num_ref0 &= (*self).specialization.block_mask();
-                    num_ref1 &= (*self).specialization.block_mask();
-                    num_ref2 &= (*self).specialization.block_mask();
-                    num_ref3 &= (*self).specialization.block_mask();
+                    num_ref0 &= self.specialization.block_mask();
+                    num_ref1 &= self.specialization.block_mask();
+                    num_ref2 &= self.specialization.block_mask();
+                    num_ref3 &= self.specialization.block_mask();
                     let offset0: usize =
                         (mixed0 << self.specialization.block_bits()) + num_ref0 as usize;
                     let offset1: usize =
@@ -1424,7 +1424,7 @@ impl<
                         * self.specialization.get_k_hash_mul())
                         & self.specialization.get_hash_mask();
                     let key = mixed_word >> shift;
-                    let minor_ix: usize = chunk_id & (*self).specialization.block_mask() as usize; //   *num_ref as usize & (*self).specialization.block_mask() as usize; //GIGANTIC HAX: overwrite firsst option
+                    let minor_ix: usize = chunk_id & self.specialization.block_mask() as usize; //   *num_ref as usize & (*self).specialization.block_mask() as usize; //GIGANTIC HAX: overwrite firsst option
                     let offset: usize =
                         minor_ix + (key << self.specialization.block_bits()) as usize;
                     buckets[offset] = (ix_offset + i) as u32;
@@ -1544,16 +1544,16 @@ impl<
             >> shift) as usize;
         let mut num_ref0 = u32::from(num[mixed0]);
         num[mixed0] = num_ref0.wrapping_add(1) as u16;
-        num_ref0 &= (*self).specialization.block_mask();
+        num_ref0 &= self.specialization.block_mask();
         let mut num_ref1 = u32::from(num[mixed1]);
         num[mixed1] = num_ref1.wrapping_add(1) as u16;
-        num_ref1 &= (*self).specialization.block_mask();
+        num_ref1 &= self.specialization.block_mask();
         let mut num_ref2 = u32::from(num[mixed2]);
         num[mixed2] = num_ref2.wrapping_add(1) as u16;
-        num_ref2 &= (*self).specialization.block_mask();
+        num_ref2 &= self.specialization.block_mask();
         let mut num_ref3 = u32::from(num[mixed3]);
         num[mixed3] = num_ref3.wrapping_add(1) as u16;
-        num_ref3 &= (*self).specialization.block_mask();
+        num_ref3 &= self.specialization.block_mask();
         let offset0: usize = (mixed0 << self.specialization.block_bits()) + num_ref0 as usize;
         let offset1: usize = (mixed1 << self.specialization.block_bits()) + num_ref1 as usize;
         let offset2: usize = (mixed2 << self.specialization.block_bits()) + num_ref2 as usize;
@@ -1607,16 +1607,16 @@ impl<
             >> shift) as usize;
         let mut num_ref0 = u32::from(num[mixed0]);
         num[mixed0] = num_ref0.wrapping_add(1) as u16;
-        num_ref0 &= (*self).specialization.block_mask();
+        num_ref0 &= self.specialization.block_mask();
         let mut num_ref1 = u32::from(num[mixed1]);
         num[mixed1] = num_ref1.wrapping_add(1) as u16;
-        num_ref1 &= (*self).specialization.block_mask();
+        num_ref1 &= self.specialization.block_mask();
         let mut num_ref2 = u32::from(num[mixed2]);
         num[mixed2] = num_ref2.wrapping_add(1) as u16;
-        num_ref2 &= (*self).specialization.block_mask();
+        num_ref2 &= self.specialization.block_mask();
         let mut num_ref3 = u32::from(num[mixed3]);
         num[mixed3] = num_ref3.wrapping_add(1) as u16;
-        num_ref3 &= (*self).specialization.block_mask();
+        num_ref3 &= self.specialization.block_mask();
         let offset0: usize = (mixed0 << self.specialization.block_bits()) + num_ref0 as usize;
         let offset1: usize = (mixed1 << self.specialization.block_bits()) + num_ref1 as usize;
         let offset2: usize = (mixed2 << self.specialization.block_bits()) + num_ref2 as usize;
@@ -1630,9 +1630,9 @@ impl<
         let (_, data_window) = data.split_at((ix & mask) as (usize));
         let key: u32 = self.HashBytes(data_window) as u32;
         let minor_ix: usize = (self.num.slice()[(key as (usize))] as (u32)
-            & (*self).specialization.block_mask() as u32) as (usize);
+            & self.specialization.block_mask() as u32) as (usize);
         let offset: usize =
-            minor_ix.wrapping_add((key << (*self).specialization.block_bits()) as (usize));
+            minor_ix.wrapping_add((key << self.specialization.block_bits()) as (usize));
         self.buckets.slice_mut()[offset] = ix as (u32);
         {
             let _lhs = &mut self.num.slice_mut()[(key as (usize))];
@@ -1683,11 +1683,11 @@ impl<
         let opts = self.Opts();
         let cur_ix_masked: usize = cur_ix & ring_buffer_mask;
         let mut is_match_found: i32 = 0i32;
-        let mut best_score: u64 = (*out).score;
-        let mut best_len: usize = (*out).len;
+        let mut best_score: u64 = out.score;
+        let mut best_len: usize = out.len;
         let mut i: usize;
-        (*out).len = 0usize;
-        (*out).len_x_code = 0usize;
+        out.len = 0usize;
+        out.len_x_code = 0usize;
         i = 0usize;
         let cur_data = data.split_at(cur_ix_masked).1;
         while i < self.GetHasherCommon.params.num_last_distances_to_check as (usize) {
@@ -1721,9 +1721,9 @@ impl<
                             if best_score < score {
                                 best_score = score;
                                 best_len = len;
-                                (*out).len = best_len;
-                                (*out).distance = backward;
-                                (*out).score = best_score;
+                                out.len = best_len;
+                                out.distance = backward;
+                                out.score = best_score;
                                 is_match_found = 1i32;
                             }
                         }
@@ -1743,19 +1743,19 @@ impl<
                 .slice_mut()
                 .split_at_mut((key << common_block_bits) as (usize))
                 .1
-                .split_at_mut((*self).specialization.block_size() as usize)
+                .split_at_mut(self.specialization.block_size() as usize)
                 .0;
-            assert!(bucket.len() > (*self).specialization.block_mask() as usize);
+            assert!(bucket.len() > self.specialization.block_mask() as usize);
             if num_copy != 0 {
                 let down: usize = core::cmp::max(
-                    i32::from(num_copy) - (*self).specialization.block_size() as i32,
+                    i32::from(num_copy) - self.specialization.block_size() as i32,
                     0,
                 ) as usize;
                 i = num_copy as (usize);
                 while i > down {
                     i -= 1;
                     let mut prev_ix =
-                        bucket[i & (*self).specialization.block_mask() as usize] as usize;
+                        bucket[i & self.specialization.block_mask() as usize] as usize;
                     let backward = cur_ix.wrapping_sub(prev_ix);
                     prev_ix &= ring_buffer_mask;
                     if (cur_ix_masked.wrapping_add(best_len) > ring_buffer_mask
@@ -1777,9 +1777,9 @@ impl<
                         if best_score < score {
                             best_score = score;
                             best_len = len;
-                            (*out).len = best_len;
-                            (*out).distance = backward;
-                            (*out).score = best_score;
+                            out.len = best_len;
+                            out.distance = backward;
+                            out.score = best_score;
                             is_match_found = 1i32;
                         }
                     }
@@ -1916,11 +1916,11 @@ fn TestStaticDictionaryItem(
     let score: u64;
     len = item & 0x1fusize;
     dist = item >> 5i32;
-    offset = ((*dictionary).offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(dist));
+    offset = (dictionary.offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(dist));
     if len > max_length {
         return 0i32;
     }
-    matchlen = FindMatchLengthWithLimit(data, &(*dictionary).data[offset..], len);
+    matchlen = FindMatchLengthWithLimit(data, &dictionary.data[offset..], len);
     if matchlen.wrapping_add(kCutoffTransformsCount as usize) <= len || matchlen == 0usize {
         return 0i32;
     }
@@ -1932,19 +1932,19 @@ fn TestStaticDictionaryItem(
         backward = max_backward
             .wrapping_add(dist)
             .wrapping_add(1usize)
-            .wrapping_add(transform_id << (*dictionary).size_bits_by_length[len] as (i32));
+            .wrapping_add(transform_id << dictionary.size_bits_by_length[len] as (i32));
     }
     if backward > max_distance {
         return 0i32;
     }
     score = BackwardReferenceScore(matchlen, backward, h9_opts);
-    if score < (*out).score {
+    if score < out.score {
         return 0i32;
     }
-    (*out).len = matchlen;
-    (*out).len_x_code = len ^ matchlen;
-    (*out).distance = backward;
-    (*out).score = score;
+    out.len = matchlen;
+    out.len_x_code = len ^ matchlen;
+    out.distance = backward;
+    out.score = score;
     1i32
 }
 
@@ -1964,7 +1964,7 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
     let mut is_match_found: i32 = 0i32;
     let opts = handle.Opts();
     let xself: &mut Struct1 = handle.GetHasherCommon();
-    if (*xself).dict_num_matches < (*xself).dict_num_lookups >> 7i32 {
+    if xself.dict_num_matches < xself.dict_num_lookups >> 7i32 {
         return 0i32;
     }
     key = (Hash14(data) << 1i32) as (usize); //FIXME: works for any kind of hasher??
@@ -1972,7 +1972,7 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
     while i < if shallow != 0 { 1u32 } else { 2u32 } as (usize) {
         {
             let item: usize = dictionary_hash[(key as (usize))] as (usize);
-            (*xself).dict_num_lookups = (*xself).dict_num_lookups.wrapping_add(1 as (usize));
+            xself.dict_num_lookups = xself.dict_num_lookups.wrapping_add(1 as (usize));
             if item != 0usize {
                 let item_matches: i32 = TestStaticDictionaryItem(
                     dictionary,
@@ -1985,8 +1985,7 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
                     out,
                 );
                 if item_matches != 0 {
-                    (*xself).dict_num_matches =
-                        (*xself).dict_num_matches.wrapping_add(1 as (usize));
+                    xself.dict_num_matches = xself.dict_num_matches.wrapping_add(1 as (usize));
                     is_match_found = 1i32;
                 }
             }
@@ -2469,7 +2468,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
     num_literals: &mut usize,
 ) {
     let gap = 0usize;
-    let max_backward_limit: usize = (1usize << (*params).lgwin).wrapping_sub(16usize);
+    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16usize);
     let mut new_commands_count: usize = 0;
     let mut insert_length: usize = *last_insert_len;
     let pos_end: usize = position.wrapping_add(num_bytes);
@@ -2525,7 +2524,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                         distance: 0,
                         score: 0,
                     };
-                    sr2.len = if (*params).quality < 5 {
+                    sr2.len = if params.quality < 5 {
                         brotli_min_size_t(sr.len.wrapping_sub(1usize), max_length)
                     } else {
                         0usize

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -128,7 +128,7 @@ fn CountLiterals(cmds: &[Command], num_commands: usize) -> usize {
 }
 
 fn CommandCopyLen(xself: &Command) -> u32 {
-    (*xself).copy_len_ & 0xffffffu32
+    xself.copy_len_ & 0xffffffu32
 }
 
 fn CopyLiteralsToByteArray(
@@ -866,10 +866,10 @@ fn ClusterBlocks<
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..(*split).types_alloc_size()]
-                .clone_from_slice(&(*split).types.slice()[..(*split).types_alloc_size()]);
+                .clone_from_slice(&split.types.slice()[..(*split).types_alloc_size()]);
             <Alloc as Allocator<u8>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).types, new_array),
+                core::mem::replace(&mut split.types, new_array),
             );
         }
     }
@@ -885,10 +885,10 @@ fn ClusterBlocks<
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..(*split).lengths_alloc_size()]
-                .clone_from_slice((*split).lengths.slice());
+                .clone_from_slice(split.lengths.slice());
             <Alloc as Allocator<u32>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).lengths, new_array),
+                core::mem::replace(&mut split.lengths, new_array),
             );
         }
     }
@@ -907,8 +907,8 @@ fn ClusterBlocks<
                     let id: u8 = new_index.slice()
                         [(histogram_symbols.slice()[(i as (usize))] as (usize))]
                         as (u8);
-                    (*split).types.slice_mut()[(block_idx as (usize))] = id;
-                    (*split).lengths.slice_mut()[(block_idx as (usize))] = cur_length;
+                    split.types.slice_mut()[(block_idx as (usize))] = id;
+                    split.lengths.slice_mut()[(block_idx as (usize))] = cur_length;
                     max_type = brotli_max_uint8_t(max_type, id);
                     cur_length = 0u32;
                     block_idx = block_idx.wrapping_add(1 as (usize));
@@ -916,8 +916,8 @@ fn ClusterBlocks<
             }
             i = i.wrapping_add(1 as (usize));
         }
-        (*split).num_blocks = block_idx;
-        (*split).num_types = (max_type as (usize)).wrapping_add(1usize);
+        split.num_blocks = block_idx;
+        split.num_types = (max_type as (usize)).wrapping_add(1usize);
     }
     <Alloc as Allocator<u32>>::free_cell(alloc, new_index);
     <Alloc as Allocator<u32>>::free_cell(alloc, block_lengths);
@@ -956,52 +956,52 @@ fn SplitByteVector<
         num_histograms = max_histograms;
     }
     if length == 0usize {
-        (*split).num_types = 1usize;
+        split.num_types = 1usize;
         return;
     } else if length < kMinLengthForBlockSplitting {
         {
-            if (*split).types_alloc_size() < (*split).num_blocks.wrapping_add(1usize) {
+            if (*split).types_alloc_size() < split.num_blocks.wrapping_add(1usize) {
                 let mut _new_size: usize = if (*split).types_alloc_size() == 0usize {
-                    (*split).num_blocks.wrapping_add(1usize)
+                    split.num_blocks.wrapping_add(1usize)
                 } else {
                     (*split).types_alloc_size()
                 };
 
-                while _new_size < (*split).num_blocks.wrapping_add(1usize) {
+                while _new_size < split.num_blocks.wrapping_add(1usize) {
                     _new_size = _new_size.wrapping_mul(2usize);
                 }
                 let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
                 new_array.slice_mut()[..(*split).types_alloc_size()]
-                    .clone_from_slice(&(*split).types.slice()[..(*split).types_alloc_size()]);
+                    .clone_from_slice(&split.types.slice()[..(*split).types_alloc_size()]);
                 <Alloc as Allocator<u8>>::free_cell(
                     alloc,
-                    core::mem::replace(&mut (*split).types, new_array),
+                    core::mem::replace(&mut split.types, new_array),
                 );
             }
         }
         {
-            if (*split).lengths_alloc_size() < (*split).num_blocks.wrapping_add(1usize) {
+            if (*split).lengths_alloc_size() < split.num_blocks.wrapping_add(1usize) {
                 let mut _new_size: usize = if (*split).lengths_alloc_size() == 0usize {
-                    (*split).num_blocks.wrapping_add(1usize)
+                    split.num_blocks.wrapping_add(1usize)
                 } else {
                     (*split).lengths_alloc_size()
                 };
-                while _new_size < (*split).num_blocks.wrapping_add(1usize) {
+                while _new_size < split.num_blocks.wrapping_add(1usize) {
                     _new_size = _new_size.wrapping_mul(2usize);
                 }
                 let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
                 new_array.slice_mut()[..(*split).lengths_alloc_size()]
-                    .clone_from_slice(&(*split).lengths.slice()[..(*split).lengths_alloc_size()]);
+                    .clone_from_slice(&split.lengths.slice()[..(*split).lengths_alloc_size()]);
                 <Alloc as Allocator<u32>>::free_cell(
                     alloc,
-                    core::mem::replace(&mut (*split).lengths, new_array),
+                    core::mem::replace(&mut split.lengths, new_array),
                 );
             }
         }
-        (*split).num_types = 1usize;
-        (*split).types.slice_mut()[((*split).num_blocks as (usize))] = 0i32 as (u8);
-        (*split).lengths.slice_mut()[((*split).num_blocks as (usize))] = length as (u32);
-        (*split).num_blocks = (*split).num_blocks.wrapping_add(1 as (usize));
+        split.num_types = 1usize;
+        split.types.slice_mut()[(split.num_blocks as (usize))] = 0i32 as (u8);
+        split.lengths.slice_mut()[(split.num_blocks as (usize))] = length as (u32);
+        split.num_blocks = split.num_blocks.wrapping_add(1 as (usize));
         return;
     }
     let mut histograms = <Alloc as Allocator<HistogramType>>::alloc_cell(alloc, num_histograms);
@@ -1033,7 +1033,7 @@ fn SplitByteVector<
         let mut switch_signal =
             <Alloc as Allocator<u8>>::alloc_cell(alloc, length.wrapping_mul(bitmaplen));
         let mut new_id = <Alloc as Allocator<u16>>::alloc_cell(alloc, num_histograms);
-        let iters: usize = (if (*params).quality <= 11 { 3i32 } else { 10i32 }) as (usize);
+        let iters: usize = (if params.quality <= 11 { 3i32 } else { 10i32 }) as (usize);
         let mut i: usize;
         i = 0usize;
         while i < iters {
@@ -1157,12 +1157,12 @@ pub fn BrotliSplitBlock<
         while i < num_commands {
             {
                 let cmd = &cmds[(i as (usize))];
-                if CommandCopyLen(cmd) != 0 && ((*cmd).cmd_prefix_ as (i32) >= 128i32) {
+                if CommandCopyLen(cmd) != 0 && (cmd.cmd_prefix_ as (i32) >= 128i32) {
                     distance_prefixes.slice_mut()[({
                         let _old = j;
                         j = j.wrapping_add(1 as (usize));
                         _old
-                    } as (usize))] = (*cmd).dist_prefix_ & 0x3ff;
+                    } as (usize))] = cmd.dist_prefix_ & 0x3ff;
                 }
             }
             i = i.wrapping_add(1 as (usize));

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1069,7 +1069,7 @@ pub struct SimpleSortHuffmanTree {}
 
 impl HuffmanComparator for SimpleSortHuffmanTree {
     fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
-        return (*v0).total_count_ < (*v1).total_count_;
+        return v0.total_count_ < v1.total_count_;
     }
 }
 
@@ -1540,15 +1540,15 @@ fn NewBlockEncoder<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 }
 
 fn NextBlockTypeCode(calculator: &mut BlockTypeCodeCalculator, type_: u8) -> usize {
-    let type_code: usize = (if type_ as (usize) == (*calculator).last_type.wrapping_add(1usize) {
+    let type_code: usize = (if type_ as (usize) == calculator.last_type.wrapping_add(1usize) {
         1u32
-    } else if type_ as (usize) == (*calculator).second_last_type {
+    } else if type_ as (usize) == calculator.second_last_type {
         0u32
     } else {
         (type_ as (u32)).wrapping_add(2u32)
     }) as (usize);
-    (*calculator).second_last_type = (*calculator).last_type;
-    (*calculator).last_type = type_ as (usize);
+    calculator.second_last_type = calculator.last_type;
+    calculator.last_type = type_ as (usize);
     type_code
 }
 
@@ -1757,22 +1757,22 @@ fn StoreBlockSwitch(
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
-    let typecode: usize = NextBlockTypeCode(&mut (*code).type_code_calculator, block_type);
+    let typecode: usize = NextBlockTypeCode(&mut code.type_code_calculator, block_type);
     let mut lencode: usize = 0;
     let mut len_nextra: u32 = 0;
     let mut len_extra: u32 = 0;
     if is_first_block == 0 {
         BrotliWriteBits(
-            (*code).type_depths[typecode] as (u8),
-            (*code).type_bits[typecode] as (u64),
+            code.type_depths[typecode] as (u8),
+            code.type_bits[typecode] as (u64),
             storage_ix,
             storage,
         );
     }
     GetBlockLengthPrefixCode(block_len, &mut lencode, &mut len_nextra, &mut len_extra);
     BrotliWriteBits(
-        (*code).length_depths[lencode] as (u8),
-        (*code).length_bits[lencode] as (u64),
+        code.length_depths[lencode] as (u8),
+        code.length_bits[lencode] as (u64),
         storage_ix,
         storage,
     );
@@ -1819,8 +1819,8 @@ fn BuildAndStoreBlockSplitCode(
             num_types.wrapping_add(2usize),
             num_types.wrapping_add(2usize),
             tree,
-            &mut (*code).type_depths[0usize..],
-            &mut (*code).type_bits[0usize..],
+            &mut code.type_depths[0usize..],
+            &mut code.type_bits[0usize..],
             storage_ix,
             storage,
         );
@@ -1829,8 +1829,8 @@ fn BuildAndStoreBlockSplitCode(
             super::constants::BROTLI_NUM_BLOCK_LEN_SYMBOLS, // 26
             super::constants::BROTLI_NUM_BLOCK_LEN_SYMBOLS,
             tree,
-            &mut (*code).length_depths[0usize..],
-            &mut (*code).length_bits[0usize..],
+            &mut code.length_depths[0usize..],
+            &mut code.length_bits[0usize..],
             storage_ix,
             storage,
         );
@@ -1852,12 +1852,12 @@ fn BuildAndStoreBlockSwitchEntropyCodes<'a, Alloc: alloc::Allocator<u8> + alloc:
     storage: &mut [u8],
 ) {
     BuildAndStoreBlockSplitCode(
-        (*xself).block_types_,
-        (*xself).block_lengths_,
-        (*xself).num_blocks_,
-        (*xself).num_block_types_,
+        xself.block_types_,
+        xself.block_lengths_,
+        xself.num_blocks_,
+        xself.num_block_types_,
         tree,
-        &mut (*xself).block_split_code_,
+        &mut xself.block_split_code_,
         storage_ix,
         storage,
     );
@@ -2199,12 +2199,12 @@ fn BuildAndStoreEntropyCodes<
     storage: &mut [u8],
 ) {
     let table_size: usize = histograms_size.wrapping_mul(xself.histogram_length_);
-    (*xself).depths_ = if table_size != 0 {
+    xself.depths_ = if table_size != 0 {
         <Alloc as Allocator<u8>>::alloc_cell(m, table_size)
     } else {
         <Alloc as Allocator<u8>>::AllocatedMemory::default()
     };
-    (*xself).bits_ = if table_size != 0 {
+    xself.bits_ = if table_size != 0 {
         <Alloc as Allocator<u16>>::alloc_cell(m, table_size)
     } else {
         <Alloc as Allocator<u16>>::AllocatedMemory::default()
@@ -2220,8 +2220,8 @@ fn BuildAndStoreEntropyCodes<
                     xself.histogram_length_,
                     alphabet_size,
                     tree,
-                    &mut (*xself).depths_.slice_mut()[(ix as (usize))..],
-                    &mut (*xself).bits_.slice_mut()[(ix as (usize))..],
+                    &mut xself.depths_.slice_mut()[(ix as (usize))..],
+                    &mut xself.bits_.slice_mut()[(ix as (usize))..],
                     storage_ix,
                     storage,
                 );
@@ -2237,17 +2237,17 @@ fn StoreSymbol<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
-    if (*xself).block_len_ == 0usize {
+    if xself.block_len_ == 0usize {
         let block_ix: usize = {
-            (*xself).block_ix_ = (*xself).block_ix_.wrapping_add(1 as (usize));
-            (*xself).block_ix_
+            xself.block_ix_ = xself.block_ix_.wrapping_add(1 as (usize));
+            xself.block_ix_
         };
-        let block_len: u32 = (*xself).block_lengths_[(block_ix as (usize))];
-        let block_type: u8 = (*xself).block_types_[(block_ix as (usize))];
-        (*xself).block_len_ = block_len as (usize);
-        (*xself).entropy_ix_ = (block_type as (usize)).wrapping_mul((*xself).histogram_length_);
+        let block_len: u32 = xself.block_lengths_[(block_ix as (usize))];
+        let block_type: u8 = xself.block_types_[(block_ix as (usize))];
+        xself.block_len_ = block_len as (usize);
+        xself.entropy_ix_ = (block_type as (usize)).wrapping_mul(xself.histogram_length_);
         StoreBlockSwitch(
-            &mut (*xself).block_split_code_,
+            &mut xself.block_split_code_,
             block_len,
             block_type,
             0i32,
@@ -2255,12 +2255,12 @@ fn StoreSymbol<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
             storage,
         );
     }
-    (*xself).block_len_ = (*xself).block_len_.wrapping_sub(1 as (usize));
+    xself.block_len_ = xself.block_len_.wrapping_sub(1 as (usize));
     {
-        let ix: usize = (*xself).entropy_ix_.wrapping_add(symbol);
+        let ix: usize = xself.entropy_ix_.wrapping_add(symbol);
         BrotliWriteBits(
-            (*xself).depths_.slice()[(ix as (usize))] as (u8),
-            (*xself).bits_.slice()[(ix as (usize))] as (u64),
+            xself.depths_.slice()[(ix as (usize))] as (u8),
+            xself.bits_.slice()[(ix as (usize))] as (u64),
             storage_ix,
             storage,
         );
@@ -2290,10 +2290,10 @@ fn GetCopyExtra(copycode: u16) -> u32 {
 
 fn StoreCommandExtra(cmd: &Command, storage_ix: &mut usize, storage: &mut [u8]) {
     let copylen_code: u32 = CommandCopyLenCode(cmd);
-    let inscode: u16 = GetInsertLengthCode((*cmd).insert_len_ as (usize));
+    let inscode: u16 = GetInsertLengthCode(cmd.insert_len_ as (usize));
     let copycode: u16 = GetCopyLengthCode(copylen_code as (usize));
     let insnumextra: u32 = GetInsertExtra(inscode);
-    let insextraval: u64 = (*cmd).insert_len_.wrapping_sub(GetInsertBase(inscode)) as (u64);
+    let insextraval: u64 = cmd.insert_len_.wrapping_sub(GetInsertBase(inscode)) as (u64);
     let copyextraval: u64 = copylen_code.wrapping_sub(GetCopyBase(copycode)) as (u64);
     let bits: u64 = copyextraval << insnumextra | insextraval;
     BrotliWriteBits(
@@ -2334,17 +2334,17 @@ fn StoreSymbolWithContext<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     storage: &mut [u8],
     context_bits: usize,
 ) {
-    if (*xself).block_len_ == 0usize {
+    if xself.block_len_ == 0usize {
         let block_ix: usize = {
-            (*xself).block_ix_ = (*xself).block_ix_.wrapping_add(1 as (usize));
-            (*xself).block_ix_
+            xself.block_ix_ = xself.block_ix_.wrapping_add(1 as (usize));
+            xself.block_ix_
         };
-        let block_len: u32 = (*xself).block_lengths_[(block_ix as (usize))];
-        let block_type: u8 = (*xself).block_types_[(block_ix as (usize))];
-        (*xself).block_len_ = block_len as (usize);
-        (*xself).entropy_ix_ = block_type as (usize) << context_bits;
+        let block_len: u32 = xself.block_lengths_[(block_ix as (usize))];
+        let block_type: u8 = xself.block_types_[(block_ix as (usize))];
+        xself.block_len_ = block_len as (usize);
+        xself.entropy_ix_ = block_type as (usize) << context_bits;
         StoreBlockSwitch(
-            &mut (*xself).block_split_code_,
+            &mut xself.block_split_code_,
             block_len,
             block_type,
             0i32,
@@ -2352,16 +2352,16 @@ fn StoreSymbolWithContext<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
             storage,
         );
     }
-    (*xself).block_len_ = (*xself).block_len_.wrapping_sub(1 as (usize));
+    xself.block_len_ = xself.block_len_.wrapping_sub(1 as (usize));
     {
         let histo_ix: usize =
-            context_map[((*xself).entropy_ix_.wrapping_add(context) as (usize))] as (usize);
+            context_map[(xself.entropy_ix_.wrapping_add(context) as (usize))] as (usize);
         let ix: usize = histo_ix
-            .wrapping_mul((*xself).histogram_length_)
+            .wrapping_mul(xself.histogram_length_)
             .wrapping_add(symbol);
         BrotliWriteBits(
-            (*xself).depths_.slice()[(ix as (usize))] as (u8),
-            (*xself).bits_.slice()[(ix as (usize))] as (u64),
+            xself.depths_.slice()[(ix as (usize))] as (u8),
+            xself.bits_.slice()[(ix as (usize))] as (u64),
             storage_ix,
             storage,
         );
@@ -2369,12 +2369,12 @@ fn StoreSymbolWithContext<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 }
 
 fn CommandCopyLen(xself: &Command) -> u32 {
-    (*xself).copy_len_ & 0xffffffu32
+    xself.copy_len_ & 0xffffffu32
 }
 
 fn CommandDistanceContext(xself: &Command) -> u32 {
-    let r: u32 = ((*xself).cmd_prefix_ as (i32) >> 6i32) as (u32);
-    let c: u32 = ((*xself).cmd_prefix_ as (i32) & 7i32) as (u32);
+    let r: u32 = (xself.cmd_prefix_ as (i32) >> 6i32) as (u32);
+    let c: u32 = (xself.cmd_prefix_ as (i32) & 7i32) as (u32);
     if (r == 0u32 || r == 2u32 || r == 4u32 || r == 7u32) && (c <= 2u32) {
         return c;
     }
@@ -2388,14 +2388,14 @@ fn CleanupBlockEncoder<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     <Alloc as Allocator<u8>>::free_cell(
         m,
         core::mem::replace(
-            &mut (*xself).depths_,
+            &mut xself.depths_,
             <Alloc as Allocator<u8>>::AllocatedMemory::default(),
         ),
     );
     <Alloc as Allocator<u16>>::free_cell(
         m,
         core::mem::replace(
-            &mut (*xself).bits_,
+            &mut xself.bits_,
             <Alloc as Allocator<u16>>::AllocatedMemory::default(),
         ),
     );
@@ -2470,24 +2470,24 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     };
     literal_enc = NewBlockEncoder::<Alloc>(
         BROTLI_NUM_LITERAL_SYMBOLS,
-        (*mb).literal_split.num_types,
-        (*mb).literal_split.types.slice(),
-        (*mb).literal_split.lengths.slice(),
-        (*mb).literal_split.num_blocks,
+        mb.literal_split.num_types,
+        mb.literal_split.types.slice(),
+        mb.literal_split.lengths.slice(),
+        mb.literal_split.num_blocks,
     );
     command_enc = NewBlockEncoder::<Alloc>(
         BROTLI_NUM_COMMAND_SYMBOLS,
-        (*mb).command_split.num_types,
-        (*mb).command_split.types.slice(),
-        (*mb).command_split.lengths.slice(),
-        (*mb).command_split.num_blocks,
+        mb.command_split.num_types,
+        mb.command_split.types.slice(),
+        mb.command_split.lengths.slice(),
+        mb.command_split.num_blocks,
     );
     distance_enc = NewBlockEncoder::<Alloc>(
         num_effective_distance_symbols,
-        (*mb).distance_split.num_types,
-        (*mb).distance_split.types.slice(),
-        (*mb).distance_split.lengths.slice(),
-        (*mb).distance_split.num_blocks,
+        mb.distance_split.num_types,
+        mb.distance_split.types.slice(),
+        mb.distance_split.lengths.slice(),
+        mb.distance_split.num_blocks,
     );
     BuildAndStoreBlockSwitchEntropyCodes(&mut literal_enc, tree.slice_mut(), storage_ix, storage);
     BuildAndStoreBlockSwitchEntropyCodes(&mut command_enc, tree.slice_mut(), storage_ix, storage);
@@ -2500,15 +2500,15 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
         storage,
     );
     i = 0usize;
-    while i < (*mb).literal_split.num_types {
+    while i < mb.literal_split.num_types {
         {
             BrotliWriteBits(2, literal_context_mode as (u64), storage_ix, storage);
         }
         i = i.wrapping_add(1 as (usize));
     }
-    if (*mb).literal_context_map_size == 0usize {
+    if mb.literal_context_map_size == 0usize {
         StoreTrivialContextMap(
-            (*mb).literal_histograms_size,
+            mb.literal_histograms_size,
             6,
             tree.slice_mut(),
             storage_ix,
@@ -2517,17 +2517,17 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     } else {
         EncodeContextMap(
             alloc,
-            (*mb).literal_context_map.slice(),
-            (*mb).literal_context_map_size,
-            (*mb).literal_histograms_size,
+            mb.literal_context_map.slice(),
+            mb.literal_context_map_size,
+            mb.literal_histograms_size,
             tree.slice_mut(),
             storage_ix,
             storage,
         );
     }
-    if (*mb).distance_context_map_size == 0usize {
+    if mb.distance_context_map_size == 0usize {
         StoreTrivialContextMap(
-            (*mb).distance_histograms_size,
+            mb.distance_histograms_size,
             2usize,
             tree.slice_mut(),
             storage_ix,
@@ -2536,9 +2536,9 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     } else {
         EncodeContextMap(
             alloc,
-            (*mb).distance_context_map.slice(),
-            (*mb).distance_context_map_size,
-            (*mb).distance_histograms_size,
+            mb.distance_context_map.slice(),
+            mb.distance_context_map_size,
+            mb.distance_histograms_size,
             tree.slice_mut(),
             storage_ix,
             storage,
@@ -2547,8 +2547,8 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     BuildAndStoreEntropyCodes(
         alloc,
         &mut literal_enc,
-        (*mb).literal_histograms.slice(),
-        (*mb).literal_histograms_size,
+        mb.literal_histograms.slice(),
+        mb.literal_histograms_size,
         BROTLI_NUM_LITERAL_SYMBOLS,
         tree.slice_mut(),
         storage_ix,
@@ -2557,8 +2557,8 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     BuildAndStoreEntropyCodes(
         alloc,
         &mut command_enc,
-        (*mb).command_histograms.slice(),
-        (*mb).command_histograms_size,
+        mb.command_histograms.slice(),
+        mb.command_histograms_size,
         BROTLI_NUM_COMMAND_SYMBOLS,
         tree.slice_mut(),
         storage_ix,
@@ -2567,8 +2567,8 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     BuildAndStoreEntropyCodes(
         alloc,
         &mut distance_enc,
-        (*mb).distance_histograms.slice(),
-        (*mb).distance_histograms_size,
+        mb.distance_histograms.slice(),
+        mb.distance_histograms_size,
         num_distance_symbols as usize,
         tree.slice_mut(),
         storage_ix,
@@ -2590,7 +2590,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
             let cmd_code: usize = cmd.cmd_prefix_ as (usize);
             StoreSymbol(&mut command_enc, cmd_code, storage_ix, storage);
             StoreCommandExtra(&cmd, storage_ix, storage);
-            if (*mb).literal_context_map_size == 0usize {
+            if mb.literal_context_map_size == 0usize {
                 let mut j: usize;
                 j = cmd.insert_len_ as (usize);
                 while j != 0usize {
@@ -2617,7 +2617,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
                             &mut literal_enc,
                             literal as (usize),
                             context,
-                            (*mb).literal_context_map.slice(),
+                            mb.literal_context_map.slice(),
                             storage_ix,
                             storage,
                             6usize,
@@ -2637,7 +2637,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
                     let dist_code: usize = cmd.dist_prefix_ as (usize) & 0x3ff;
                     let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10i32; //FIXME: from command
                     let distextra: u64 = cmd.dist_extra_ as (u64);
-                    if (*mb).distance_context_map_size == 0usize {
+                    if mb.distance_context_map_size == 0usize {
                         StoreSymbol(&mut distance_enc, dist_code, storage_ix, storage);
                     } else {
                         let context: usize = CommandDistanceContext(&cmd) as (usize);
@@ -2645,7 +2645,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
                             &mut distance_enc,
                             dist_code,
                             context,
-                            (*mb).distance_context_map.slice(),
+                            mb.distance_context_map.slice(),
                             storage_ix,
                             storage,
                             2usize,

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -47,13 +47,13 @@ fn brotli_max_double(a: super::util::floatX, b: super::util::floatX) -> super::u
 
 #[inline(always)]
 fn HistogramPairIsLess(p1: &HistogramPair, p2: &HistogramPair) -> bool {
-    if (*p1).cost_diff != (*p2).cost_diff {
-        if !!((*p1).cost_diff > (*p2).cost_diff) {
+    if p1.cost_diff != p2.cost_diff {
+        if !!(p1.cost_diff > p2.cost_diff) {
             true
         } else {
             false
         }
-    } else if !!((*p1).idx2.wrapping_sub((*p1).idx1) > (*p2).idx2.wrapping_sub((*p2).idx1)) {
+    } else if !!(p1.idx2.wrapping_sub(p1.idx1) > p2.idx2.wrapping_sub(p2.idx1)) {
         true
     } else {
         false

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -31,12 +31,12 @@ impl Default for Command {
     }
 }
 pub fn CommandCopyLen(xself: &Command) -> u32 {
-    (*xself).copy_len_ & 0x1ffffffi32 as (u32)
+    xself.copy_len_ & 0x1ffffffi32 as (u32)
 }
 
 pub fn CommandDistanceContext(xself: &Command) -> u32 {
-    let r: u32 = ((*xself).cmd_prefix_ as (i32) >> 6i32) as (u32);
-    let c: u32 = ((*xself).cmd_prefix_ as (i32) & 7i32) as (u32);
+    let r: u32 = (xself.cmd_prefix_ as (i32) >> 6i32) as (u32);
+    let c: u32 = (xself.cmd_prefix_ as (i32) & 7i32) as (u32);
     if (r == 0i32 as (u32) || r == 2i32 as (u32) || r == 4i32 as (u32) || r == 7i32 as (u32))
         && (c <= 2i32 as (u32))
     {
@@ -170,14 +170,14 @@ pub fn PrefixEncodeCopyDistance(
     }
 }
 pub fn CommandRestoreDistanceCode(xself: &Command, dist: &BrotliDistanceParams) -> u32 {
-    if ((*xself).dist_prefix_ as (i32) & 0x3ff)
+    if (xself.dist_prefix_ as (i32) & 0x3ff)
         < BROTLI_NUM_DISTANCE_SHORT_CODES as i32 + dist.num_direct_distance_codes as i32
     {
-        (*xself).dist_prefix_ as (u32) & 0x3ff
+        xself.dist_prefix_ as (u32) & 0x3ff
     } else {
         let dcode = xself.dist_prefix_ as u32 & 0x3ff;
-        let nbits: u32 = u32::from((*xself).dist_prefix_ >> 10);
-        let extra: u32 = (*xself).dist_extra_;
+        let nbits: u32 = u32::from(xself.dist_prefix_ >> 10);
+        let extra: u32 = xself.dist_extra_;
         let postfix_mask = (1u32 << dist.distance_postfix_bits) - 1;
         let hcode = dcode
             .wrapping_sub(dist.num_direct_distance_codes)
@@ -381,13 +381,13 @@ pub fn RecomputeDistancePrefixes(
     while i < num_commands {
         {
             let cmd: &mut Command = &mut cmds[(i as (usize))];
-            if CommandCopyLen(cmd) != 0 && ((*cmd).cmd_prefix_ as (i32) >= 128i32) {
+            if CommandCopyLen(cmd) != 0 && (cmd.cmd_prefix_ as (i32) >= 128i32) {
                 PrefixEncodeCopyDistance(
                     CommandRestoreDistanceCode(cmd, dist) as (usize),
                     num_direct_distance_codes as (usize),
                     distance_postfix_bits as (u64),
-                    &mut (*cmd).dist_prefix_,
-                    &mut (*cmd).dist_extra_,
+                    &mut cmd.dist_prefix_,
+                    &mut cmd.dist_extra_,
                 );
             }
         }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -350,7 +350,7 @@ pub fn BrotliEncoderSetParameter<Alloc: BrotliAlloc>(
     p: BrotliEncoderParameter,
     value: u32,
 ) -> i32 {
-    if (*state).is_initialized_ {
+    if state.is_initialized_ {
         return 0i32;
     }
     set_parameter(&mut state.params, p, value)
@@ -577,7 +577,7 @@ fn BrotliEncoderCleanupState<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruc
         <Alloc as Allocator<u8>>::free_cell(
             &mut s.m8,
             core::mem::replace(
-                &mut (*s).storage_,
+                &mut s.storage_,
                 <Alloc as Allocator<u8>>::AllocatedMemory::default(),
             ),
         );
@@ -586,18 +586,18 @@ fn BrotliEncoderCleanupState<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruc
         <Alloc as Allocator<Command>>::free_cell(
             &mut s.m8,
             core::mem::replace(
-                &mut (*s).commands_,
+                &mut s.commands_,
                 <Alloc as Allocator<Command>>::AllocatedMemory::default(),
             ),
         );
     }
-    RingBufferFree(&mut s.m8, &mut (*s).ringbuffer_);
-    DestroyHasher(&mut s.m8, &mut (*s).hasher_);
+    RingBufferFree(&mut s.m8, &mut s.ringbuffer_);
+    DestroyHasher(&mut s.m8, &mut s.hasher_);
     {
         <Alloc as Allocator<i32>>::free_cell(
             &mut s.m8,
             core::mem::replace(
-                &mut (*s).large_table_,
+                &mut s.large_table_,
                 <Alloc as Allocator<i32>>::AllocatedMemory::default(),
             ),
         );
@@ -606,7 +606,7 @@ fn BrotliEncoderCleanupState<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruc
         <Alloc as Allocator<u32>>::free_cell(
             &mut s.m8,
             core::mem::replace(
-                &mut (*s).command_buf_,
+                &mut s.command_buf_,
                 <Alloc as Allocator<u32>>::AllocatedMemory::default(),
             ),
         );
@@ -615,7 +615,7 @@ fn BrotliEncoderCleanupState<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruc
         <Alloc as Allocator<u8>>::free_cell(
             &mut s.m8,
             core::mem::replace(
-                &mut (*s).literal_buf_,
+                &mut s.literal_buf_,
                 <Alloc as Allocator<u8>>::AllocatedMemory::default(),
             ),
         );
@@ -652,16 +652,16 @@ fn check_large_window_ok() -> bool {
 }
 
 pub fn SanitizeParams(params: &mut BrotliEncoderParams) {
-    (*params).quality = brotli_min_int(11i32, brotli_max_int(0i32, (*params).quality));
-    if (*params).lgwin < 10i32 {
-        (*params).lgwin = 10i32;
-    } else if (*params).lgwin > 24i32 {
+    params.quality = brotli_min_int(11i32, brotli_max_int(0i32, params.quality));
+    if params.lgwin < 10i32 {
+        params.lgwin = 10i32;
+    } else if params.lgwin > 24i32 {
         if params.large_window && check_large_window_ok() {
-            if (*params).lgwin > 30i32 {
-                (*params).lgwin = 30i32;
+            if params.lgwin > 30i32 {
+                params.lgwin = 30i32;
             }
         } else {
-            (*params).lgwin = 24i32;
+            params.lgwin = 24i32;
         }
     }
     if params.catable {
@@ -670,15 +670,15 @@ pub fn SanitizeParams(params: &mut BrotliEncoderParams) {
 }
 
 fn ComputeLgBlock(params: &BrotliEncoderParams) -> i32 {
-    let mut lgblock: i32 = (*params).lgblock;
-    if (*params).quality == 0i32 || (*params).quality == 1i32 {
-        lgblock = (*params).lgwin;
-    } else if (*params).quality < 4i32 {
+    let mut lgblock: i32 = params.lgblock;
+    if params.quality == 0i32 || params.quality == 1i32 {
+        lgblock = params.lgwin;
+    } else if params.quality < 4i32 {
         lgblock = 14i32;
     } else if lgblock == 0i32 {
         lgblock = 16i32;
-        if (*params).quality >= 9i32 && ((*params).lgwin > lgblock) {
-            lgblock = brotli_min_int(18i32, (*params).lgwin);
+        if params.quality >= 9i32 && (params.lgwin > lgblock) {
+            lgblock = brotli_min_int(18i32, params.lgwin);
         }
     } else {
         lgblock = brotli_min_int(24i32, brotli_max_int(16i32, lgblock));
@@ -687,7 +687,7 @@ fn ComputeLgBlock(params: &BrotliEncoderParams) -> i32 {
 }
 
 fn ComputeRbBits(params: &BrotliEncoderParams) -> i32 {
-    1i32 + brotli_max_int((*params).lgwin, (*params).lgblock)
+    1i32 + brotli_max_int(params.lgwin, params.lgblock)
 }
 
 fn RingBufferSetup<AllocU8: alloc::Allocator<u8>>(
@@ -695,11 +695,11 @@ fn RingBufferSetup<AllocU8: alloc::Allocator<u8>>(
     rb: &mut RingBuffer<AllocU8>,
 ) {
     let window_bits: i32 = ComputeRbBits(params);
-    let tail_bits: i32 = (*params).lgblock;
-    *(&mut (*rb).size_) = 1u32 << window_bits;
-    *(&mut (*rb).mask_) = (1u32 << window_bits).wrapping_sub(1u32);
-    *(&mut (*rb).tail_size_) = 1u32 << tail_bits;
-    *(&mut (*rb).total_size_) = (*rb).size_.wrapping_add((*rb).tail_size_);
+    let tail_bits: i32 = params.lgblock;
+    *(&mut rb.size_) = 1u32 << window_bits;
+    *(&mut rb.mask_) = (1u32 << window_bits).wrapping_sub(1u32);
+    *(&mut rb.tail_size_) = 1u32 << tail_bits;
+    *(&mut rb.total_size_) = rb.size_.wrapping_add(rb.tail_size_);
 }
 
 fn EncodeWindowBits(
@@ -763,32 +763,32 @@ fn InitCommandPrefixCodes(
 }
 
 fn EnsureInitialized<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) -> i32 {
-    if (*s).is_initialized_ {
+    if s.is_initialized_ {
         return 1i32;
     }
-    SanitizeParams(&mut (*s).params);
-    (*s).params.lgblock = ComputeLgBlock(&mut (*s).params);
+    SanitizeParams(&mut s.params);
+    s.params.lgblock = ComputeLgBlock(&mut s.params);
     ChooseDistanceParams(&mut s.params);
-    (*s).remaining_metadata_bytes_ = !(0u32);
-    RingBufferSetup(&mut (*s).params, &mut (*s).ringbuffer_);
+    s.remaining_metadata_bytes_ = !(0u32);
+    RingBufferSetup(&mut s.params, &mut s.ringbuffer_);
     {
-        let mut lgwin: i32 = (*s).params.lgwin;
-        if (*s).params.quality == 0i32 || (*s).params.quality == 1i32 {
+        let mut lgwin: i32 = s.params.lgwin;
+        if s.params.quality == 0i32 || s.params.quality == 1i32 {
             lgwin = brotli_max_int(lgwin, 18i32);
         }
         EncodeWindowBits(
             lgwin,
             s.params.large_window,
-            &mut (*s).last_bytes_,
-            &mut (*s).last_bytes_bits_,
+            &mut s.last_bytes_,
+            &mut s.last_bytes_bits_,
         );
     }
-    if (*s).params.quality == 0i32 {
+    if s.params.quality == 0i32 {
         InitCommandPrefixCodes(
-            &mut (*s).cmd_depths_[..],
-            &mut (*s).cmd_bits_[..],
-            &mut (*s).cmd_code_[..],
-            &mut (*s).cmd_code_numbits_,
+            &mut s.cmd_depths_[..],
+            &mut s.cmd_bits_[..],
+            &mut s.cmd_code_[..],
+            &mut s.cmd_code_numbits_,
         );
     }
     if s.params.catable {
@@ -802,7 +802,7 @@ fn EnsureInitialized<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>
             *item = 0x7ffffff0;
         }
     }
-    (*s).is_initialized_ = true;
+    s.is_initialized_ = true;
     1i32
 }
 
@@ -816,26 +816,26 @@ fn RingBufferInitBuffer<AllocU8: alloc::Allocator<u8>>(
         ((2u32).wrapping_add(buflen) as (usize)).wrapping_add(kSlackForEightByteHashingEverywhere),
     );
     let mut i: usize;
-    if (*rb).data_mo.slice().len() != 0 {
-        let lim: usize = ((2u32).wrapping_add((*rb).cur_size_) as (usize))
+    if rb.data_mo.slice().len() != 0 {
+        let lim: usize = ((2u32).wrapping_add(rb.cur_size_) as (usize))
             .wrapping_add(kSlackForEightByteHashingEverywhere);
-        new_data.slice_mut()[..lim].clone_from_slice(&(*rb).data_mo.slice()[..lim]);
+        new_data.slice_mut()[..lim].clone_from_slice(&rb.data_mo.slice()[..lim]);
         m.free_cell(core::mem::replace(
-            &mut (*rb).data_mo,
+            &mut rb.data_mo,
             AllocU8::AllocatedMemory::default(),
         ));
     }
-    let _ = core::mem::replace(&mut (*rb).data_mo, new_data);
-    (*rb).cur_size_ = buflen;
-    (*rb).buffer_index = 2usize;
-    (*rb).data_mo.slice_mut()[((*rb).buffer_index.wrapping_sub(2usize))] = 0;
-    (*rb).data_mo.slice_mut()[((*rb).buffer_index.wrapping_sub(1usize))] = 0;
+    let _ = core::mem::replace(&mut rb.data_mo, new_data);
+    rb.cur_size_ = buflen;
+    rb.buffer_index = 2usize;
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2usize))] = 0;
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(1usize))] = 0;
     i = 0usize;
     while i < kSlackForEightByteHashingEverywhere {
         {
-            (*rb).data_mo.slice_mut()[((*rb)
+            rb.data_mo.slice_mut()[(rb
                 .buffer_index
-                .wrapping_add((*rb).cur_size_ as (usize))
+                .wrapping_add(rb.cur_size_ as (usize))
                 .wrapping_add(i) as (usize))] = 0;
         }
         i = i.wrapping_add(1 as (usize));
@@ -847,12 +847,12 @@ fn RingBufferWriteTail<AllocU8: alloc::Allocator<u8>>(
     n: usize,
     rb: &mut RingBuffer<AllocU8>,
 ) {
-    let masked_pos: usize = ((*rb).pos_ & (*rb).mask_) as (usize);
-    if masked_pos < (*rb).tail_size_ as (usize) {
-        let p: usize = ((*rb).size_ as (usize)).wrapping_add(masked_pos);
-        let begin = ((*rb).buffer_index.wrapping_add(p) as (usize));
-        let lim = brotli_min_size_t(n, ((*rb).tail_size_ as (usize)).wrapping_sub(masked_pos));
-        (*rb).data_mo.slice_mut()[begin..(begin + lim)].clone_from_slice(&bytes[..lim]);
+    let masked_pos: usize = (rb.pos_ & rb.mask_) as (usize);
+    if masked_pos < rb.tail_size_ as (usize) {
+        let p: usize = (rb.size_ as (usize)).wrapping_add(masked_pos);
+        let begin = (rb.buffer_index.wrapping_add(p) as (usize));
+        let lim = brotli_min_size_t(n, (rb.tail_size_ as (usize)).wrapping_sub(masked_pos));
+        rb.data_mo.slice_mut()[begin..(begin + lim)].clone_from_slice(&bytes[..lim]);
     }
 }
 
@@ -862,62 +862,61 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
     n: usize,
     rb: &mut RingBuffer<AllocU8>,
 ) {
-    if (*rb).pos_ == 0u32 && (n < (*rb).tail_size_ as (usize)) {
-        (*rb).pos_ = n as (u32);
-        RingBufferInitBuffer(m, (*rb).pos_, rb);
-        (*rb).data_mo.slice_mut()
-            [((*rb).buffer_index as (usize))..(((*rb).buffer_index as (usize)) + n)]
+    if rb.pos_ == 0u32 && (n < rb.tail_size_ as (usize)) {
+        rb.pos_ = n as (u32);
+        RingBufferInitBuffer(m, rb.pos_, rb);
+        rb.data_mo.slice_mut()[(rb.buffer_index as (usize))..((rb.buffer_index as (usize)) + n)]
             .clone_from_slice(&bytes[..n]);
         return;
     }
-    if (*rb).cur_size_ < (*rb).total_size_ {
-        RingBufferInitBuffer(m, (*rb).total_size_, rb);
+    if rb.cur_size_ < rb.total_size_ {
+        RingBufferInitBuffer(m, rb.total_size_, rb);
         if !(0i32 == 0) {
             return;
         }
-        (*rb).data_mo.slice_mut()[((*rb)
+        rb.data_mo.slice_mut()[(rb
             .buffer_index
-            .wrapping_add((*rb).size_ as (usize))
+            .wrapping_add(rb.size_ as (usize))
             .wrapping_sub(2usize) as (usize))] = 0i32 as (u8);
-        (*rb).data_mo.slice_mut()[((*rb)
+        rb.data_mo.slice_mut()[(rb
             .buffer_index
-            .wrapping_add((*rb).size_ as (usize))
+            .wrapping_add(rb.size_ as (usize))
             .wrapping_sub(1usize) as (usize))] = 0i32 as (u8);
     }
     {
-        let masked_pos: usize = ((*rb).pos_ & (*rb).mask_) as (usize);
+        let masked_pos: usize = (rb.pos_ & rb.mask_) as (usize);
         RingBufferWriteTail(bytes, n, rb);
-        if masked_pos.wrapping_add(n) <= (*rb).size_ as (usize) {
+        if masked_pos.wrapping_add(n) <= rb.size_ as (usize) {
             // a single write fits
-            let start = ((*rb).buffer_index.wrapping_add(masked_pos) as (usize));
-            (*rb).data_mo.slice_mut()[start..(start + n)].clone_from_slice(&bytes[..n]);
+            let start = (rb.buffer_index.wrapping_add(masked_pos) as (usize));
+            rb.data_mo.slice_mut()[start..(start + n)].clone_from_slice(&bytes[..n]);
         } else {
             {
-                let start = ((*rb).buffer_index.wrapping_add(masked_pos) as (usize));
+                let start = (rb.buffer_index.wrapping_add(masked_pos) as (usize));
                 let mid =
-                    brotli_min_size_t(n, ((*rb).total_size_ as (usize)).wrapping_sub(masked_pos));
-                (*rb).data_mo.slice_mut()[start..(start + mid)].clone_from_slice(&bytes[..mid]);
+                    brotli_min_size_t(n, (rb.total_size_ as (usize)).wrapping_sub(masked_pos));
+                rb.data_mo.slice_mut()[start..(start + mid)].clone_from_slice(&bytes[..mid]);
             }
-            let xstart = ((*rb).buffer_index.wrapping_add(0usize) as (usize));
-            let size = n.wrapping_sub(((*rb).size_ as (usize)).wrapping_sub(masked_pos));
-            let bytes_start = (((*rb).size_ as (usize)).wrapping_sub(masked_pos) as (usize));
-            (*rb).data_mo.slice_mut()[xstart..(xstart + size)]
+            let xstart = (rb.buffer_index.wrapping_add(0usize) as (usize));
+            let size = n.wrapping_sub((rb.size_ as (usize)).wrapping_sub(masked_pos));
+            let bytes_start = ((rb.size_ as (usize)).wrapping_sub(masked_pos) as (usize));
+            rb.data_mo.slice_mut()[xstart..(xstart + size)]
                 .clone_from_slice(&bytes[bytes_start..(bytes_start + size)]);
         }
     }
-    let data_2 = (*rb).data_mo.slice()[((*rb)
+    let data_2 = rb.data_mo.slice()[(rb
         .buffer_index
-        .wrapping_add((*rb).size_ as (usize))
+        .wrapping_add(rb.size_ as (usize))
         .wrapping_sub(2usize) as (usize))];
-    (*rb).data_mo.slice_mut()[((*rb).buffer_index.wrapping_sub(2usize) as (usize))] = data_2;
-    let data_1 = (*rb).data_mo.slice()[((*rb)
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2usize) as (usize))] = data_2;
+    let data_1 = rb.data_mo.slice()[(rb
         .buffer_index
-        .wrapping_add((*rb).size_ as (usize))
+        .wrapping_add(rb.size_ as (usize))
         .wrapping_sub(1usize) as (usize))];
-    (*rb).data_mo.slice_mut()[((*rb).buffer_index.wrapping_sub(1usize) as (usize))] = data_1;
-    (*rb).pos_ = (*rb).pos_.wrapping_add(n as (u32));
-    if (*rb).pos_ > 1u32 << 30i32 {
-        (*rb).pos_ = (*rb).pos_ & (1u32 << 30i32).wrapping_sub(1u32) | 1u32 << 30i32;
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(1usize) as (usize))] = data_1;
+    rb.pos_ = rb.pos_.wrapping_add(n as (u32));
+    if rb.pos_ > 1u32 << 30i32 {
+        rb.pos_ = rb.pos_ & (1u32 << 30i32).wrapping_sub(1u32) | 1u32 << 30i32;
     }
 }
 
@@ -933,7 +932,7 @@ fn CopyInputToRingBuffer<Alloc: BrotliAlloc>(
     if !(0i32 == 0) {
         return;
     }
-    (*s).input_pos_ = (*s).input_pos_.wrapping_add(input_size as u64);
+    s.input_pos_ = s.input_pos_.wrapping_add(input_size as u64);
     if (s.ringbuffer_).pos_ <= (s.ringbuffer_).mask_ {
         let start = ((s.ringbuffer_)
             .buffer_index
@@ -946,60 +945,59 @@ fn CopyInputToRingBuffer<Alloc: BrotliAlloc>(
 
 fn ChooseHasher(params: &mut BrotliEncoderParams) {
     let hparams = &mut params.hasher;
-    if (*params).quality >= 10 && !params.q9_5 {
-        (*hparams).type_ = 10;
-    } else if (*params).quality == 10 {
+    if params.quality >= 10 && !params.q9_5 {
+        hparams.type_ = 10;
+    } else if params.quality == 10 {
         // we are using quality 10 as a proxy for "9.5"
-        (*hparams).type_ = 9;
-        (*hparams).num_last_distances_to_check = H9_NUM_LAST_DISTANCES_TO_CHECK as i32;
-        (*hparams).block_bits = H9_BLOCK_BITS as i32;
-        (*hparams).bucket_bits = H9_BUCKET_BITS as i32;
-        (*hparams).hash_len = 4;
-    } else if (*params).quality == 9 {
-        (*hparams).type_ = 9;
-        (*hparams).num_last_distances_to_check = H9_NUM_LAST_DISTANCES_TO_CHECK as i32;
-        (*hparams).block_bits = H9_BLOCK_BITS as i32;
-        (*hparams).bucket_bits = H9_BUCKET_BITS as i32;
-        (*hparams).hash_len = 4;
-    } else if (*params).quality == 4 && ((*params).size_hint >= (1i32 << 20i32) as (usize)) {
-        (*hparams).type_ = 54i32;
-    } else if (*params).quality < 5 {
-        (*hparams).type_ = (*params).quality;
-    } else if (*params).lgwin <= 16 {
-        (*hparams).type_ = if (*params).quality < 7 {
+        hparams.type_ = 9;
+        hparams.num_last_distances_to_check = H9_NUM_LAST_DISTANCES_TO_CHECK as i32;
+        hparams.block_bits = H9_BLOCK_BITS as i32;
+        hparams.bucket_bits = H9_BUCKET_BITS as i32;
+        hparams.hash_len = 4;
+    } else if params.quality == 9 {
+        hparams.type_ = 9;
+        hparams.num_last_distances_to_check = H9_NUM_LAST_DISTANCES_TO_CHECK as i32;
+        hparams.block_bits = H9_BLOCK_BITS as i32;
+        hparams.bucket_bits = H9_BUCKET_BITS as i32;
+        hparams.hash_len = 4;
+    } else if params.quality == 4 && (params.size_hint >= (1i32 << 20i32) as (usize)) {
+        hparams.type_ = 54i32;
+    } else if params.quality < 5 {
+        hparams.type_ = params.quality;
+    } else if params.lgwin <= 16 {
+        hparams.type_ = if params.quality < 7 {
             40i32
-        } else if (*params).quality < 9 {
+        } else if params.quality < 9 {
             41i32
         } else {
             42i32
         };
-    } else if ((params.q9_5 && (*params).size_hint > (1usize << 20i32))
-        || (*params).size_hint > (1usize << 22i32))
-        && ((*params).lgwin >= 19i32)
+    } else if ((params.q9_5 && params.size_hint > (1usize << 20i32))
+        || params.size_hint > (1usize << 22i32))
+        && (params.lgwin >= 19i32)
     {
-        (*hparams).type_ = 6i32;
-        (*hparams).block_bits = core::cmp::min((*params).quality - 1, 9);
-        (*hparams).bucket_bits = 15i32;
-        (*hparams).hash_len = 5i32;
-        (*hparams).num_last_distances_to_check = if (*params).quality < 7 {
+        hparams.type_ = 6i32;
+        hparams.block_bits = core::cmp::min(params.quality - 1, 9);
+        hparams.bucket_bits = 15i32;
+        hparams.hash_len = 5i32;
+        hparams.num_last_distances_to_check = if params.quality < 7 {
             4i32
-        } else if (*params).quality < 9 {
+        } else if params.quality < 9 {
             10i32
         } else {
             16i32
         };
     } else {
-        (*hparams).type_ = 5i32;
-        (*hparams).block_bits = core::cmp::min((*params).quality - 1, 9);
-        (*hparams).bucket_bits =
-            if (*params).quality < 7 && (*params).size_hint <= (1usize << 20i32) {
-                14i32
-            } else {
-                15i32
-            };
-        (*hparams).num_last_distances_to_check = if (*params).quality < 7 {
+        hparams.type_ = 5i32;
+        hparams.block_bits = core::cmp::min(params.quality - 1, 9);
+        hparams.bucket_bits = if params.quality < 7 && params.size_hint <= (1usize << 20i32) {
+            14i32
+        } else {
+            15i32
+        };
+        hparams.num_last_distances_to_check = if params.quality < 7 {
             4i32
-        } else if (*params).quality < 9 {
+        } else if params.quality < 9 {
             10i32
         } else {
             16i32
@@ -1261,7 +1259,7 @@ pub fn HasherSetup<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
         //alloc_size = HasherSize(params, one_shot, input_size);
         //xself = BrotliAllocate(m, alloc_size.wrapping_mul(::std::mem::size_of::<u8>()))
         *handle = BrotliMakeHasher(m16, params);
-        handle.GetHasherCommon().params = (*params).hasher;
+        handle.GetHasherCommon().params = params.hasher;
         HasherReset(handle); // this sets everything to zero, unlike in C
         handle.GetHasherCommon().is_prepared_ = 1;
     } else {
@@ -1270,8 +1268,8 @@ pub fn HasherSetup<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
             HowPrepared::NEWLY_PREPARED => {
                 if position == 0usize {
                     let common = handle.GetHasherCommon();
-                    (*common).dict_num_lookups = 0usize;
-                    (*common).dict_num_matches = 0usize;
+                    common.dict_num_lookups = 0usize;
+                    common.dict_num_matches = 0usize;
                 }
             }
         }
@@ -1325,19 +1323,15 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
     } else {
         true
     };
-    let max_dict_size: usize = (1usize << (*s).params.lgwin).wrapping_sub(16usize);
+    let max_dict_size: usize = (1usize << s.params.lgwin).wrapping_sub(16usize);
     s.hasher_ = opt_hasher;
     let mut dict_size: usize = size;
     if EnsureInitialized(s) == 0 {
         return;
     }
-    if dict_size == 0usize
-        || (*s).params.quality == 0i32
-        || (*s).params.quality == 1i32
-        || size <= 1
-    {
-        (*s).params.catable = true; // don't risk a too-short dictionary
-        (*s).params.appendable = true; // don't risk a too-short dictionary
+    if dict_size == 0usize || s.params.quality == 0i32 || s.params.quality == 1i32 || size <= 1 {
+        s.params.catable = true; // don't risk a too-short dictionary
+        s.params.appendable = true; // don't risk a too-short dictionary
         return;
     }
     s.custom_dictionary = true;
@@ -1346,13 +1340,13 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
         dict_size = max_dict_size;
     }
     CopyInputToRingBuffer(s, dict_size, dict);
-    (*s).last_flush_pos_ = dict_size as u64;
-    (*s).last_processed_pos_ = dict_size as u64;
+    s.last_flush_pos_ = dict_size as u64;
+    s.last_processed_pos_ = dict_size as u64;
     if dict_size > 0 {
-        (*s).prev_byte_ = dict[(dict_size.wrapping_sub(1usize) as (usize))];
+        s.prev_byte_ = dict[(dict_size.wrapping_sub(1usize) as (usize))];
     }
     if dict_size > 1usize {
-        (*s).prev_byte2_ = dict[(dict_size.wrapping_sub(2usize) as (usize))];
+        s.prev_byte2_ = dict[(dict_size.wrapping_sub(2usize) as (usize))];
     }
     let m16 = &mut s.m8;
     if cfg!(debug_assertions) || !has_optional_hasher {
@@ -1360,7 +1354,7 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
         if has_optional_hasher {
             orig_hasher = core::mem::replace(&mut s.hasher_, UnionHasher::Uninit);
         }
-        HasherPrependCustomDictionary(m16, &mut (*s).hasher_, &mut (*s).params, dict_size, dict);
+        HasherPrependCustomDictionary(m16, &mut s.hasher_, &mut s.params, dict_size, dict);
         if has_optional_hasher {
             debug_assert!(orig_hasher == s.hasher_);
             DestroyHasher(m16, &mut orig_hasher);
@@ -1410,11 +1404,11 @@ fn InitOrStitchToPreviousBlock<Alloc: alloc::Allocator<u16> + alloc::Allocator<u
 }
 
 pub fn InitInsertCommand(xself: &mut Command, insertlen: usize) {
-    (*xself).insert_len_ = insertlen as (u32);
-    (*xself).copy_len_ = (4i32 << 25i32) as (u32);
-    (*xself).dist_extra_ = 0u32;
-    (*xself).dist_prefix_ = (1u16 << 10) | BROTLI_NUM_DISTANCE_SHORT_CODES as (u16);
-    GetLengthCode(insertlen, 4usize, 0i32, &mut (*xself).cmd_prefix_);
+    xself.insert_len_ = insertlen as (u32);
+    xself.copy_len_ = (4i32 << 25i32) as (u32);
+    xself.dist_extra_ = 0u32;
+    xself.dist_prefix_ = (1u16 << 10) | BROTLI_NUM_DISTANCE_SHORT_CODES as (u16);
+    GetLengthCode(insertlen, 4usize, 0i32, &mut xself.cmd_prefix_);
 }
 
 fn ShouldCompress(
@@ -1690,18 +1684,18 @@ pub fn BrotliEncoderCompress<
 }
 
 fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) {
-    let mut seal: u32 = (*s).last_bytes_ as (u32);
-    let mut seal_bits: usize = (*s).last_bytes_bits_ as (usize);
+    let mut seal: u32 = s.last_bytes_ as (u32);
+    let mut seal_bits: usize = s.last_bytes_bits_ as (usize);
     let destination: &mut [u8];
-    (*s).last_bytes_ = 0;
-    (*s).last_bytes_bits_ = 0;
+    s.last_bytes_ = 0;
+    s.last_bytes_bits_ = 0;
     seal = seal | 0x6u32 << seal_bits;
     seal_bits = seal_bits.wrapping_add(6usize);
-    if !IsNextOutNull(&(*s).next_out_) {
-        destination = &mut GetNextOut!(*s)[((*s).available_out_ as (usize))..];
+    if !IsNextOutNull(&s.next_out_) {
+        destination = &mut GetNextOut!(*s)[(s.available_out_ as (usize))..];
     } else {
-        destination = &mut (*s).tiny_buf_[..];
-        (*s).next_out_ = NextOut::TinyBuf(0);
+        destination = &mut s.tiny_buf_[..];
+        s.next_out_ = NextOut::TinyBuf(0);
     }
     destination[(0usize)] = seal as (u8);
     if seal_bits > 8usize {
@@ -1710,7 +1704,7 @@ fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<A
     if seal_bits > 16usize {
         destination[(2usize)] = (seal >> 16i32) as (u8);
     }
-    (*s).available_out_ = (*s)
+    s.available_out_ = s
         .available_out_
         .wrapping_add(seal_bits.wrapping_add(7usize) >> 3i32);
 }
@@ -1721,25 +1715,24 @@ fn InjectFlushOrPushOutput<Alloc: BrotliAlloc>(
     next_out_offset: &mut usize,
     total_out: &mut Option<usize>,
 ) -> i32 {
-    if (*s).stream_state_ as (i32)
-        == BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED as (i32)
-        && ((*s).last_bytes_bits_ as (i32) != 0i32)
+    if s.stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED as (i32)
+        && (s.last_bytes_bits_ as (i32) != 0i32)
     {
         InjectBytePaddingBlock(s);
         return 1i32;
     }
-    if (*s).available_out_ != 0usize && (*available_out != 0usize) {
-        let copy_output_size: usize = brotli_min_size_t((*s).available_out_, *available_out);
+    if s.available_out_ != 0usize && (*available_out != 0usize) {
+        let copy_output_size: usize = brotli_min_size_t(s.available_out_, *available_out);
         (*next_out_array)[(*next_out_offset)..(*next_out_offset + copy_output_size)]
             .clone_from_slice(&GetNextOut!(s)[..copy_output_size]);
         //memcpy(*next_out, (*s).next_out_, copy_output_size);
         *next_out_offset = (*next_out_offset).wrapping_add(copy_output_size);
         *available_out = (*available_out).wrapping_sub(copy_output_size);
-        (*s).next_out_ = NextOutIncrement(&(*s).next_out_, (copy_output_size as (i32)));
-        (*s).available_out_ = (*s).available_out_.wrapping_sub(copy_output_size);
-        (*s).total_out_ = (*s).total_out_.wrapping_add(copy_output_size as u64);
+        s.next_out_ = NextOutIncrement(&s.next_out_, (copy_output_size as (i32)));
+        s.available_out_ = s.available_out_.wrapping_sub(copy_output_size);
+        s.total_out_ = s.total_out_.wrapping_add(copy_output_size as u64);
         if let &mut Some(ref mut total_out_inner) = total_out {
-            *total_out_inner = (*s).total_out_ as usize;
+            *total_out_inner = s.total_out_ as usize;
         }
         return 1i32;
     }
@@ -1747,14 +1740,14 @@ fn InjectFlushOrPushOutput<Alloc: BrotliAlloc>(
 }
 
 fn UnprocessedInputSize<Alloc: BrotliAlloc>(s: &BrotliEncoderStateStruct<Alloc>) -> u64 {
-    (*s).input_pos_.wrapping_sub((*s).last_processed_pos_)
+    s.input_pos_.wrapping_sub(s.last_processed_pos_)
 }
 
 fn UpdateSizeHint<Alloc: BrotliAlloc>(
     s: &mut BrotliEncoderStateStruct<Alloc>,
     available_in: usize,
 ) {
-    if (*s).params.size_hint == 0usize {
+    if s.params.size_hint == 0usize {
         let delta: u64 = UnprocessedInputSize(s);
         let tail: u64 = available_in as u64;
         let limit: u32 = 1u32 << 30i32;
@@ -1767,7 +1760,7 @@ fn UpdateSizeHint<Alloc: BrotliAlloc>(
         } else {
             total = delta.wrapping_add(tail) as (u32);
         }
-        (*s).params.size_hint = total as (usize);
+        s.params.size_hint = total as (usize);
     }
 }
 
@@ -1785,20 +1778,20 @@ fn InputBlockSize<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) -
     if EnsureInitialized(s) == 0 {
         return 0usize;
     }
-    1usize << (*s).params.lgblock
+    1usize << s.params.lgblock
 }
 
 fn GetBrotliStorage<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>, size: usize) {
-    if (*s).storage_size_ < size {
+    if s.storage_size_ < size {
         <Alloc as Allocator<u8>>::free_cell(
-            &mut (*s).m8,
+            &mut s.m8,
             core::mem::replace(
-                &mut (*s).storage_,
+                &mut s.storage_,
                 <Alloc as Allocator<u8>>::AllocatedMemory::default(),
             ),
         );
-        (*s).storage_ = <Alloc as Allocator<u8>>::alloc_cell(&mut (*s).m8, size);
-        (*s).storage_size_ = size;
+        s.storage_ = <Alloc as Allocator<u8>>::alloc_cell(&mut s.m8, size);
+        s.storage_size_ = size;
     }
 }
 
@@ -1868,9 +1861,9 @@ fn GetHashTableInternal<'a, AllocI32: alloc::Allocator<i32>>(
     table // FIXME: probably need a macro to do this without borrowing the whole EncoderStateStruct
 }
 fn UpdateLastProcessedPos<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) -> i32 {
-    let wrapped_last_processed_pos: u32 = WrapPosition((*s).last_processed_pos_);
-    let wrapped_input_pos: u32 = WrapPosition((*s).input_pos_);
-    (*s).last_processed_pos_ = (*s).input_pos_;
+    let wrapped_last_processed_pos: u32 = WrapPosition(s.last_processed_pos_);
+    let wrapped_input_pos: u32 = WrapPosition(s.input_pos_);
+    s.last_processed_pos_ = s.input_pos_;
     if !!(wrapped_input_pos < wrapped_last_processed_pos) {
         1i32
     } else {
@@ -2216,7 +2209,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
                                 params.dist.distance_postfix_bits);
     }*/
     // why was this removed??
-    if (*params).quality <= 2i32 {
+    if params.quality <= 2i32 {
         BrotliStoreMetaBlockFast(
             alloc,
             data,
@@ -2233,7 +2226,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
             storage,
             cb,
         );
-    } else if (*params).quality < 4i32 {
+    } else if params.quality < 4i32 {
         BrotliStoreMetaBlockTrivial(
             alloc,
             data,
@@ -2254,17 +2247,17 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
         //let mut literal_context_mode: ContextType = ContextType::CONTEXT_UTF8;
 
         let mut mb = MetaBlockSplit::<Alloc>::new();
-        if (*params).quality < 10i32 {
+        if params.quality < 10i32 {
             let mut num_literal_contexts: usize = 1usize;
             let mut literal_context_map: &[u32] = &[];
-            if (*params).disable_literal_context_modeling == 0 {
+            if params.disable_literal_context_modeling == 0 {
                 DecideOverLiteralContextModeling(
                     data,
                     wrapped_last_flush_pos as (usize),
                     bytes,
                     mask,
-                    (*params).quality,
-                    (*params).size_hint,
+                    params.quality,
+                    params.size_hint,
                     &mut num_literal_contexts,
                     &mut literal_context_map,
                 );
@@ -2302,7 +2295,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
                 &mut mb,
             );
         }
-        if (*params).quality >= 4i32 {
+        if params.quality >= 4i32 {
             let mut num_effective_dist_codes = block_params.dist.alphabet_size;
             if num_effective_dist_codes > BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS as u32 {
                 num_effective_dist_codes = BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS as u32;
@@ -2421,40 +2414,40 @@ where
 {
     let mut delta: u64 = UnprocessedInputSize(s);
     let mut bytes: u32 = delta as (u32);
-    let mask = (*s).ringbuffer_.mask_;
+    let mask = s.ringbuffer_.mask_;
     if EnsureInitialized(s) == 0 {
         return 0i32;
     }
     let dictionary = BrotliGetDictionary();
-    if (*s).is_last_block_emitted_ {
+    if s.is_last_block_emitted_ {
         return 0i32;
     }
     if is_last != 0 {
-        (*s).is_last_block_emitted_ = true;
+        s.is_last_block_emitted_ = true;
     }
     if delta > InputBlockSize(s) as u64 {
         return 0i32;
     }
-    let mut storage_ix: usize = usize::from((*s).last_bytes_bits_);
+    let mut storage_ix: usize = usize::from(s.last_bytes_bits_);
     {
         let meta_size = core::cmp::max(
             bytes as usize,
-            (*s).input_pos_.wrapping_sub((*s).last_flush_pos_) as usize,
+            s.input_pos_.wrapping_sub(s.last_flush_pos_) as usize,
         );
         GetBrotliStorage(s, (2usize).wrapping_mul(meta_size).wrapping_add(503 + 24));
     }
     {
-        (*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
-        (*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
+        s.storage_.slice_mut()[0] = s.last_bytes_ as u8;
+        s.storage_.slice_mut()[1] = (s.last_bytes_ >> 8) as u8;
     }
     let mut catable_header_size = 0;
     if let IsFirst::NothingWritten = s.is_first_mb {
         if s.params.magic_number {
-            BrotliWriteMetadataMetaBlock(&s.params, &mut storage_ix, (*s).storage_.slice_mut());
-            (*s).last_bytes_ = (*s).storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | (((*s).storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
-            (*s).last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
-            (*s).next_out_ = NextOut::DynamicStorage(0);
+            BrotliWriteMetadataMetaBlock(&s.params, &mut storage_ix, s.storage_.slice_mut());
+            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
+                | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+            s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
+            s.next_out_ = NextOut::DynamicStorage(0);
             catable_header_size = storage_ix >> 3;
             *out_size = catable_header_size;
             s.is_first_mb = IsFirst::HeaderWritten;
@@ -2468,8 +2461,8 @@ where
         assert!(s.last_processed_pos_ < 2 || s.custom_dictionary);
         let num_bytes_to_write_uncompressed: usize = core::cmp::min(2, bytes as usize);
         {
-            let data = &mut (*s).ringbuffer_.data_mo.slice_mut()
-                [((*s).ringbuffer_.buffer_index as (usize))..];
+            let data =
+                &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..];
             BrotliStoreUncompressedMetaBlock(
                 &mut s.m8,
                 0,
@@ -2478,15 +2471,15 @@ where
                 mask as usize,
                 &s.params,
                 num_bytes_to_write_uncompressed,
-                &mut (*s).recoder_state,
+                &mut s.recoder_state,
                 &mut storage_ix,
-                (*s).storage_.slice_mut(),
+                s.storage_.slice_mut(),
                 false, /* suppress meta-block logging */
                 callback,
             );
-            (*s).last_bytes_ = (*s).storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | (((*s).storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
-            (*s).last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
+            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
+                | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+            s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
             s.prev_byte2_ = s.prev_byte_;
             s.prev_byte_ = data[s.last_flush_pos_ as usize & mask as usize];
             if num_bytes_to_write_uncompressed == 2 {
@@ -2496,7 +2489,7 @@ where
         }
         s.last_flush_pos_ += num_bytes_to_write_uncompressed as u64;
         bytes -= num_bytes_to_write_uncompressed as u32;
-        (*s).last_processed_pos_ += num_bytes_to_write_uncompressed as u64;
+        s.last_processed_pos_ += num_bytes_to_write_uncompressed as u64;
         if num_bytes_to_write_uncompressed >= 2 {
             s.is_first_mb = IsFirst::BothCatableBytesWritten;
         } else if num_bytes_to_write_uncompressed == 1 {
@@ -2507,20 +2500,20 @@ where
             }
         }
         catable_header_size = storage_ix >> 3;
-        (*s).next_out_ = NextOut::DynamicStorage(0);
+        s.next_out_ = NextOut::DynamicStorage(0);
         *out_size = catable_header_size;
         delta = UnprocessedInputSize(s);
     }
-    let mut wrapped_last_processed_pos: u32 = WrapPosition((*s).last_processed_pos_);
-    if (*s).params.quality == 1i32 && (*s).command_buf_.slice().len() == 0 {
+    let mut wrapped_last_processed_pos: u32 = WrapPosition(s.last_processed_pos_);
+    if s.params.quality == 1i32 && s.command_buf_.slice().len() == 0 {
         let new_buf =
-            <Alloc as Allocator<u32>>::alloc_cell(&mut (*s).m8, kCompressFragmentTwoPassBlockSize);
-        (*s).command_buf_ = new_buf;
+            <Alloc as Allocator<u32>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
+        s.command_buf_ = new_buf;
         let new_buf8 =
-            <Alloc as Allocator<u8>>::alloc_cell(&mut (*s).m8, kCompressFragmentTwoPassBlockSize);
-        (*s).literal_buf_ = new_buf8;
+            <Alloc as Allocator<u8>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
+        s.literal_buf_ = new_buf8;
     }
-    if (*s).params.quality == 0i32 || (*s).params.quality == 1i32 {
+    if s.params.quality == 0i32 || s.params.quality == 1i32 {
         let mut table_size: usize = 0;
         {
             let table: &mut [i32];
@@ -2528,15 +2521,15 @@ where
                 *out_size = catable_header_size;
                 return 1i32;
             }
-            let data = &mut (*s).ringbuffer_.data_mo.slice_mut()
-                [((*s).ringbuffer_.buffer_index as (usize))..];
+            let data =
+                &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..];
 
             //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
             //        (*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
 
-            table = GetHashTable!(s, (*s).params.quality, bytes as (usize), &mut table_size);
+            table = GetHashTable!(s, s.params.quality, bytes as (usize), &mut table_size);
 
-            if (*s).params.quality == 0i32 {
+            if s.params.quality == 0i32 {
                 BrotliCompressFragmentFast(
                     &mut s.m8,
                     &mut data[((wrapped_last_processed_pos & mask) as (usize))..],
@@ -2544,12 +2537,12 @@ where
                     is_last,
                     table,
                     table_size,
-                    &mut (*s).cmd_depths_[..],
-                    &mut (*s).cmd_bits_[..],
-                    &mut (*s).cmd_code_numbits_,
-                    &mut (*s).cmd_code_[..],
+                    &mut s.cmd_depths_[..],
+                    &mut s.cmd_bits_[..],
+                    &mut s.cmd_code_numbits_,
+                    &mut s.cmd_code_[..],
                     &mut storage_ix,
-                    (*s).storage_.slice_mut(),
+                    s.storage_.slice_mut(),
                 );
             } else {
                 BrotliCompressFragmentTwoPass(
@@ -2557,60 +2550,60 @@ where
                     &mut data[((wrapped_last_processed_pos & mask) as (usize))..],
                     bytes as (usize),
                     is_last,
-                    (*s).command_buf_.slice_mut(),
-                    (*s).literal_buf_.slice_mut(),
+                    s.command_buf_.slice_mut(),
+                    s.literal_buf_.slice_mut(),
                     table,
                     table_size,
                     &mut storage_ix,
-                    (*s).storage_.slice_mut(),
+                    s.storage_.slice_mut(),
                 );
             }
-            (*s).last_bytes_ = (*s).storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-                | (((*s).storage_.slice()[((storage_ix >> 3i32) as (usize)) + 1] as u16) << 8);
-            (*s).last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
+            s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
+                | ((s.storage_.slice()[((storage_ix >> 3i32) as (usize)) + 1] as u16) << 8);
+            s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
         }
         UpdateLastProcessedPos(s);
         // *output = &mut (*s).storage_.slice_mut();
-        (*s).next_out_ = NextOut::DynamicStorage(0); // this always returns that
+        s.next_out_ = NextOut::DynamicStorage(0); // this always returns that
         *out_size = storage_ix >> 3i32;
         return 1i32;
     }
     {
-        let mut newsize: usize = (*s)
+        let mut newsize: usize = s
             .num_commands_
             .wrapping_add(bytes.wrapping_div(2u32) as (usize))
             .wrapping_add(1usize);
-        if newsize > (*s).cmd_alloc_size_ {
+        if newsize > s.cmd_alloc_size_ {
             newsize = newsize.wrapping_add(bytes.wrapping_div(4u32).wrapping_add(16u32) as (usize));
-            (*s).cmd_alloc_size_ = newsize;
+            s.cmd_alloc_size_ = newsize;
             let mut new_commands = <Alloc as Allocator<Command>>::alloc_cell(&mut s.m8, newsize);
-            if (*s).commands_.slice().len() != 0 {
-                new_commands.slice_mut()[..(*s).num_commands_]
-                    .clone_from_slice(&(*s).commands_.slice()[..(*s).num_commands_]);
+            if s.commands_.slice().len() != 0 {
+                new_commands.slice_mut()[..s.num_commands_]
+                    .clone_from_slice(&s.commands_.slice()[..s.num_commands_]);
                 <Alloc as Allocator<Command>>::free_cell(
                     &mut s.m8,
                     core::mem::replace(
-                        &mut (*s).commands_,
+                        &mut s.commands_,
                         <Alloc as Allocator<Command>>::AllocatedMemory::default(),
                     ),
                 );
             }
-            (*s).commands_ = new_commands;
+            s.commands_ = new_commands;
         }
     }
     InitOrStitchToPreviousBlock(
-        &mut (*s).m8,
-        &mut (*s).hasher_,
-        &mut (*s).ringbuffer_.data_mo.slice_mut()[((*s).ringbuffer_.buffer_index as (usize))..],
+        &mut s.m8,
+        &mut s.hasher_,
+        &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as (usize))..],
         mask as (usize),
-        &mut (*s).params,
+        &mut s.params,
         wrapped_last_processed_pos as (usize),
         bytes as (usize),
         is_last,
     );
     let literal_context_mode = ChooseContextMode(
         &s.params,
-        (*s).ringbuffer_.data_mo.slice(),
+        s.ringbuffer_.data_mo.slice(),
         WrapPosition(s.last_flush_pos_) as usize,
         mask as usize,
         (s.input_pos_.wrapping_sub(s.last_flush_pos_)) as usize,
@@ -2636,7 +2629,7 @@ where
                                          &mut (*s).num_commands_,
                                          &mut (*s).num_literals_);"####
         );
-    } else if false && (*s).params.quality == 11i32 {
+    } else if false && s.params.quality == 11i32 {
         panic!(
             r####"BrotliCreateHqZopfliBackwardReferences(m,
                                            dictionary,
@@ -2654,34 +2647,34 @@ where
         );
     } else {
         BrotliCreateBackwardReferences(
-            &mut (*s).m8,
+            &mut s.m8,
             &dictionary,
             bytes as (usize),
             wrapped_last_processed_pos as (usize),
-            &mut (*s).ringbuffer_.data_mo.slice_mut()[((*s).ringbuffer_.buffer_index as usize)..],
+            &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as usize)..],
             mask as (usize),
-            &mut (*s).params,
-            &mut (*s).hasher_,
-            &mut (*s).dist_cache_,
-            &mut (*s).last_insert_len_,
-            &mut (*s).commands_.slice_mut()[((*s).num_commands_ as (usize))..],
-            &mut (*s).num_commands_,
-            &mut (*s).num_literals_,
+            &mut s.params,
+            &mut s.hasher_,
+            &mut s.dist_cache_,
+            &mut s.last_insert_len_,
+            &mut s.commands_.slice_mut()[(s.num_commands_ as (usize))..],
+            &mut s.num_commands_,
+            &mut s.num_literals_,
         );
     }
     {
-        let max_length: usize = MaxMetablockSize(&mut (*s).params);
+        let max_length: usize = MaxMetablockSize(&mut s.params);
         let max_literals: usize = max_length.wrapping_div(8usize);
         let max_commands: usize = max_length.wrapping_div(8usize);
-        let processed_bytes: usize = (*s).input_pos_.wrapping_sub((*s).last_flush_pos_) as usize;
+        let processed_bytes: usize = s.input_pos_.wrapping_sub(s.last_flush_pos_) as usize;
         let next_input_fits_metablock: i32 =
             if !!(processed_bytes.wrapping_add(InputBlockSize(s)) <= max_length) {
                 1i32
             } else {
                 0i32
             };
-        let should_flush: i32 = if !!((*s).params.quality < 4i32
-            && ((*s).num_literals_.wrapping_add((*s).num_commands_) >= 0x2fffusize))
+        let should_flush: i32 = if !!(s.params.quality < 4i32
+            && (s.num_literals_.wrapping_add(s.num_commands_) >= 0x2fffusize))
         {
             1i32
         } else {
@@ -2691,98 +2684,97 @@ where
             && (force_flush == 0)
             && (should_flush == 0)
             && (next_input_fits_metablock != 0)
-            && ((*s).num_literals_ < max_literals)
-            && ((*s).num_commands_ < max_commands)
+            && (s.num_literals_ < max_literals)
+            && (s.num_commands_ < max_commands)
         {
             if UpdateLastProcessedPos(s) != 0 {
-                HasherReset(&mut (*s).hasher_);
+                HasherReset(&mut s.hasher_);
             }
             *out_size = catable_header_size;
             return 1i32;
         }
     }
-    if (*s).last_insert_len_ > 0usize {
+    if s.last_insert_len_ > 0usize {
         InitInsertCommand(
-            &mut (*s).commands_.slice_mut()[({
-                let _old = (*s).num_commands_;
-                (*s).num_commands_ = (*s).num_commands_.wrapping_add(1 as (usize));
+            &mut s.commands_.slice_mut()[({
+                let _old = s.num_commands_;
+                s.num_commands_ = s.num_commands_.wrapping_add(1 as (usize));
                 _old
             } as (usize))],
-            (*s).last_insert_len_,
+            s.last_insert_len_,
         );
-        (*s).num_literals_ = (*s).num_literals_.wrapping_add((*s).last_insert_len_);
-        (*s).last_insert_len_ = 0usize;
+        s.num_literals_ = s.num_literals_.wrapping_add(s.last_insert_len_);
+        s.last_insert_len_ = 0usize;
     }
-    if is_last == 0 && ((*s).input_pos_ == (*s).last_flush_pos_) {
+    if is_last == 0 && (s.input_pos_ == s.last_flush_pos_) {
         *out_size = catable_header_size;
         return 1i32;
     }
     {
-        let metablock_size: u32 = (*s).input_pos_.wrapping_sub((*s).last_flush_pos_) as (u32);
+        let metablock_size: u32 = s.input_pos_.wrapping_sub(s.last_flush_pos_) as (u32);
         //let mut storage_ix: usize = (*s).last_bytes_bits_ as (usize);
         //(*s).storage_.slice_mut()[(0usize)] = (*s).last_bytes_ as u8;
         //(*s).storage_.slice_mut()[(1usize)] = ((*s).last_bytes_ >> 8) as u8;
 
         WriteMetaBlockInternal(
-            &mut (*s).m8,
-            &mut (*s).ringbuffer_.data_mo.slice_mut()[((*s).ringbuffer_.buffer_index as usize)..],
+            &mut s.m8,
+            &mut s.ringbuffer_.data_mo.slice_mut()[(s.ringbuffer_.buffer_index as usize)..],
             mask as (usize),
-            (*s).last_flush_pos_,
+            s.last_flush_pos_,
             metablock_size as (usize),
             is_last,
             literal_context_mode,
-            &mut (*s).params,
-            &mut (*s).literal_scratch_space,
-            &mut (*s).command_scratch_space,
-            &mut (*s).distance_scratch_space,
-            (*s).prev_byte_,
-            (*s).prev_byte2_,
-            (*s).num_literals_,
-            (*s).num_commands_,
-            (*s).commands_.slice_mut(),
-            &mut (*s).saved_dist_cache_,
-            &mut (*s).dist_cache_,
-            &mut (*s).recoder_state,
+            &mut s.params,
+            &mut s.literal_scratch_space,
+            &mut s.command_scratch_space,
+            &mut s.distance_scratch_space,
+            s.prev_byte_,
+            s.prev_byte2_,
+            s.num_literals_,
+            s.num_commands_,
+            s.commands_.slice_mut(),
+            &mut s.saved_dist_cache_,
+            &mut s.dist_cache_,
+            &mut s.recoder_state,
             &mut storage_ix,
-            (*s).storage_.slice_mut(),
+            s.storage_.slice_mut(),
             callback,
         );
 
-        (*s).last_bytes_ = (*s).storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
-            | (((*s).storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
-        (*s).last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
-        (*s).last_flush_pos_ = (*s).input_pos_;
+        s.last_bytes_ = s.storage_.slice()[((storage_ix >> 3i32) as (usize))] as u16
+            | ((s.storage_.slice()[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
+        s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
+        s.last_flush_pos_ = s.input_pos_;
         if UpdateLastProcessedPos(s) != 0 {
-            HasherReset(&mut (*s).hasher_);
+            HasherReset(&mut s.hasher_);
         }
-        let data = &(*s).ringbuffer_.data_mo.slice()[(*s).ringbuffer_.buffer_index as usize..];
-        if (*s).last_flush_pos_ > 0 {
-            (*s).prev_byte_ =
-                data[((((*s).last_flush_pos_ as (u32)).wrapping_sub(1u32) & mask) as (usize))];
+        let data = &s.ringbuffer_.data_mo.slice()[s.ringbuffer_.buffer_index as usize..];
+        if s.last_flush_pos_ > 0 {
+            s.prev_byte_ =
+                data[(((s.last_flush_pos_ as (u32)).wrapping_sub(1u32) & mask) as (usize))];
         }
-        if (*s).last_flush_pos_ > 1 {
-            (*s).prev_byte2_ =
-                data[(((*s).last_flush_pos_.wrapping_sub(2) as (u32) & mask) as (usize))];
+        if s.last_flush_pos_ > 1 {
+            s.prev_byte2_ = data[((s.last_flush_pos_.wrapping_sub(2) as (u32) & mask) as (usize))];
         }
-        (*s).num_commands_ = 0usize;
-        (*s).num_literals_ = 0usize;
-        (*s).saved_dist_cache_
-            .clone_from_slice(&(*s).dist_cache_.split_at(4).0);
-        (*s).next_out_ = NextOut::DynamicStorage(0); // this always returns that
+        s.num_commands_ = 0usize;
+        s.num_literals_ = 0usize;
+        s.saved_dist_cache_
+            .clone_from_slice(&s.dist_cache_.split_at(4).0);
+        s.next_out_ = NextOut::DynamicStorage(0); // this always returns that
         *out_size = storage_ix >> 3i32;
         1i32
     }
 }
 
 fn WriteMetadataHeader<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) -> usize {
-    let block_size = (*s).remaining_metadata_bytes_ as (usize);
+    let block_size = s.remaining_metadata_bytes_ as (usize);
     let header = GetNextOut!(*s);
     let mut storage_ix: usize;
-    storage_ix = (*s).last_bytes_bits_ as (usize);
-    header[(0usize)] = (*s).last_bytes_ as u8;
-    header[(1usize)] = ((*s).last_bytes_ >> 8) as u8;
-    (*s).last_bytes_ = 0;
-    (*s).last_bytes_bits_ = 0;
+    storage_ix = s.last_bytes_bits_ as (usize);
+    header[(0usize)] = s.last_bytes_ as u8;
+    header[(1usize)] = (s.last_bytes_ >> 8) as u8;
+    s.last_bytes_ = 0;
+    s.last_bytes_bits_ = 0;
     BrotliWriteBits(1usize, 0, &mut storage_ix, header);
     BrotliWriteBits(2usize, 3, &mut storage_ix, header);
     BrotliWriteBits(1usize, 0, &mut storage_ix, header);
@@ -2835,12 +2827,12 @@ fn ProcessMetadata<
     if *available_in > (1u32 << 24i32) as (usize) {
         return 0i32;
     }
-    if (*s).stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32) {
-        (*s).remaining_metadata_bytes_ = *available_in as (u32);
-        (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD;
+    if s.stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32) {
+        s.remaining_metadata_bytes_ = *available_in as (u32);
+        s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD;
     }
-    if (*s).stream_state_ as (i32) != BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as (i32)
-        && ((*s).stream_state_ as (i32)
+    if s.stream_state_ as (i32) != BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as (i32)
+        && (s.stream_state_ as (i32)
             != BrotliEncoderStreamState::BROTLI_STREAM_METADATA_BODY as (i32))
     {
         return 0i32;
@@ -2853,15 +2845,15 @@ fn ProcessMetadata<
                 continue;
             }
         }
-        if (*s).available_out_ != 0usize {
+        if s.available_out_ != 0usize {
             {
                 break;
             }
         }
-        if (*s).input_pos_ != (*s).last_flush_pos_ {
-            let mut avail_out: usize = (*s).available_out_;
+        if s.input_pos_ != s.last_flush_pos_ {
+            let mut avail_out: usize = s.available_out_;
             let result: i32 = EncodeData(s, 0i32, 1i32, &mut avail_out, metablock_callback);
-            (*s).available_out_ = avail_out;
+            s.available_out_ = avail_out;
             if result == 0 {
                 return 0i32;
             }
@@ -2871,21 +2863,21 @@ fn ProcessMetadata<
                 }
             }
         }
-        if (*s).stream_state_ as (i32)
+        if s.stream_state_ as (i32)
             == BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as (i32)
         {
-            (*s).next_out_ = NextOut::TinyBuf(0);
-            (*s).available_out_ = WriteMetadataHeader(s);
-            (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_METADATA_BODY;
+            s.next_out_ = NextOut::TinyBuf(0);
+            s.available_out_ = WriteMetadataHeader(s);
+            s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_METADATA_BODY;
             {
                 {
                     continue;
                 }
             }
         } else {
-            if (*s).remaining_metadata_bytes_ == 0u32 {
-                (*s).remaining_metadata_bytes_ = !(0u32);
-                (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING;
+            if s.remaining_metadata_bytes_ == 0u32 {
+                s.remaining_metadata_bytes_ = !(0u32);
+                s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING;
                 {
                     {
                         break;
@@ -2894,7 +2886,7 @@ fn ProcessMetadata<
             }
             if *available_out != 0 {
                 let copy: u32 =
-                    brotli_min_size_t((*s).remaining_metadata_bytes_ as (usize), *available_out)
+                    brotli_min_size_t(s.remaining_metadata_bytes_ as (usize), *available_out)
                         as (u32);
                 next_out_array[*next_out_offset..(*next_out_offset + copy as usize)]
                     .clone_from_slice(
@@ -2904,13 +2896,13 @@ fn ProcessMetadata<
                 // *next_in = (*next_in).offset(copy as (isize));
                 *next_in_offset += copy as usize;
                 *available_in = (*available_in).wrapping_sub(copy as (usize));
-                (*s).remaining_metadata_bytes_ = (*s).remaining_metadata_bytes_.wrapping_sub(copy);
+                s.remaining_metadata_bytes_ = s.remaining_metadata_bytes_.wrapping_sub(copy);
                 *next_out_offset += copy as usize;
                 // *next_out = (*next_out).offset(copy as (isize));
                 *available_out = (*available_out).wrapping_sub(copy as (usize));
             } else {
-                let copy: u32 = brotli_min_uint32_t((*s).remaining_metadata_bytes_, 16u32);
-                (*s).next_out_ = NextOut::TinyBuf(0);
+                let copy: u32 = brotli_min_uint32_t(s.remaining_metadata_bytes_, 16u32);
+                s.next_out_ = NextOut::TinyBuf(0);
                 GetNextOut!(s)[..(copy as usize)].clone_from_slice(
                     &next_in_array[*next_in_offset..(*next_in_offset + copy as usize)],
                 );
@@ -2918,8 +2910,8 @@ fn ProcessMetadata<
                 // *next_in = (*next_in).offset(copy as (isize));
                 *next_in_offset += copy as usize;
                 *available_in = (*available_in).wrapping_sub(copy as (usize));
-                (*s).remaining_metadata_bytes_ = (*s).remaining_metadata_bytes_.wrapping_sub(copy);
-                (*s).available_out_ = copy as (usize);
+                s.remaining_metadata_bytes_ = s.remaining_metadata_bytes_.wrapping_sub(copy);
+                s.available_out_ = copy as (usize);
             }
             {
                 {
@@ -2944,11 +2936,7 @@ fn CheckFlushCompleteInner(
 }
 
 fn CheckFlushComplete<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>) {
-    CheckFlushCompleteInner(
-        &mut (*s).stream_state_,
-        (*s).available_out_,
-        &mut (*s).next_out_,
-    );
+    CheckFlushCompleteInner(&mut s.stream_state_, s.available_out_, &mut s.next_out_);
 }
 
 fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
@@ -2962,30 +2950,30 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
     next_out_offset: &mut usize,
     total_out: &mut Option<usize>,
 ) -> i32 {
-    let block_size_limit: usize = 1usize << (*s).params.lgwin;
+    let block_size_limit: usize = 1usize << s.params.lgwin;
     let buf_size: usize = brotli_min_size_t(
         kCompressFragmentTwoPassBlockSize,
         brotli_min_size_t(*available_in, block_size_limit),
     );
     let mut command_buf = <Alloc as Allocator<u32>>::AllocatedMemory::default();
     let mut literal_buf = <Alloc as Allocator<u8>>::AllocatedMemory::default();
-    if (*s).params.quality != 0i32 && ((*s).params.quality != 1i32) {
+    if s.params.quality != 0i32 && (s.params.quality != 1i32) {
         return 0i32;
     }
-    if (*s).params.quality == 1i32 {
-        if (*s).command_buf_.slice().len() == 0 && (buf_size == kCompressFragmentTwoPassBlockSize) {
-            (*s).command_buf_ =
+    if s.params.quality == 1i32 {
+        if s.command_buf_.slice().len() == 0 && (buf_size == kCompressFragmentTwoPassBlockSize) {
+            s.command_buf_ =
                 <Alloc as Allocator<u32>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
-            (*s).literal_buf_ =
+            s.literal_buf_ =
                 <Alloc as Allocator<u8>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
         }
-        if (*s).command_buf_.slice().len() != 0 {
+        if s.command_buf_.slice().len() != 0 {
             command_buf = core::mem::replace(
-                &mut (*s).command_buf_,
+                &mut s.command_buf_,
                 <Alloc as Allocator<u32>>::AllocatedMemory::default(),
             );
             literal_buf = core::mem::replace(
-                &mut (*s).literal_buf_,
+                &mut s.literal_buf_,
                 <Alloc as Allocator<u8>>::AllocatedMemory::default(),
             );
         } else {
@@ -3001,8 +2989,8 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 continue;
             }
         }
-        if (*s).available_out_ == 0usize
-            && ((*s).stream_state_ as (i32)
+        if s.available_out_ == 0usize
+            && (s.stream_state_ as (i32)
                 == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32))
             && (*available_in != 0usize
                 || op as (i32) != BrotliEncoderOperation::BROTLI_OPERATION_PROCESS as (i32))
@@ -3017,11 +3005,11 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             let max_out_size: usize = (2usize).wrapping_mul(block_size).wrapping_add(503usize);
             let mut inplace: i32 = 1i32;
             let storage: &mut [u8];
-            let mut storage_ix: usize = (*s).last_bytes_bits_ as (usize);
+            let mut storage_ix: usize = s.last_bytes_bits_ as (usize);
             let mut table_size: usize = 0;
             let table: &mut [i32];
             if force_flush != 0 && (block_size == 0usize) {
-                (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
+                s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
                 {
                     {
                         continue;
@@ -3033,12 +3021,12 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             } else {
                 inplace = 0i32;
                 GetBrotliStorage(s, max_out_size);
-                storage = (*s).storage_.slice_mut();
+                storage = s.storage_.slice_mut();
             }
-            storage[(0usize)] = (*s).last_bytes_ as u8;
-            storage[(1usize)] = ((*s).last_bytes_ >> 8) as u8;
-            table = GetHashTable!(s, (*s).params.quality, block_size, &mut table_size);
-            if (*s).params.quality == 0i32 {
+            storage[(0usize)] = s.last_bytes_ as u8;
+            storage[(1usize)] = (s.last_bytes_ >> 8) as u8;
+            table = GetHashTable!(s, s.params.quality, block_size, &mut table_size);
+            if s.params.quality == 0i32 {
                 BrotliCompressFragmentFast(
                     &mut s.m8,
                     &(next_in_array)[*next_in_offset..],
@@ -3046,10 +3034,10 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                     is_last,
                     table,
                     table_size,
-                    &mut (*s).cmd_depths_[..],
-                    &mut (*s).cmd_bits_[..],
-                    &mut (*s).cmd_code_numbits_,
-                    &mut (*s).cmd_code_[..],
+                    &mut s.cmd_depths_[..],
+                    &mut s.cmd_bits_[..],
+                    &mut s.cmd_code_numbits_,
+                    &mut s.cmd_code_[..],
                     &mut storage_ix,
                     storage,
                 );
@@ -3075,23 +3063,23 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 0i32;
                 *next_out_offset += out_bytes as (usize);
                 *available_out = (*available_out).wrapping_sub(out_bytes);
-                (*s).total_out_ = (*s).total_out_.wrapping_add(out_bytes as u64);
+                s.total_out_ = s.total_out_.wrapping_add(out_bytes as u64);
                 if let &mut Some(ref mut total_out_inner) = total_out {
-                    *total_out_inner = (*s).total_out_ as usize;
+                    *total_out_inner = s.total_out_ as usize;
                 }
             } else {
                 let out_bytes: usize = storage_ix >> 3i32;
-                (*s).next_out_ = NextOut::DynamicStorage(0);
-                (*s).available_out_ = out_bytes;
+                s.next_out_ = NextOut::DynamicStorage(0);
+                s.available_out_ = out_bytes;
             }
-            (*s).last_bytes_ = storage[((storage_ix >> 3i32) as (usize))] as u16
+            s.last_bytes_ = storage[((storage_ix >> 3i32) as (usize))] as u16
                 | ((storage[1 + ((storage_ix >> 3i32) as (usize))] as u16) << 8);
-            (*s).last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
+            s.last_bytes_bits_ = (storage_ix & 7u32 as (usize)) as (u8);
             if force_flush != 0 {
-                (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
+                s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
             }
             if is_last != 0 {
-                (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
+                s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
             }
             {
                 {
@@ -3109,11 +3097,11 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
         && s.command_buf_.slice().len() == 0
     {
         // undo temporary aliasing of command_buf and literal_buf
-        (*s).command_buf_ = core::mem::replace(
+        s.command_buf_ = core::mem::replace(
             &mut command_buf,
             <Alloc as Allocator<u32>>::AllocatedMemory::default(),
         );
-        (*s).literal_buf_ = core::mem::replace(
+        s.literal_buf_ = core::mem::replace(
             &mut literal_buf,
             <Alloc as Allocator<u8>>::AllocatedMemory::default(),
         );
@@ -3156,8 +3144,8 @@ pub fn BrotliEncoderCompressStream<
     if EnsureInitialized(s) == 0 {
         return 0i32;
     }
-    if (*s).remaining_metadata_bytes_ != !(0u32) {
-        if *available_in != (*s).remaining_metadata_bytes_ as (usize) {
+    if s.remaining_metadata_bytes_ != !(0u32) {
+        if *available_in != s.remaining_metadata_bytes_ as (usize) {
             return 0i32;
         }
         if op as (i32) != BrotliEncoderOperation::BROTLI_OPERATION_EMIT_METADATA as (i32) {
@@ -3178,18 +3166,18 @@ pub fn BrotliEncoderCompressStream<
             metablock_callback,
         );
     }
-    if (*s).stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as (i32)
-        || (*s).stream_state_ as (i32)
+    if s.stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as (i32)
+        || s.stream_state_ as (i32)
             == BrotliEncoderStreamState::BROTLI_STREAM_METADATA_BODY as (i32)
     {
         return 0i32;
     }
-    if (*s).stream_state_ as (i32) != BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32)
+    if s.stream_state_ as (i32) != BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32)
         && (*available_in != 0usize)
     {
         return 0i32;
     }
-    if ((*s).params.quality == 0i32 || (*s).params.quality == 1i32) && !s.params.catable {
+    if (s.params.quality == 0i32 || s.params.quality == 1i32) && !s.params.catable {
         // this part of the code does not support concatability
         return BrotliEncoderCompressStreamFast(
             s,
@@ -3223,8 +3211,8 @@ pub fn BrotliEncoderCompressStream<
                 continue;
             }
         }
-        if (*s).available_out_ == 0usize
-            && ((*s).stream_state_ as (i32)
+        if s.available_out_ == 0usize
+            && (s.stream_state_ as (i32)
                 == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as (i32))
         {
             if remaining_block_size == 0usize
@@ -3246,18 +3234,18 @@ pub fn BrotliEncoderCompressStream<
                 };
                 let result: i32;
                 UpdateSizeHint(s, *available_in);
-                let mut avail_out = (*s).available_out_;
+                let mut avail_out = s.available_out_;
                 result = EncodeData(s, is_last, force_flush, &mut avail_out, metablock_callback);
-                (*s).available_out_ = avail_out;
+                s.available_out_ = avail_out;
                 //this function set next_out to &storage[0]
                 if result == 0 {
                     return 0i32;
                 }
                 if force_flush != 0 {
-                    (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
+                    s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
                 }
                 if is_last != 0 {
-                    (*s).stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
+                    s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
                 }
                 {
                     {
@@ -3277,7 +3265,7 @@ pub fn BrotliEncoderCompressStream<
 }
 
 pub fn BrotliEncoderIsFinished<Alloc: BrotliAlloc>(s: &BrotliEncoderStateStruct<Alloc>) -> i32 {
-    if !!((*s).stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_FINISHED as (i32)
+    if !!(s.stream_state_ as (i32) == BrotliEncoderStreamState::BROTLI_STREAM_FINISHED as (i32)
         && (BrotliEncoderHasMoreOutput(s) == 0))
     {
         1i32
@@ -3287,7 +3275,7 @@ pub fn BrotliEncoderIsFinished<Alloc: BrotliAlloc>(s: &BrotliEncoderStateStruct<
 }
 
 pub fn BrotliEncoderHasMoreOutput<Alloc: BrotliAlloc>(s: &BrotliEncoderStateStruct<Alloc>) -> i32 {
-    if !!((*s).available_out_ != 0usize) {
+    if !!(s.available_out_ != 0usize) {
         1i32
     } else {
         0i32
@@ -3298,20 +3286,16 @@ pub fn BrotliEncoderTakeOutput<'a, Alloc: BrotliAlloc>(
     s: &'a mut BrotliEncoderStateStruct<Alloc>,
     size: &mut usize,
 ) -> &'a [u8] {
-    let mut consumed_size: usize = (*s).available_out_;
+    let mut consumed_size: usize = s.available_out_;
     let mut result: &[u8] = GetNextOut!(*s);
     if *size != 0 {
-        consumed_size = brotli_min_size_t(*size, (*s).available_out_);
+        consumed_size = brotli_min_size_t(*size, s.available_out_);
     }
     if consumed_size != 0 {
-        (*s).next_out_ = NextOutIncrement(&(*s).next_out_, consumed_size as i32);
-        (*s).available_out_ = (*s).available_out_.wrapping_sub(consumed_size);
-        (*s).total_out_ = (*s).total_out_.wrapping_add(consumed_size as u64);
-        CheckFlushCompleteInner(
-            &mut (*s).stream_state_,
-            (*s).available_out_,
-            &mut (*s).next_out_,
-        );
+        s.next_out_ = NextOutIncrement(&s.next_out_, consumed_size as i32);
+        s.available_out_ = s.available_out_.wrapping_sub(consumed_size);
+        s.total_out_ = s.total_out_.wrapping_add(consumed_size as u64);
+        CheckFlushCompleteInner(&mut s.stream_state_, s.available_out_, &mut s.next_out_);
         *size = consumed_size;
     } else {
         *size = 0usize;
@@ -3356,6 +3340,6 @@ pub fn BrotliEncoderWriteData<
     metablock_callback: &mut MetablockCallback,
 ) -> i32 {
     let ret = EncodeData(s, is_last, force_flush, out_size, metablock_callback);
-    *output = (*s).storage_.slice_mut();
+    *output = s.storage_.slice_mut();
     ret
 }

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -75,13 +75,13 @@ pub trait HuffmanComparator {
 pub struct SortHuffmanTree {}
 impl HuffmanComparator for SortHuffmanTree {
     fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
-        if (*v0).total_count_ != (*v1).total_count_ {
-            if !!((*v0).total_count_ < (*v1).total_count_) {
+        if v0.total_count_ != v1.total_count_ {
+            if !!(v0.total_count_ < v1.total_count_) {
                 true
             } else {
                 false
             }
-        } else if !!((*v0).index_right_or_value_ as (i32) > (*v1).index_right_or_value_ as (i32)) {
+        } else if !!(v0.index_right_or_value_ as (i32) > v1.index_right_or_value_ as (i32)) {
             true
         } else {
             false

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -340,8 +340,8 @@ fn NewBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>
         split_: split,
         idx_: 0i32 as (usize),
         type_: 0i32 as (usize),
-        length_: if (*split).lengths.slice().len() != 0 {
-            (*split).lengths.slice()[0] as usize
+        length_: if split.lengths.slice().len() != 0 {
+            split.lengths.slice()[0] as usize
         } else {
             0i32 as (usize)
         },
@@ -352,11 +352,11 @@ fn InitBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32
     xself: &'a mut BlockSplitIterator<'a, Alloc>,
     split: &'a BlockSplit<Alloc>,
 ) {
-    (*xself).split_ = split;
-    (*xself).idx_ = 0i32 as (usize);
-    (*xself).type_ = 0i32 as (usize);
-    (*xself).length_ = if (*split).lengths.slice().len() != 0 {
-        (*split).lengths.slice()[0] as u32
+    xself.split_ = split;
+    xself.idx_ = 0i32 as (usize);
+    xself.type_ = 0i32 as (usize);
+    xself.length_ = if split.lengths.slice().len() != 0 {
+        split.lengths.slice()[0] as u32
     } else {
         0i32 as (u32)
     } as (usize);
@@ -364,12 +364,12 @@ fn InitBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32
 fn BlockSplitIteratorNext<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>>(
     xself: &mut BlockSplitIterator<Alloc>,
 ) {
-    if (*xself).length_ == 0i32 as (usize) {
-        (*xself).idx_ = (*xself).idx_.wrapping_add(1 as (usize));
-        (*xself).type_ = (*(*xself).split_).types.slice()[(*xself).idx_ as (usize)] as (usize);
-        (*xself).length_ = (*(*xself).split_).lengths.slice()[(*xself).idx_ as (usize)] as (usize);
+    if xself.length_ == 0i32 as (usize) {
+        xself.idx_ = xself.idx_.wrapping_add(1 as (usize));
+        xself.type_ = xself.split_.types.slice()[xself.idx_ as (usize)] as (usize);
+        xself.length_ = xself.split_.lengths.slice()[xself.idx_ as (usize)] as (usize);
     }
-    (*xself).length_ = (*xself).length_.wrapping_sub(1 as (usize));
+    xself.length_ = xself.length_.wrapping_sub(1 as (usize));
 }
 pub fn HistogramAddItem<HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> + CostAccessors>(
     xself: &mut HistogramType,
@@ -512,9 +512,9 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
             BlockSplitIteratorNext(&mut insert_and_copy_it);
             HistogramAddItem(
                 &mut insert_and_copy_histograms[(insert_and_copy_it.type_ as (usize))],
-                (*cmd).cmd_prefix_ as (usize),
+                cmd.cmd_prefix_ as (usize),
             );
-            j = (*cmd).insert_len_ as (usize);
+            j = cmd.insert_len_ as (usize);
             while j != 0usize {
                 {
                     let context: usize;
@@ -543,14 +543,14 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
             if CommandCopyLen(cmd) != 0 {
                 prev_byte2 = ringbuffer[((pos.wrapping_sub(2usize) & mask) as (usize))];
                 prev_byte = ringbuffer[((pos.wrapping_sub(1usize) & mask) as (usize))];
-                if (*cmd).cmd_prefix_ as (i32) >= 128i32 {
+                if cmd.cmd_prefix_ as (i32) >= 128i32 {
                     let context: usize;
                     BlockSplitIteratorNext(&mut dist_it);
                     context = (dist_it.type_ << 2i32)
                         .wrapping_add(CommandDistanceContext(cmd) as (usize));
                     HistogramAddItem(
                         &mut copy_dist_histograms[(context as (usize))],
-                        (*cmd).dist_prefix_ as (usize) & 0x3ff,
+                        cmd.dist_prefix_ as (usize) & 0x3ff,
                     );
                 }
             }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -222,36 +222,36 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         lit_scratch_space,
         cmd_scratch_space,
         dst_scratch_space,
-        &mut (*mb).literal_split,
-        &mut (*mb).command_split,
-        &mut (*mb).distance_split,
+        &mut mb.literal_split,
+        &mut mb.command_split,
+        &mut mb.distance_split,
     );
-    if (*params).disable_literal_context_modeling == 0 {
+    if params.disable_literal_context_modeling == 0 {
         literal_context_multiplier = (1i32 << 6i32) as (usize);
         literal_context_modes =
-            <Alloc as Allocator<ContextType>>::alloc_cell(alloc, (*mb).literal_split.num_types);
+            <Alloc as Allocator<ContextType>>::alloc_cell(alloc, mb.literal_split.num_types);
         for item in literal_context_modes.slice_mut().iter_mut() {
             *item = literal_context_mode;
         }
     }
-    literal_histograms_size = (*mb)
+    literal_histograms_size = mb
         .literal_split
         .num_types
         .wrapping_mul(literal_context_multiplier);
     literal_histograms =
         <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, literal_histograms_size);
-    distance_histograms_size = (*mb).distance_split.num_types << 2i32;
+    distance_histograms_size = mb.distance_split.num_types << 2i32;
     distance_histograms =
         <Alloc as Allocator<HistogramDistance>>::alloc_cell(alloc, distance_histograms_size);
-    (*mb).command_histograms_size = (*mb).command_split.num_types;
-    (*mb).command_histograms =
-        <Alloc as Allocator<HistogramCommand>>::alloc_cell(alloc, (*mb).command_histograms_size);
+    mb.command_histograms_size = mb.command_split.num_types;
+    mb.command_histograms =
+        <Alloc as Allocator<HistogramCommand>>::alloc_cell(alloc, mb.command_histograms_size);
     BrotliBuildHistogramsWithContext(
         cmds,
         num_commands,
-        &mut (*mb).literal_split,
-        &mut (*mb).command_split,
-        &mut (*mb).distance_split,
+        &mut mb.literal_split,
+        &mut mb.command_split,
+        &mut mb.distance_split,
         ringbuffer,
         pos,
         mask,
@@ -259,57 +259,57 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         prev_byte2,
         literal_context_modes.slice(),
         literal_histograms.slice_mut(),
-        (*mb).command_histograms.slice_mut(),
+        mb.command_histograms.slice_mut(),
         distance_histograms.slice_mut(),
     );
     <Alloc as Allocator<ContextType>>::free_cell(alloc, literal_context_modes);
-    (*mb).literal_context_map_size = (*mb).literal_split.num_types << 6i32;
-    (*mb).literal_context_map =
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, (*mb).literal_context_map_size);
-    (*mb).literal_histograms_size = (*mb).literal_context_map_size;
-    (*mb).literal_histograms =
-        <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, (*mb).literal_histograms_size);
+    mb.literal_context_map_size = mb.literal_split.num_types << 6i32;
+    mb.literal_context_map =
+        <Alloc as Allocator<u32>>::alloc_cell(alloc, mb.literal_context_map_size);
+    mb.literal_histograms_size = mb.literal_context_map_size;
+    mb.literal_histograms =
+        <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, mb.literal_histograms_size);
     BrotliClusterHistograms(
         alloc,
         literal_histograms.slice(),
         literal_histograms_size,
         kMaxNumberOfHistograms,
         lit_scratch_space,
-        (*mb).literal_histograms.slice_mut(),
-        &mut (*mb).literal_histograms_size,
-        (*mb).literal_context_map.slice_mut(),
+        mb.literal_histograms.slice_mut(),
+        &mut mb.literal_histograms_size,
+        mb.literal_context_map.slice_mut(),
     );
     <Alloc as Allocator<HistogramLiteral>>::free_cell(alloc, literal_histograms);
-    if (*params).disable_literal_context_modeling != 0 {
-        i = (*mb).literal_split.num_types;
+    if params.disable_literal_context_modeling != 0 {
+        i = mb.literal_split.num_types;
         while i != 0usize {
             let mut j: usize = 0usize;
             i = i.wrapping_sub(1 as (usize));
             while j < (1i32 << 6i32) as (usize) {
                 {
-                    let val = (*mb).literal_context_map.slice()[(i as (usize))];
-                    (*mb).literal_context_map.slice_mut()
-                        [((i << 6i32).wrapping_add(j) as (usize))] = val;
+                    let val = mb.literal_context_map.slice()[(i as (usize))];
+                    mb.literal_context_map.slice_mut()[((i << 6i32).wrapping_add(j) as (usize))] =
+                        val;
                 }
                 j = j.wrapping_add(1 as (usize));
             }
         }
     }
-    (*mb).distance_context_map_size = (*mb).distance_split.num_types << 2i32;
-    (*mb).distance_context_map =
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, (*mb).distance_context_map_size);
-    (*mb).distance_histograms_size = (*mb).distance_context_map_size;
-    (*mb).distance_histograms =
-        <Alloc as Allocator<HistogramDistance>>::alloc_cell(alloc, (*mb).distance_histograms_size);
+    mb.distance_context_map_size = mb.distance_split.num_types << 2i32;
+    mb.distance_context_map =
+        <Alloc as Allocator<u32>>::alloc_cell(alloc, mb.distance_context_map_size);
+    mb.distance_histograms_size = mb.distance_context_map_size;
+    mb.distance_histograms =
+        <Alloc as Allocator<HistogramDistance>>::alloc_cell(alloc, mb.distance_histograms_size);
     BrotliClusterHistograms(
         alloc,
         distance_histograms.slice(),
-        (*mb).distance_context_map_size,
+        mb.distance_context_map_size,
         kMaxNumberOfHistograms,
         dst_scratch_space,
-        (*mb).distance_histograms.slice_mut(),
-        &mut (*mb).distance_histograms_size,
-        (*mb).distance_context_map.slice_mut(),
+        mb.distance_histograms.slice_mut(),
+        &mut mb.distance_histograms_size,
+        mb.distance_context_map.slice_mut(),
     );
     <Alloc as Allocator<HistogramDistance>>::free_cell(alloc, distance_histograms);
 }
@@ -428,47 +428,47 @@ fn InitBlockSplitter<
         last_histogram_ix_: [0usize; 2],
     };
     {
-        if (*split).types.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).types.slice().len() == 0usize {
+        if split.types.slice().len() < max_num_blocks {
+            let mut _new_size: usize = if split.types.slice().len() == 0usize {
                 max_num_blocks
             } else {
-                (*split).types.slice().len()
+                split.types.slice().len()
             };
             let mut new_array: <Alloc as Allocator<u8>>::AllocatedMemory;
             while _new_size < max_num_blocks {
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
-            if ((*split).types.slice().len() != 0usize) {
-                new_array.slice_mut()[..(*split).types.slice().len()]
-                    .clone_from_slice((*split).types.slice());
+            if (split.types.slice().len() != 0usize) {
+                new_array.slice_mut()[..split.types.slice().len()]
+                    .clone_from_slice(split.types.slice());
             }
             <Alloc as Allocator<u8>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).types, new_array),
+                core::mem::replace(&mut split.types, new_array),
             );
         }
     }
     {
-        if (*split).lengths.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).lengths.slice().len() == 0usize {
+        if split.lengths.slice().len() < max_num_blocks {
+            let mut _new_size: usize = if split.lengths.slice().len() == 0usize {
                 max_num_blocks
             } else {
-                (*split).lengths.slice().len()
+                split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
-            new_array.slice_mut()[..(*split).lengths.slice().len()]
-                .clone_from_slice((*split).lengths.slice());
+            new_array.slice_mut()[..split.lengths.slice().len()]
+                .clone_from_slice(split.lengths.slice());
             <Alloc as Allocator<u32>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).lengths, new_array),
+                core::mem::replace(&mut split.lengths, new_array),
             );
         }
     }
-    (*split).num_blocks = max_num_blocks;
+    split.num_blocks = max_num_blocks;
     *histograms_size = max_num_types;
     let hlocal = <Alloc as Allocator<HistogramType>>::alloc_cell(alloc, *histograms_size);
     <Alloc as Allocator<HistogramType>>::free_cell(
@@ -515,48 +515,48 @@ fn InitContextBlockSplitter<
     };
     max_num_types = brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1usize));
     {
-        if (*split).types.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).types.slice().len() == 0usize {
+        if split.types.slice().len() < max_num_blocks {
+            let mut _new_size: usize = if split.types.slice().len() == 0usize {
                 max_num_blocks
             } else {
-                (*split).types.slice().len()
+                split.types.slice().len()
             };
             while _new_size < max_num_blocks {
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
-            if ((*split).types.slice().len() != 0usize) {
-                new_array.slice_mut()[..(*split).types.slice().len()]
-                    .clone_from_slice((*split).types.slice());
+            if (split.types.slice().len() != 0usize) {
+                new_array.slice_mut()[..split.types.slice().len()]
+                    .clone_from_slice(split.types.slice());
             }
             <Alloc as Allocator<u8>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).types, new_array),
+                core::mem::replace(&mut split.types, new_array),
             );
         }
     }
     {
-        if (*split).lengths.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).lengths.slice().len() == 0usize {
+        if split.lengths.slice().len() < max_num_blocks {
+            let mut _new_size: usize = if split.lengths.slice().len() == 0usize {
                 max_num_blocks
             } else {
-                (*split).lengths.slice().len()
+                split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
-            if ((*split).lengths.slice().len() != 0usize) {
-                new_array.slice_mut()[..(*split).lengths.slice().len()]
-                    .clone_from_slice((*split).lengths.slice());
+            if (split.lengths.slice().len() != 0usize) {
+                new_array.slice_mut()[..split.lengths.slice().len()]
+                    .clone_from_slice(split.lengths.slice());
             }
             <Alloc as Allocator<u32>>::free_cell(
                 alloc,
-                core::mem::replace(&mut (*split).lengths, new_array),
+                core::mem::replace(&mut split.lengths, new_array),
             );
         }
     }
-    (*split).num_blocks = max_num_blocks;
+    split.num_blocks = max_num_blocks;
     *histograms_size = max_num_types.wrapping_mul(num_contexts);
     *histograms = <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, *histograms_size);
     //(*xself).histograms_ = *histograms;
@@ -576,28 +576,28 @@ fn BlockSplitterFinishBlock<
     histograms_size: &mut usize,
     is_final: i32,
 ) {
-    (*xself).block_size_ = brotli_max_size_t((*xself).block_size_, (*xself).min_block_size_);
-    if (*xself).num_blocks_ == 0usize {
-        (*split).lengths.slice_mut()[(0usize)] = (*xself).block_size_ as (u32);
-        (*split).types.slice_mut()[(0usize)] = 0i32 as (u8);
-        (*xself).last_entropy_[(0usize)] =
-            BitsEntropy((histograms[(0usize)]).slice(), (*xself).alphabet_size_);
-        (*xself).last_entropy_[(1usize)] = (*xself).last_entropy_[(0usize)];
-        (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-        (*split).num_types = (*split).num_types.wrapping_add(1 as (usize));
-        (*xself).curr_histogram_ix_ = (*xself).curr_histogram_ix_.wrapping_add(1 as (usize));
-        if (*xself).curr_histogram_ix_ < *histograms_size {
-            HistogramClear(&mut histograms[((*xself).curr_histogram_ix_ as (usize))]);
+    xself.block_size_ = brotli_max_size_t(xself.block_size_, xself.min_block_size_);
+    if xself.num_blocks_ == 0usize {
+        split.lengths.slice_mut()[(0usize)] = xself.block_size_ as (u32);
+        split.types.slice_mut()[(0usize)] = 0i32 as (u8);
+        xself.last_entropy_[(0usize)] =
+            BitsEntropy((histograms[(0usize)]).slice(), xself.alphabet_size_);
+        xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
+        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+        split.num_types = split.num_types.wrapping_add(1 as (usize));
+        xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1 as (usize));
+        if xself.curr_histogram_ix_ < *histograms_size {
+            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
         }
-        (*xself).block_size_ = 0usize;
-    } else if (*xself).block_size_ > 0usize {
+        xself.block_size_ = 0usize;
+    } else if xself.block_size_ > 0usize {
         let entropy: super::util::floatX = BitsEntropy(
-            (histograms[((*xself).curr_histogram_ix_ as (usize))]).slice(),
-            (*xself).alphabet_size_,
+            (histograms[(xself.curr_histogram_ix_ as (usize))]).slice(),
+            xself.alphabet_size_,
         );
         let mut combined_histo: [HistogramType; 2] = [
-            histograms[(*xself).curr_histogram_ix_].clone(),
-            histograms[(*xself).curr_histogram_ix_].clone(),
+            histograms[xself.curr_histogram_ix_].clone(),
+            histograms[xself.curr_histogram_ix_].clone(),
         ];
 
         let mut combined_entropy: [super::util::floatX; 2] =
@@ -606,87 +606,83 @@ fn BlockSplitterFinishBlock<
             [0.0 as super::util::floatX, 0.0 as super::util::floatX];
         for j in 0..2 {
             {
-                let last_histogram_ix: usize = (*xself).last_histogram_ix_[j];
+                let last_histogram_ix: usize = xself.last_histogram_ix_[j];
                 HistogramAddHistogram(
                     &mut combined_histo[j],
                     &histograms[(last_histogram_ix as (usize))],
                 );
                 combined_entropy[j] = BitsEntropy(
                     &mut combined_histo[j].slice_mut()[0usize..],
-                    (*xself).alphabet_size_,
+                    xself.alphabet_size_,
                 );
-                diff[j] = combined_entropy[j] - entropy - (*xself).last_entropy_[(j as (usize))];
+                diff[j] = combined_entropy[j] - entropy - xself.last_entropy_[(j as (usize))];
             }
         }
-        if (*split).num_types < 256usize
-            && (diff[0usize] > (*xself).split_threshold_)
-            && (diff[1usize] > (*xself).split_threshold_)
+        if split.num_types < 256usize
+            && (diff[0usize] > xself.split_threshold_)
+            && (diff[1usize] > xself.split_threshold_)
         {
-            (*split).lengths.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*xself).block_size_ as (u32);
-            (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*split).num_types as (u8);
-            (*xself).last_histogram_ix_[1usize] = (*xself).last_histogram_ix_[0usize];
-            (*xself).last_histogram_ix_[0usize] = (*split).num_types as (u8) as (usize);
-            (*xself).last_entropy_[(1usize)] = (*xself).last_entropy_[(0usize)];
-            (*xself).last_entropy_[(0usize)] = entropy;
-            (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-            (*split).num_types = (*split).num_types.wrapping_add(1 as (usize));
-            (*xself).curr_histogram_ix_ = (*xself).curr_histogram_ix_.wrapping_add(1 as (usize));
-            if (*xself).curr_histogram_ix_ < *histograms_size {
-                HistogramClear(&mut histograms[((*xself).curr_histogram_ix_ as (usize))]);
+            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
+            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = split.num_types as (u8);
+            xself.last_histogram_ix_[1usize] = xself.last_histogram_ix_[0usize];
+            xself.last_histogram_ix_[0usize] = split.num_types as (u8) as (usize);
+            xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
+            xself.last_entropy_[(0usize)] = entropy;
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            split.num_types = split.num_types.wrapping_add(1 as (usize));
+            xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1 as (usize));
+            if xself.curr_histogram_ix_ < *histograms_size {
+                HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
             }
-            (*xself).block_size_ = 0usize;
-            (*xself).merge_last_count_ = 0usize;
-            (*xself).target_block_size_ = (*xself).min_block_size_;
+            xself.block_size_ = 0usize;
+            xself.merge_last_count_ = 0usize;
+            xself.target_block_size_ = xself.min_block_size_;
         } else if diff[1usize] < diff[0usize] - 20.0 as super::util::floatX {
-            (*split).lengths.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*xself).block_size_ as (u32);
-            (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*split).types.slice()[((*xself).num_blocks_.wrapping_sub(2usize) as (usize))]; //FIXME: investigate copy?
+            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
+            split.types.slice_mut()[(xself.num_blocks_ as (usize))] =
+                split.types.slice()[(xself.num_blocks_.wrapping_sub(2usize) as (usize))]; //FIXME: investigate copy?
             {
-                let mut __brotli_swap_tmp: usize = (*xself).last_histogram_ix_[0usize];
-                (*xself).last_histogram_ix_[0usize] = (*xself).last_histogram_ix_[1usize];
-                (*xself).last_histogram_ix_[1usize] = __brotli_swap_tmp;
+                let mut __brotli_swap_tmp: usize = xself.last_histogram_ix_[0usize];
+                xself.last_histogram_ix_[0usize] = xself.last_histogram_ix_[1usize];
+                xself.last_histogram_ix_[1usize] = __brotli_swap_tmp;
             }
-            histograms[((*xself).last_histogram_ix_[0usize] as (usize))] =
+            histograms[(xself.last_histogram_ix_[0usize] as (usize))] =
                 combined_histo[1usize].clone();
-            (*xself).last_entropy_[(1usize)] = (*xself).last_entropy_[(0usize)];
-            (*xself).last_entropy_[(0usize)] = combined_entropy[1usize];
-            (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-            (*xself).block_size_ = 0usize;
-            HistogramClear(&mut histograms[((*xself).curr_histogram_ix_ as (usize))]);
-            (*xself).merge_last_count_ = 0usize;
-            (*xself).target_block_size_ = (*xself).min_block_size_;
+            xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
+            xself.last_entropy_[(0usize)] = combined_entropy[1usize];
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            xself.block_size_ = 0usize;
+            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
+            xself.merge_last_count_ = 0usize;
+            xself.target_block_size_ = xself.min_block_size_;
         } else {
             {
-                let _rhs = (*xself).block_size_ as (u32);
-                let _lhs = &mut (*split).lengths.slice_mut()
-                    [((*xself).num_blocks_.wrapping_sub(1usize) as (usize))];
+                let _rhs = xself.block_size_ as (u32);
+                let _lhs = &mut split.lengths.slice_mut()
+                    [(xself.num_blocks_.wrapping_sub(1usize) as (usize))];
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
-            histograms[((*xself).last_histogram_ix_[0usize] as (usize))] =
+            histograms[(xself.last_histogram_ix_[0usize] as (usize))] =
                 combined_histo[0usize].clone();
-            (*xself).last_entropy_[(0usize)] = combined_entropy[0usize];
-            if (*split).num_types == 1usize {
-                (*xself).last_entropy_[(1usize)] = (*xself).last_entropy_[(0usize)];
+            xself.last_entropy_[(0usize)] = combined_entropy[0usize];
+            if split.num_types == 1usize {
+                xself.last_entropy_[(1usize)] = xself.last_entropy_[(0usize)];
             }
-            (*xself).block_size_ = 0usize;
-            HistogramClear(&mut histograms[((*xself).curr_histogram_ix_ as (usize))]);
+            xself.block_size_ = 0usize;
+            HistogramClear(&mut histograms[(xself.curr_histogram_ix_ as (usize))]);
             if {
-                (*xself).merge_last_count_ = (*xself).merge_last_count_.wrapping_add(1 as (usize));
-                (*xself).merge_last_count_
+                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1 as (usize));
+                xself.merge_last_count_
             } > 1usize
             {
-                (*xself).target_block_size_ = (*xself)
-                    .target_block_size_
-                    .wrapping_add((*xself).min_block_size_);
+                xself.target_block_size_ =
+                    xself.target_block_size_.wrapping_add(xself.min_block_size_);
             }
         }
     }
     if is_final != 0 {
-        *histograms_size = (*split).num_types;
-        (*split).num_blocks = (*xself).num_blocks_;
+        *histograms_size = split.num_types;
+        split.num_blocks = xself.num_blocks_;
     }
 }
 const BROTLI_MAX_STATIC_CONTEXTS: usize = 13;
@@ -702,37 +698,35 @@ fn ContextBlockSplitterFinishBlock<
     histograms_size: &mut usize,
     is_final: i32,
 ) {
-    let num_contexts: usize = (*xself).num_contexts_;
-    if (*xself).block_size_ < (*xself).min_block_size_ {
-        (*xself).block_size_ = (*xself).min_block_size_;
+    let num_contexts: usize = xself.num_contexts_;
+    if xself.block_size_ < xself.min_block_size_ {
+        xself.block_size_ = xself.min_block_size_;
     }
-    if (*xself).num_blocks_ == 0usize {
+    if xself.num_blocks_ == 0usize {
         let mut i: usize;
-        (*split).lengths.slice_mut()[(0usize)] = (*xself).block_size_ as (u32);
-        (*split).types.slice_mut()[(0usize)] = 0i32 as (u8);
+        split.lengths.slice_mut()[(0usize)] = xself.block_size_ as (u32);
+        split.types.slice_mut()[(0usize)] = 0i32 as (u8);
         i = 0usize;
         while i < num_contexts {
             {
-                (*xself).last_entropy_[(i as (usize))] = BitsEntropy(
-                    (histograms[(i as (usize))]).slice(),
-                    (*xself).alphabet_size_,
-                );
-                (*xself).last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                    (*xself).last_entropy_[(i as (usize))];
+                xself.last_entropy_[(i as (usize))] =
+                    BitsEntropy((histograms[(i as (usize))]).slice(), xself.alphabet_size_);
+                xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
+                    xself.last_entropy_[(i as (usize))];
             }
             i = i.wrapping_add(1 as (usize));
         }
-        (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-        (*split).num_types = (*split).num_types.wrapping_add(1 as (usize));
-        (*xself).curr_histogram_ix_ = (*xself).curr_histogram_ix_.wrapping_add(num_contexts);
-        if (*xself).curr_histogram_ix_ < *histograms_size {
+        xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+        split.num_types = split.num_types.wrapping_add(1 as (usize));
+        xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(num_contexts);
+        if xself.curr_histogram_ix_ < *histograms_size {
             ClearHistograms(
-                &mut histograms[((*xself).curr_histogram_ix_ as (usize))..],
-                (*xself).num_contexts_,
+                &mut histograms[(xself.curr_histogram_ix_ as (usize))..],
+                xself.num_contexts_,
             );
         }
-        (*xself).block_size_ = 0usize;
-    } else if (*xself).block_size_ > 0usize {
+        xself.block_size_ = 0usize;
+    } else if xself.block_size_ > 0usize {
         let mut entropy = [0.0 as super::util::floatX; BROTLI_MAX_STATIC_CONTEXTS];
         let mut combined_histo = m.alloc_cell(2 * num_contexts);
         let mut combined_entropy = [0.0 as super::util::floatX; 2 * BROTLI_MAX_STATIC_CONTEXTS];
@@ -741,32 +735,29 @@ fn ContextBlockSplitterFinishBlock<
         i = 0usize;
         while i < num_contexts {
             {
-                let curr_histo_ix: usize = (*xself).curr_histogram_ix_.wrapping_add(i);
+                let curr_histo_ix: usize = xself.curr_histogram_ix_.wrapping_add(i);
                 let mut j: usize;
                 entropy[i] = BitsEntropy(
                     &(histograms[(curr_histo_ix as (usize))]).slice(),
-                    (*xself).alphabet_size_,
+                    xself.alphabet_size_,
                 );
                 j = 0usize;
                 while j < 2usize {
                     {
                         let jx: usize = j.wrapping_mul(num_contexts).wrapping_add(i);
-                        let last_histogram_ix: usize =
-                            (*xself).last_histogram_ix_[j].wrapping_add(i);
+                        let last_histogram_ix: usize = xself.last_histogram_ix_[j].wrapping_add(i);
                         combined_histo.slice_mut()[jx] =
                             histograms[(curr_histo_ix as (usize))].clone();
                         HistogramAddHistogram(
                             &mut combined_histo.slice_mut()[jx],
                             &mut histograms[(last_histogram_ix as (usize))],
                         );
-                        combined_entropy[jx] = BitsEntropy(
-                            combined_histo.slice()[jx].slice(),
-                            (*xself).alphabet_size_,
-                        );
+                        combined_entropy[jx] =
+                            BitsEntropy(combined_histo.slice()[jx].slice(), xself.alphabet_size_);
                         {
                             let _rhs = combined_entropy[jx]
                                 - entropy[i]
-                                - (*xself).last_entropy_[(jx as (usize))];
+                                - xself.last_entropy_[(jx as (usize))];
                             let _lhs = &mut diff[j];
                             *_lhs = *_lhs + _rhs;
                         }
@@ -776,108 +767,103 @@ fn ContextBlockSplitterFinishBlock<
             }
             i = i.wrapping_add(1 as (usize));
         }
-        if (*split).num_types < (*xself).max_block_types_
-            && (diff[0usize] > (*xself).split_threshold_)
-            && (diff[1usize] > (*xself).split_threshold_)
+        if split.num_types < xself.max_block_types_
+            && (diff[0usize] > xself.split_threshold_)
+            && (diff[1usize] > xself.split_threshold_)
         {
-            (*split).lengths.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*xself).block_size_ as (u32);
-            (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*split).num_types as (u8);
-            (*xself).last_histogram_ix_[1usize] = (*xself).last_histogram_ix_[0usize];
-            (*xself).last_histogram_ix_[0usize] = (*split).num_types.wrapping_mul(num_contexts);
+            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
+            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = split.num_types as (u8);
+            xself.last_histogram_ix_[1usize] = xself.last_histogram_ix_[0usize];
+            xself.last_histogram_ix_[0usize] = split.num_types.wrapping_mul(num_contexts);
             i = 0usize;
             while i < num_contexts {
                 {
-                    (*xself).last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                        (*xself).last_entropy_[(i as (usize))];
-                    (*xself).last_entropy_[(i as (usize))] = entropy[i];
+                    xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
+                        xself.last_entropy_[(i as (usize))];
+                    xself.last_entropy_[(i as (usize))] = entropy[i];
                 }
                 i = i.wrapping_add(1 as (usize));
             }
-            (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-            (*split).num_types = (*split).num_types.wrapping_add(1 as (usize));
-            (*xself).curr_histogram_ix_ = (*xself).curr_histogram_ix_.wrapping_add(num_contexts);
-            if (*xself).curr_histogram_ix_ < *histograms_size {
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            split.num_types = split.num_types.wrapping_add(1 as (usize));
+            xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(num_contexts);
+            if xself.curr_histogram_ix_ < *histograms_size {
                 ClearHistograms(
-                    &mut histograms[((*xself).curr_histogram_ix_ as (usize))..],
-                    (*xself).num_contexts_,
+                    &mut histograms[(xself.curr_histogram_ix_ as (usize))..],
+                    xself.num_contexts_,
                 );
             }
-            (*xself).block_size_ = 0usize;
-            (*xself).merge_last_count_ = 0usize;
-            (*xself).target_block_size_ = (*xself).min_block_size_;
+            xself.block_size_ = 0usize;
+            xself.merge_last_count_ = 0usize;
+            xself.target_block_size_ = xself.min_block_size_;
         } else if diff[1usize] < diff[0usize] - 20.0 as super::util::floatX {
-            (*split).lengths.slice_mut()[((*xself).num_blocks_ as (usize))] =
-                (*xself).block_size_ as (u32);
-            let nbm2 =
-                (*split).types.slice()[((*xself).num_blocks_.wrapping_sub(2usize) as (usize))];
-            (*split).types.slice_mut()[((*xself).num_blocks_ as (usize))] = nbm2;
+            split.lengths.slice_mut()[(xself.num_blocks_ as (usize))] = xself.block_size_ as (u32);
+            let nbm2 = split.types.slice()[(xself.num_blocks_.wrapping_sub(2usize) as (usize))];
+            split.types.slice_mut()[(xself.num_blocks_ as (usize))] = nbm2;
 
             {
-                let mut __brotli_swap_tmp: usize = (*xself).last_histogram_ix_[0usize];
-                (*xself).last_histogram_ix_[0usize] = (*xself).last_histogram_ix_[1usize];
-                (*xself).last_histogram_ix_[1usize] = __brotli_swap_tmp;
+                let mut __brotli_swap_tmp: usize = xself.last_histogram_ix_[0usize];
+                xself.last_histogram_ix_[0usize] = xself.last_histogram_ix_[1usize];
+                xself.last_histogram_ix_[1usize] = __brotli_swap_tmp;
             }
             i = 0usize;
             while i < num_contexts {
                 {
-                    histograms[((*xself).last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
+                    histograms[(xself.last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
                         combined_histo.slice()[num_contexts.wrapping_add(i)].clone();
-                    (*xself).last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                        (*xself).last_entropy_[(i as (usize))];
-                    (*xself).last_entropy_[(i as (usize))] =
+                    xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
+                        xself.last_entropy_[(i as (usize))];
+                    xself.last_entropy_[(i as (usize))] =
                         combined_entropy[num_contexts.wrapping_add(i)];
                     HistogramClear(
-                        &mut histograms[((*xself).curr_histogram_ix_.wrapping_add(i) as (usize))],
+                        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(i) as (usize))],
                     );
                 }
                 i = i.wrapping_add(1 as (usize));
             }
-            (*xself).num_blocks_ = (*xself).num_blocks_.wrapping_add(1 as (usize));
-            (*xself).block_size_ = 0usize;
-            (*xself).merge_last_count_ = 0usize;
-            (*xself).target_block_size_ = (*xself).min_block_size_;
+            xself.num_blocks_ = xself.num_blocks_.wrapping_add(1 as (usize));
+            xself.block_size_ = 0usize;
+            xself.merge_last_count_ = 0usize;
+            xself.target_block_size_ = xself.min_block_size_;
         } else {
             {
-                let _rhs = (*xself).block_size_ as (u32);
-                let _lhs = &mut (*split).lengths.slice_mut()
-                    [((*xself).num_blocks_.wrapping_sub(1usize) as (usize))];
+                let _rhs = xself.block_size_ as (u32);
+                let _lhs = &mut split.lengths.slice_mut()
+                    [(xself.num_blocks_.wrapping_sub(1usize) as (usize))];
                 let old_split_length = *_lhs;
                 *_lhs = old_split_length.wrapping_add(_rhs);
             }
             i = 0usize;
             while i < num_contexts {
                 {
-                    histograms[((*xself).last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
+                    histograms[(xself.last_histogram_ix_[0usize].wrapping_add(i) as (usize))] =
                         combined_histo.slice()[i].clone();
-                    (*xself).last_entropy_[(i as (usize))] = combined_entropy[i];
-                    if (*split).num_types == 1usize {
-                        (*xself).last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
-                            (*xself).last_entropy_[(i as (usize))];
+                    xself.last_entropy_[(i as (usize))] = combined_entropy[i];
+                    if split.num_types == 1usize {
+                        xself.last_entropy_[(num_contexts.wrapping_add(i) as (usize))] =
+                            xself.last_entropy_[(i as (usize))];
                     }
                     HistogramClear(
-                        &mut histograms[((*xself).curr_histogram_ix_.wrapping_add(i) as (usize))],
+                        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(i) as (usize))],
                     );
                 }
                 i = i.wrapping_add(1 as (usize));
             }
-            (*xself).block_size_ = 0usize;
+            xself.block_size_ = 0usize;
             if {
-                (*xself).merge_last_count_ = (*xself).merge_last_count_.wrapping_add(1 as (usize));
-                (*xself).merge_last_count_
+                xself.merge_last_count_ = xself.merge_last_count_.wrapping_add(1 as (usize));
+                xself.merge_last_count_
             } > 1usize
             {
-                (*xself).target_block_size_ = (*xself)
-                    .target_block_size_
-                    .wrapping_add((*xself).min_block_size_);
+                xself.target_block_size_ =
+                    xself.target_block_size_.wrapping_add(xself.min_block_size_);
             }
         }
         m.free_cell(combined_histo);
     }
     if is_final != 0 {
-        *histograms_size = (*split).num_types.wrapping_mul(num_contexts);
-        (*split).num_blocks = (*xself).num_blocks_;
+        *histograms_size = split.num_types.wrapping_mul(num_contexts);
+        split.num_blocks = xself.num_blocks_;
     }
 }
 
@@ -892,11 +878,11 @@ fn BlockSplitterAddSymbol<
     symbol: usize,
 ) {
     HistogramAddItem(
-        &mut histograms[((*xself).curr_histogram_ix_ as (usize))],
+        &mut histograms[(xself.curr_histogram_ix_ as (usize))],
         symbol,
     );
-    (*xself).block_size_ = (*xself).block_size_.wrapping_add(1 as (usize));
-    if (*xself).block_size_ == (*xself).target_block_size_ {
+    xself.block_size_ = xself.block_size_.wrapping_add(1 as (usize));
+    if xself.block_size_ == xself.target_block_size_ {
         BlockSplitterFinishBlock(xself, split, histograms, histograms_size, 0i32);
     }
 }
@@ -913,11 +899,11 @@ fn ContextBlockSplitterAddSymbol<
     context: usize,
 ) {
     HistogramAddItem(
-        &mut histograms[((*xself).curr_histogram_ix_.wrapping_add(context) as (usize))],
+        &mut histograms[(xself.curr_histogram_ix_.wrapping_add(context) as (usize))],
         symbol,
     );
-    (*xself).block_size_ = (*xself).block_size_.wrapping_add(1 as (usize));
-    if (*xself).block_size_ == (*xself).target_block_size_ {
+    xself.block_size_ = xself.block_size_.wrapping_add(1 as (usize));
+    if xself.block_size_ == xself.target_block_size_ {
         ContextBlockSplitterFinishBlock(xself, m, split, histograms, histograms_size, 0i32);
     }
 }
@@ -935,23 +921,22 @@ fn MapStaticContexts<
     mb: &mut MetaBlockSplit<Alloc>,
 ) {
     let mut i: usize;
-    (*mb).literal_context_map_size = (*mb).literal_split.num_types << 6i32;
+    mb.literal_context_map_size = mb.literal_split.num_types << 6i32;
     let new_literal_context_map =
-        <Alloc as Allocator<u32>>::alloc_cell(m32, (*mb).literal_context_map_size);
+        <Alloc as Allocator<u32>>::alloc_cell(m32, mb.literal_context_map_size);
     <Alloc as Allocator<u32>>::free_cell(
         m32,
-        core::mem::replace(&mut (*mb).literal_context_map, new_literal_context_map),
+        core::mem::replace(&mut mb.literal_context_map, new_literal_context_map),
     );
     i = 0usize;
-    while i < (*mb).literal_split.num_types {
+    while i < mb.literal_split.num_types {
         {
             let offset: u32 = i.wrapping_mul(num_contexts) as (u32);
             let mut j: usize;
             j = 0usize;
             while j < (1u32 << 6i32) as (usize) {
                 {
-                    (*mb).literal_context_map.slice_mut()
-                        [((i << 6i32).wrapping_add(j) as (usize))] =
+                    mb.literal_context_map.slice_mut()[((i << 6i32).wrapping_add(j) as (usize))] =
                         offset.wrapping_add(static_context_map[(j as (usize))]);
                 }
                 j = j.wrapping_add(1 as (usize));
@@ -1000,9 +985,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             512usize,
             400.0 as super::util::floatX,
             num_literals,
-            &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms,
-            &mut (*mb).literal_histograms_size,
+            &mut mb.literal_split,
+            &mut mb.literal_histograms,
+            &mut mb.literal_histograms_size,
         ))
     } else {
         LitBlocks::ctx(InitContextBlockSplitter::<Alloc>(
@@ -1012,9 +997,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             512usize,
             400.0 as super::util::floatX,
             num_literals,
-            &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms,
-            &mut (*mb).literal_histograms_size,
+            &mut mb.literal_split,
+            &mut mb.literal_histograms,
+            &mut mb.literal_histograms_size,
         ))
     };
     cmd_blocks = InitBlockSplitter::<HistogramCommand, Alloc>(
@@ -1023,9 +1008,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
         1024usize,
         500.0 as super::util::floatX,
         n_commands,
-        &mut (*mb).command_split,
-        &mut (*mb).command_histograms,
-        &mut (*mb).command_histograms_size,
+        &mut mb.command_split,
+        &mut mb.command_histograms,
+        &mut mb.command_histograms_size,
     );
     dist_blocks = InitBlockSplitter::<HistogramDistance, Alloc>(
         alloc,
@@ -1033,9 +1018,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
         512usize,
         100.0 as super::util::floatX,
         n_commands,
-        &mut (*mb).distance_split,
-        &mut (*mb).distance_histograms,
-        &mut (*mb).distance_histograms_size,
+        &mut mb.distance_split,
+        &mut mb.distance_histograms,
+        &mut mb.distance_histograms_size,
     );
 
     i = 0usize;
@@ -1045,9 +1030,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             let mut j: usize;
             BlockSplitterAddSymbol(
                 &mut cmd_blocks,
-                &mut (*mb).command_split,
-                &mut (*mb).command_histograms.slice_mut(),
-                &mut (*mb).command_histograms_size,
+                &mut mb.command_split,
+                &mut mb.command_histograms.slice_mut(),
+                &mut mb.command_histograms_size,
                 cmd.cmd_prefix_ as (usize),
             );
             j = cmd.insert_len_ as (usize);
@@ -1057,9 +1042,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                     match (&mut lit_blocks) {
                         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterAddSymbol(
                             lit_blocks_plain,
-                            &mut (*mb).literal_split,
-                            &mut (*mb).literal_histograms.slice_mut(),
-                            &mut (*mb).literal_histograms_size,
+                            &mut mb.literal_split,
+                            &mut mb.literal_histograms.slice_mut(),
+                            &mut mb.literal_histograms_size,
                             literal as (usize),
                         ),
                         &mut LitBlocks::ctx(ref mut lit_blocks_ctx) => {
@@ -1068,9 +1053,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                             ContextBlockSplitterAddSymbol(
                                 lit_blocks_ctx,
                                 alloc,
-                                &mut (*mb).literal_split,
-                                &mut (*mb).literal_histograms.slice_mut(),
-                                &mut (*mb).literal_histograms_size,
+                                &mut mb.literal_split,
+                                &mut mb.literal_histograms.slice_mut(),
+                                &mut mb.literal_histograms_size,
                                 literal as (usize),
                                 static_context_map[(context as (usize))] as (usize),
                             );
@@ -1089,9 +1074,9 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                 if cmd.cmd_prefix_ as (i32) >= 128i32 {
                     BlockSplitterAddSymbol(
                         &mut dist_blocks,
-                        &mut (*mb).distance_split,
-                        &mut (*mb).distance_histograms.slice_mut(),
-                        &mut (*mb).distance_histograms_size,
+                        &mut mb.distance_split,
+                        &mut mb.distance_histograms.slice_mut(),
+                        &mut mb.distance_histograms_size,
                         cmd.dist_prefix_ as (usize) & 0x3ff,
                     );
                 }
@@ -1102,32 +1087,32 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
     match (&mut lit_blocks) {
         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterFinishBlock(
             lit_blocks_plain,
-            &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms.slice_mut(),
-            &mut (*mb).literal_histograms_size,
+            &mut mb.literal_split,
+            &mut mb.literal_histograms.slice_mut(),
+            &mut mb.literal_histograms_size,
             1i32,
         ),
         &mut LitBlocks::ctx(ref mut lit_blocks_ctx) => ContextBlockSplitterFinishBlock(
             lit_blocks_ctx,
             alloc,
-            &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms.slice_mut(),
-            &mut (*mb).literal_histograms_size,
+            &mut mb.literal_split,
+            &mut mb.literal_histograms.slice_mut(),
+            &mut mb.literal_histograms_size,
             1i32,
         ),
     }
     BlockSplitterFinishBlock(
         &mut cmd_blocks,
-        &mut (*mb).command_split,
-        &mut (*mb).command_histograms.slice_mut(),
-        &mut (*mb).command_histograms_size,
+        &mut mb.command_split,
+        &mut mb.command_histograms.slice_mut(),
+        &mut mb.command_histograms_size,
         1i32,
     );
     BlockSplitterFinishBlock(
         &mut dist_blocks,
-        &mut (*mb).distance_split,
-        &mut (*mb).distance_histograms.slice_mut(),
-        &mut (*mb).distance_histograms_size,
+        &mut mb.distance_split,
+        &mut mb.distance_histograms.slice_mut(),
+        &mut mb.distance_histograms_size,
         1i32,
     );
     if num_contexts > 1usize {
@@ -1201,33 +1186,33 @@ pub fn BrotliOptimizeHistograms<
     let mut good_for_rle: [u8; 704] = [0; 704];
     let mut i: usize;
     i = 0usize;
-    while i < (*mb).literal_histograms_size {
+    while i < mb.literal_histograms_size {
         {
             BrotliOptimizeHuffmanCountsForRle(
                 256usize,
-                (*mb).literal_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.literal_histograms.slice_mut()[(i as (usize))].slice_mut(),
                 &mut good_for_rle[..],
             );
         }
         i = i.wrapping_add(1 as (usize));
     }
     i = 0usize;
-    while i < (*mb).command_histograms_size {
+    while i < mb.command_histograms_size {
         {
             BrotliOptimizeHuffmanCountsForRle(
                 704usize,
-                (*mb).command_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.command_histograms.slice_mut()[(i as (usize))].slice_mut(),
                 &mut good_for_rle[..],
             );
         }
         i = i.wrapping_add(1 as (usize));
     }
     i = 0usize;
-    while i < (*mb).distance_histograms_size {
+    while i < mb.distance_histograms_size {
         {
             BrotliOptimizeHuffmanCountsForRle(
                 num_distance_codes,
-                (*mb).distance_histograms.slice_mut()[(i as (usize))].slice_mut(),
+                mb.distance_histograms.slice_mut()[(i as (usize))].slice_mut(),
                 &mut good_for_rle[..],
             );
         }

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -355,9 +355,9 @@ pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_leng
     if w.l as (usize) > max_length {
         0i32
     } else {
-        let offset: usize = ((*dictionary).offsets_by_length[w.l as (usize)] as (usize))
+        let offset: usize = (dictionary.offsets_by_length[w.l as (usize)] as (usize))
             .wrapping_add((w.len() as (usize)).wrapping_mul(w.idx() as (usize)));
-        let dict = &(*dictionary).data.split_at(offset).1;
+        let dict = &dictionary.data.split_at(offset).1;
         if w.transform() as (i32) == 0i32 {
             if !!(FindMatchLengthWithLimit(dict, data, w.l as (usize)) == w.l as (usize)) {
                 1i32
@@ -433,9 +433,9 @@ fn DictMatchLength(
     maxlen: usize,
 ) -> usize {
     let offset: usize =
-        ((*dictionary).offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(id));
+        (dictionary.offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(id));
     FindMatchLengthWithLimit(
-        &(*dictionary).data.split_at(offset).1,
+        &dictionary.data.split_at(offset).1,
         data,
         brotli_min_size_t(len, maxlen),
     )
@@ -469,7 +469,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
-            let n: usize = 1usize << (*dictionary).size_bits_by_length[l] as (i32);
+            let n: usize = 1usize << dictionary.size_bits_by_length[l] as (i32);
             let id: usize = w.idx() as (usize);
             end = !(w.len() as (i32) & 0x80i32 == 0) as (i32);
             w.l = l as (u8);
@@ -1173,7 +1173,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 _old
             }];
             let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
-            let n: usize = 1usize << (*dictionary).size_bits_by_length[l] as (i32);
+            let n: usize = 1usize << dictionary.size_bits_by_length[l] as (i32);
             let id: usize = w.idx() as (usize);
             end = !(w.len() as (i32) & 0x80i32 == 0) as (i32);
             w.l = l as (u8);
@@ -1416,7 +1416,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     _old
                 }];
                 let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
-                let n: usize = 1usize << (*dictionary).size_bits_by_length[l] as (i32);
+                let n: usize = 1usize << dictionary.size_bits_by_length[l] as (i32);
                 let id: usize = w.idx() as (usize);
                 end = !(w.len() as (i32) & 0x80i32 == 0) as (i32);
                 w.l = l as (u8);
@@ -1482,7 +1482,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     _old
                 }];
                 let l: usize = (w.len() as (i32) & 0x1fi32) as (usize);
-                let n: usize = 1usize << (*dictionary).size_bits_by_length[l] as (i32);
+                let n: usize = 1usize << dictionary.size_bits_by_length[l] as (i32);
                 let id: usize = w.idx() as (usize);
                 end = !(w.len() as (i32) & 0x80i32 == 0) as (i32);
                 w.l = l as (u8);

--- a/src/enc/util.rs
+++ b/src/enc/util.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
+#![allow(clippy::excessive_precision)]
+
 use core;
+
 #[cfg(feature = "float64")]
 pub type floatX = f64;
 


### PR DESCRIPTION
This was fully automatic change using

```
cargo clippy --fix -- -A clippy::all -W clippy::explicit_auto_deref
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/explicit_auto_deref
Also ignored `clippy::excessive_precision` in utils because of a huge number of false positives there.

This PR also passed CI in the https://github.com/rust-brotli/rust-brotli/pull/8