### PR TITLE
Auto-fixed clippy::assign_op_pattern

### DIFF
--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -175,7 +175,7 @@ where
             if err {
                 timing_error = true;
             }
-            total = total + delta;
+            total += delta;
             if output_offset != 0 {
                 _write_all(&mut w, &output.slice()[..output_offset]).unwrap();
                 output_offset = 0;

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -268,9 +268,8 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
                 + literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX;
             literal_costs[(i.wrapping_add(1usize) as (usize))] =
                 (literal_costs[(i as (usize))] as floatX + literal_carry) as floatX;
-            literal_carry = literal_carry
-                - (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
-                    - literal_costs[(i as (usize))] as floatX);
+            literal_carry -= (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
+                - literal_costs[(i as (usize))] as floatX);
         }
         i = i.wrapping_add(1 as (usize));
     }
@@ -402,7 +401,7 @@ where
                 if backward > max_backward {
                     break 'break14;
                 }
-                prev_ix = prev_ix & ring_buffer_mask;
+                prev_ix &= ring_buffer_mask;
                 if data[(cur_ix_masked as (usize))] as (i32) != data[(prev_ix as (usize))] as (i32)
                     || data[(cur_ix_masked.wrapping_add(1usize) as (usize))] as (i32)
                         != data[(prev_ix.wrapping_add(1usize) as (usize))] as (i32)
@@ -557,7 +556,7 @@ fn ComputeDistanceCache(
         let dist: usize = ZopfliNodeCopyDistance(&nodes[(p as (usize))]) as (usize);
         dist_cache[({
             let _old = idx;
-            idx = idx + 1;
+            idx += 1;
             _old
         } as (usize))] = dist as (i32);
         p = match (nodes[(p.wrapping_sub(clen).wrapping_sub(ilen) as (usize))]).u {
@@ -573,7 +572,7 @@ fn ComputeDistanceCache(
                 _old[0]
             };
         }
-        idx = idx + 1;
+        idx += 1;
     }
 }
 
@@ -678,7 +677,7 @@ fn ComputeMinimumCopyLength(
     {
         len = len.wrapping_add(1 as (usize));
         if len == next_len_offset {
-            min_cost = min_cost + 1.0 as floatX;
+            min_cost += 1.0 as floatX;
             next_len_offset = next_len_offset.wrapping_add(next_len_bucket);
             next_len_bucket = next_len_bucket.wrapping_mul(2usize);
         }
@@ -822,7 +821,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 if prev_ix >= cur_ix {
                                     break 'continue30;
                                 }
-                                prev_ix = prev_ix & ringbuffer_mask;
+                                prev_ix &= ringbuffer_mask;
                                 if prev_ix.wrapping_add(best_len) > ringbuffer_mask
                                     || continuation as (i32)
                                         != ringbuffer[(prev_ix.wrapping_add(best_len) as (usize))]
@@ -1349,15 +1348,13 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
         i = 0usize;
         while i < num_bytes {
             {
-                literal_carry = literal_carry
-                    + cost_literal[(ringbuffer
-                        [((position.wrapping_add(i) & ringbuffer_mask) as (usize))]
-                        as (usize))] as floatX;
+                literal_carry += cost_literal[(ringbuffer
+                    [((position.wrapping_add(i) & ringbuffer_mask) as (usize))]
+                    as (usize))] as floatX;
                 literal_costs[(i.wrapping_add(1usize) as (usize))] =
                     (literal_costs[(i as (usize))] as floatX + literal_carry) as floatX;
-                literal_carry = literal_carry
-                    - (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
-                        - literal_costs[(i as (usize))] as floatX);
+                literal_carry -= (literal_costs[(i.wrapping_add(1usize) as (usize))] as floatX
+                    - literal_costs[(i as (usize))] as floatX);
             }
             i = i.wrapping_add(1 as (usize));
         }

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -372,7 +372,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         let mut is_match_found: i32 = 0i32;
         (*out).len_x_code = 0usize;
         if prev_ix < cur_ix {
-            prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
+            prev_ix &= ring_buffer_mask as (u32) as (usize);
             if compare_char == data[(prev_ix.wrapping_add(best_len) as (usize))] as (i32) {
                 let len: usize = FindMatchLengthWithLimitMin4(
                     &data[(prev_ix as (usize))..],
@@ -402,7 +402,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
             prev_ix = (*self).buckets_.slice()[key as (usize)] as (usize);
             (*self).buckets_.slice_mut()[key as (usize)] = cur_ix as (u32);
             backward = cur_ix.wrapping_sub(prev_ix);
-            prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
+            prev_ix &= ring_buffer_mask as (u32) as (usize);
             if compare_char != data[(prev_ix.wrapping_add(best_len_in) as (usize))] as (i32) {
                 return false;
             }
@@ -426,7 +426,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
             {
                 let mut prev_ix = *prev_ix_ref as usize;
                 let backward: usize = cur_ix.wrapping_sub(prev_ix);
-                prev_ix = prev_ix & ring_buffer_mask as (u32) as (usize);
+                prev_ix &= ring_buffer_mask as (u32) as (usize);
                 if compare_char != data[(prev_ix.wrapping_add(best_len) as (usize))] as (i32) {
                     continue;
                 }
@@ -1701,7 +1701,7 @@ impl<
                     if backward > max_backward {
                         break 'continue45;
                     }
-                    prev_ix = prev_ix & ring_buffer_mask;
+                    prev_ix &= ring_buffer_mask;
                     if (cur_ix_masked.wrapping_add(best_len) > ring_buffer_mask
                         || prev_ix.wrapping_add(best_len) > ring_buffer_mask
                         || cur_data[best_len] != data[prev_ix.wrapping_add(best_len)])
@@ -1867,7 +1867,7 @@ pub struct H42 {
 fn unopt_ctzll(mut val: usize) -> u8 {
     let mut cnt: u8 = 0i32 as (u8);
     while val & 1usize == 0usize {
-        val = val >> 1i32;
+        val >>= 1i32;
         cnt = (cnt as (i32) + 1) as (u8);
     }
     cnt
@@ -2553,8 +2553,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                         insert_length = insert_length.wrapping_add(1 as (usize));
                         sr = sr2;
                         if {
-                            delayed_backward_references_in_row =
-                                delayed_backward_references_in_row + 1;
+                            delayed_backward_references_in_row += 1;
                             delayed_backward_references_in_row
                         } < 4i32
                             && (position.wrapping_add(hasher.HashTypeLength()) < pos_end)

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -32,15 +32,15 @@ pub fn ShannonEntropy(
         p = population[0] as usize;
         population = population.split_at(1).1;
         sum = sum.wrapping_add(p);
-        retval = retval - p as super::util::floatX * FastLog2u16(p as u16);
+        retval -= p as super::util::floatX * FastLog2u16(p as u16);
     }
     for pop_iter in population.split_at((size >> 1) << 1).0 {
         p = *pop_iter as usize;
         sum = sum.wrapping_add(p);
-        retval = retval - p as super::util::floatX * FastLog2u16(p as u16);
+        retval -= p as super::util::floatX * FastLog2u16(p as u16);
     }
     if sum != 0 {
-        retval = retval + sum as super::util::floatX * FastLog2(sum as u64); // not sure it's 16 bit
+        retval += sum as super::util::floatX * FastLog2(sum as u64); // not sure it's 16 bit
     }
     *total = sum;
     retval
@@ -218,7 +218,7 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
         let log_counts = log2i(*nnz_data_item);
         let log2p = ymm_log2total - log_counts;
         let tmp = counts * log2p;
-        bits_cumulative = bits_cumulative + tmp;
+        bits_cumulative += tmp;
     }
     bits += sum8(bits_cumulative);
     if rem != 0 {
@@ -261,7 +261,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         {
             if (*histogram).slice()[i] > 0u32 {
                 s[count as (usize)] = i;
-                count = count + 1;
+                count += 1;
                 if count > 4i32 {
                     {
                         break 'break1;
@@ -358,8 +358,8 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                     let mut depth_histo_adds: u32 = 0;
                     while reps > 0u32 {
                         depth_histo_adds += 1;
-                        bits = bits + 3i32 as super::util::floatX;
-                        reps = reps >> 3i32;
+                        bits += 3i32 as super::util::floatX;
+                        reps >>= 3i32;
                     }
                     depth_histo[BROTLI_REPEAT_ZERO_CODE_LENGTH] += depth_histo_adds;
                 }
@@ -383,15 +383,15 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                         reps -= 2;
                         while reps > 0u32 {
                             depth_histo[17] += 1;
-                            bits = bits + 3 as super::util::floatX;
-                            reps = reps >> 3;
+                            bits += 3 as super::util::floatX;
+                            reps >>= 3;
                         }
                     }
                     reps = 0;
                 }
                 let log2p: super::util::floatX = log2total - FastLog2u16(*histo as (u16));
                 let mut depth: usize = (log2p + 0.5 as super::util::floatX) as (usize);
-                bits = bits + *histo as super::util::floatX * log2p;
+                bits += *histo as super::util::floatX * log2p;
                 depth = core::cmp::min(depth, 15);
                 max_depth = core::cmp::max(depth, max_depth);
                 depth_histo[depth] += 1;
@@ -399,9 +399,8 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 reps += 1;
             }
         }
-        bits =
-            bits + (18usize).wrapping_add((2usize).wrapping_mul(max_depth)) as super::util::floatX;
-        bits = bits + BitsEntropy(&depth_histo[..], 18usize);
+        bits += (18usize).wrapping_add((2usize).wrapping_mul(max_depth)) as super::util::floatX;
+        bits += BitsEntropy(&depth_histo[..], 18usize);
     }
     bits
 }

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -417,10 +417,9 @@ where
                 }
             }
             if byte_ix < 2000usize {
-                block_switch_cost = block_switch_cost
-                    * (0.77 as super::util::floatX
-                        + 0.07 as super::util::floatX * byte_ix as (super::util::floatX)
-                            / 2000i32 as (super::util::floatX));
+                block_switch_cost *= (0.77 as super::util::floatX
+                    + 0.07 as super::util::floatX * byte_ix as (super::util::floatX)
+                        / 2000i32 as (super::util::floatX));
             }
             update_cost_and_signal(
                 num_histograms as u32,

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1165,19 +1165,19 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                                 <= (tree.slice()[(j as (usize))]).total_count_
                             {
                                 left = i;
-                                i = i + 1;
+                                i += 1;
                             } else {
                                 left = j;
-                                j = j + 1;
+                                j += 1;
                             }
                             if (tree.slice()[(i as (usize))]).total_count_
                                 <= (tree.slice()[(j as (usize))]).total_count_
                             {
                                 right = i;
-                                i = i + 1;
+                                i += 1;
                             } else {
                                 right = j;
-                                j = j + 1;
+                                j += 1;
                             }
                             let sum_total = (tree.slice()[(left as (usize))])
                                 .total_count_
@@ -1189,7 +1189,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                             tree.slice_mut()[(node_index as (usize))] = sentinel.clone();
                             node_index = node_index.wrapping_add(1u32);
                         }
-                        k = k - 1;
+                        k -= 1;
                     }
                     if BrotliSetDepth(2i32 * n - 1i32, tree.slice_mut(), depth, 14i32) {
                         {
@@ -1444,7 +1444,7 @@ fn Log2FloorNonZero(mut n: u64) -> u32 {
     let mut result: u32 = 0u32;
     'loop1: loop {
         if {
-            n = n >> 1i32;
+            n >>= 1i32;
             n
         } != 0
         {
@@ -1719,7 +1719,7 @@ fn BuildAndStoreHuffmanTree(
     {
         let mut max_bits_counter: usize = alphabet_size.wrapping_sub(1usize);
         while max_bits_counter != 0 {
-            max_bits_counter = max_bits_counter >> 1i32;
+            max_bits_counter >>= 1i32;
             max_bits = max_bits.wrapping_add(1 as (usize));
         }
     }

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -95,8 +95,8 @@ fn BrotliCompareAndPushToQueue<
                 cluster_size[idx1 as usize] as (usize),
                 cluster_size[idx2 as usize] as (usize),
             );
-        p.cost_diff = p.cost_diff - (out[idx1 as (usize)]).bit_cost();
-        p.cost_diff = p.cost_diff - (out[idx2 as (usize)]).bit_cost();
+        p.cost_diff -= (out[idx1 as (usize)]).bit_cost();
+        p.cost_diff -= (out[idx2 as (usize)]).bit_cost();
         if (out[idx1 as (usize)]).total_count() == 0i32 as (usize) {
             p.cost_combo = (out[idx2 as (usize)]).bit_cost();
             is_good_pair = 1i32;
@@ -122,7 +122,7 @@ fn BrotliCompareAndPushToQueue<
             }
         }
         if is_good_pair != 0 {
-            p.cost_diff = p.cost_diff + p.cost_combo;
+            p.cost_diff += p.cost_combo;
             if *num_pairs > 0i32 as (usize)
                 && (HistogramPairIsLess(&pairs[0i32 as (usize)], &p) != false)
             {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -626,7 +626,7 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> i32 {
         i = 0usize;
         while i < 256usize {
             {
-                r = r - histo[i] as (super::util::floatX)
+                r -= histo[i] as (super::util::floatX)
                     * (depths[(i as (usize))] as (super::util::floatX) + FastLog2(histo[i] as u64));
             }
             i = i.wrapping_add(1 as (usize));
@@ -652,7 +652,7 @@ fn UpdateBits(mut n_bits: usize, mut bits: u32, mut pos: usize, array: &mut [u8]
         let changed_bits: u32 = bits & (1u32 << n_changed_bits).wrapping_sub(1u32);
         array[(byte_pos as (usize))] = (changed_bits << n_unchanged_bits | unchanged_bits) as (u8);
         n_bits = n_bits.wrapping_sub(n_changed_bits);
-        bits = bits >> n_changed_bits;
+        bits >>= n_changed_bits;
         pos = pos.wrapping_add(n_changed_bits);
     }
 }

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -467,7 +467,7 @@ fn ShouldCompress(input: &[u8], input_size: usize, num_literals: usize) -> i32 {
 pub fn BrotliWriteBits(n_bits: usize, bits: u64, pos: &mut usize, array: &mut [u8]) {
     let p = &mut array[((*pos >> 3i32) as (usize))..];
     let mut v: u64 = p[0] as (u64);
-    v = v | bits << (*pos & 7);
+    v |= bits << (*pos & 7);
     BROTLI_UNALIGNED_STORE64(p, v);
     *pos = (*pos).wrapping_add(n_bits);
 }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1695,7 +1695,7 @@ fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<A
     let destination: &mut [u8];
     (*s).last_bytes_ = 0;
     (*s).last_bytes_bits_ = 0;
-    seal = seal | 0x6u32 << seal_bits;
+    seal |= 0x6u32 << seal_bits;
     seal_bits = seal_bits.wrapping_add(6usize);
     if !IsNextOutNull(&(*s).next_out_) {
         destination = &mut GetNextOut!(*s)[((*s).available_out_ as (usize))..];
@@ -1813,7 +1813,7 @@ fn MaxHashTableSize(quality: i32) -> usize {
 fn HashTableSize(max_table_size: usize, input_size: usize) -> usize {
     let mut htsize: usize = 256usize;
     while htsize < max_table_size && (htsize < input_size) {
-        htsize = htsize << 1i32;
+        htsize <<= 1i32;
     }
     htsize
 }
@@ -1843,7 +1843,7 @@ fn GetHashTableInternal<'a, AllocI32: alloc::Allocator<i32>>(
     let table: &mut [i32];
     if quality == 0i32 {
         if htsize & 0xaaaaausize == 0usize {
-            htsize = htsize << 1i32;
+            htsize <<= 1i32;
         }
     }
     if htsize <= small_table_.len() {
@@ -1938,7 +1938,7 @@ fn ChooseContextMap(
                 &mut dummy,
             );
             let _lhs = &mut entropy[3usize];
-            *_lhs = *_lhs + _rhs;
+            *_lhs += _rhs;
         }
         i = i.wrapping_add(1 as (usize));
     }
@@ -1950,17 +1950,17 @@ fn ChooseContextMap(
     {
         let _rhs = entropy[0usize];
         let _lhs = &mut entropy[1usize];
-        *_lhs = *_lhs * _rhs;
+        *_lhs *= _rhs;
     }
     {
         let _rhs = entropy[0usize];
         let _lhs = &mut entropy[2usize];
-        *_lhs = *_lhs * _rhs;
+        *_lhs *= _rhs;
     }
     {
         let _rhs = entropy[0usize];
         let _lhs = &mut entropy[3usize];
-        *_lhs = *_lhs * _rhs;
+        *_lhs *= _rhs;
     }
     if quality < 7i32 {
         entropy[3usize] = entropy[1usize] * 10i32 as (super::util::floatX);

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -43,7 +43,7 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
     stack[0usize] = -1i32;
     loop {
         if (pool[(p as (usize))]).index_left_ as (i32) >= 0i32 {
-            level = level + 1;
+            level += 1;
             if level > max_depth {
                 return false;
             }
@@ -59,7 +59,7 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
             depth[((pp).index_right_or_value_ as (usize))] = level as (u8);
         }
         while level >= 0i32 && (stack[level as (usize)] == -1i32) {
-            level = level - 1;
+            level -= 1;
         }
         if level < 0i32 {
             return true;
@@ -145,7 +145,7 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
                     i = i.wrapping_add(1 as (usize));
                 }
             }
-            g = g + 1;
+            g += 1;
         }
     }
 }
@@ -532,7 +532,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
             tree[(*tree_size as (usize))] = 16i32 as (u8);
             extra_bits_data[(*tree_size as (usize))] = (repetitions & 0x3usize) as (u8);
             *tree_size = (*tree_size).wrapping_add(1 as (usize));
-            repetitions = repetitions >> 2i32;
+            repetitions >>= 2i32;
             if repetitions == 0usize {
                 {
                     break;
@@ -575,7 +575,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
             tree[(*tree_size as (usize))] = 17i32 as (u8);
             extra_bits_data[(*tree_size as (usize))] = (repetitions & 0x7usize) as (u8);
             *tree_size = (*tree_size).wrapping_add(1 as (usize));
-            repetitions = repetitions >> 3i32;
+            repetitions >>= 3i32;
             if repetitions == 0usize {
                 {
                     break;
@@ -662,13 +662,13 @@ fn BrotliReverseBits(num_bits: usize, mut bits: u16) -> u16 {
     i = 4usize;
     while i < num_bits {
         {
-            retval = retval << 4i32;
+            retval <<= 4i32;
             bits = (bits as (i32) >> 4i32) as (u16);
-            retval = retval | kLut[(bits as (i32) & 0xfi32) as (usize)];
+            retval |= kLut[(bits as (i32) & 0xfi32) as (usize)];
         }
         i = i.wrapping_add(4usize);
     }
-    retval = retval >> ((0usize).wrapping_sub(num_bits) & 0x3usize);
+    retval >>= ((0usize).wrapping_sub(num_bits) & 0x3usize);
     retval as (u16)
 }
 const MAX_HUFFMAN_BITS: usize = 16;

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -170,14 +170,13 @@ fn EstimateBitCostsForLiteralsUTF8(
                 }
                 lit_cost = FastLog2f64(in_window_utf8[utf8_pos] as u64) as f64
                     - FastLog2f64(histo as u64) as f64;
-                lit_cost = lit_cost + 0.02905;
+                lit_cost += 0.02905;
                 if lit_cost < 1.0 {
-                    lit_cost = lit_cost * 0.5;
-                    lit_cost = lit_cost + 0.5;
+                    lit_cost *= 0.5;
+                    lit_cost += 0.5;
                 }
                 if i < 2000usize {
-                    lit_cost =
-                        lit_cost + (0.7 - (2000usize).wrapping_sub(i) as (f64) / 2000.0 * 0.35);
+                    lit_cost += (0.7 - (2000usize).wrapping_sub(i) as (f64) / 2000.0 * 0.35);
                 }
                 cost[(i as (usize))] = lit_cost as (super::util::floatX);
             }
@@ -243,10 +242,10 @@ pub fn BrotliEstimateBitCostsForLiterals(
                     //precision is vital here: lets keep double precision
                     let mut lit_cost: f64 =
                         FastLog2f64(in_window as u64) as f64 - FastLog2f64(histo as u64) as f64;
-                    lit_cost = lit_cost + 0.029;
+                    lit_cost += 0.029;
                     if lit_cost < 1.0 {
-                        lit_cost = lit_cost * 0.5;
-                        lit_cost = lit_cost + 0.5;
+                        lit_cost *= 0.5;
+                        lit_cost += 0.5;
                     }
                     cost[(i as (usize))] = lit_cost as (super::util::floatX);
                 }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -768,7 +768,7 @@ fn ContextBlockSplitterFinishBlock<
                                 - entropy[i]
                                 - (*xself).last_entropy_[(jx as (usize))];
                             let _lhs = &mut diff[j];
-                            *_lhs = *_lhs + _rhs;
+                            *_lhs += _rhs;
                         }
                     }
                     j = j.wrapping_add(1 as (usize));

--- a/src/enc/util.rs
+++ b/src/enc/util.rs
@@ -381,7 +381,7 @@ mod test {
     fn baseline_log2_floor_non_zero(mut n: u64) -> u32 {
         let mut result: u32 = 0u32;
         while {
-            n = n >> 1i32;
+            n >>= 1i32;
             n
         } != 0
         {


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::assign_op_pattern
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/assign_op_pattern

See CI results in https://github.com/rust-brotli/rust-brotli/pull/12