### PR TITLE
Auto-fixed clippy::needless_borrow + refs

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -437,8 +437,8 @@ where
     brotli::BrotliCompressCustomIoCustomDict(
         &mut IoReaderWrapper::<InputType>(r),
         &mut IoWriterWrapper::<OutputType>(w),
-        &mut input_buffer.slice_mut(),
-        &mut output_buffer.slice_mut(),
+        input_buffer.slice_mut(),
+        output_buffer.slice_mut(),
         params,
         new_brotli_heap_alloc(),
         &mut log,

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -163,10 +163,10 @@ where
             result = BrotliDecompressStream(
                 &mut available_in,
                 &mut input_offset,
-                &input.slice(),
+                input.slice(),
                 &mut available_out,
                 &mut output_offset,
-                &mut output.slice_mut(),
+                output.slice_mut(),
                 &mut written,
                 &mut brotli_state,
             );
@@ -315,7 +315,7 @@ fn roundtrip_helper(in_buf: &[u8], q: i32, lgwin: i32, q9_5: bool) -> usize {
     } else {
         in_buf.len()
     };
-    let mut input = UnlimitedBuffer::new(&in_buf);
+    let mut input = UnlimitedBuffer::new(in_buf);
     let mut compressed = UnlimitedBuffer::new(&[]);
     let mut output = UnlimitedBuffer::new(&[]);
     match super::compress(&mut input, &mut compressed, 4096, &params, &[], 1) {
@@ -466,7 +466,7 @@ fn test_roundtrip_as_you_lik() {
 fn reader_helper(mut in_buf: &[u8], q: u32, lgwin: u32) {
     let original_buf = in_buf;
     let mut cmp = [0u8; 259];
-    let mut input = UnlimitedBuffer::new(&in_buf);
+    let mut input = UnlimitedBuffer::new(in_buf);
     {
         let renc = CompressorReader::new(&mut input, 255, q, lgwin);
         let mut rdec = Decompressor::new(renc, 257);
@@ -486,7 +486,7 @@ fn reader_helper(mut in_buf: &[u8], q: u32, lgwin: u32) {
         let _inner_inner_item = inner_item.into_inner();
     }
     in_buf = original_buf;
-    input = UnlimitedBuffer::new(&in_buf);
+    input = UnlimitedBuffer::new(in_buf);
     let mut r2enc = CompressorReader::new(&mut input, 255, q, lgwin);
     let mut compressed_size = 0usize;
     loop {

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -90,16 +90,16 @@ impl<'a> fmt::LowerHex for SliceU8Ref<'a> {
 pub fn write_one<T: SliceWrapper<u8>>(cmd: &interface::Command<T>) {
     use std::io::Write;
     match cmd {
-        &interface::Command::BlockSwitchLiteral(ref bsl) => {
+        interface::Command::BlockSwitchLiteral(bsl) => {
             println_stderr!("ltype {} {}", bsl.0.block_type(), bsl.1);
         }
-        &interface::Command::BlockSwitchCommand(ref bsc) => {
+        interface::Command::BlockSwitchCommand(bsc) => {
             println_stderr!("ctype {}", bsc.0);
         }
-        &interface::Command::BlockSwitchDistance(ref bsd) => {
+        interface::Command::BlockSwitchDistance(bsd) => {
             println_stderr!("dtype {}", bsd.0);
         }
-        &interface::Command::PredictionMode(ref prediction) => {
+        interface::Command::PredictionMode(prediction) => {
             let prediction_mode = prediction_mode_str(prediction.literal_prediction_mode());
             let lit_cm = prediction
                 .literal_context_map
@@ -149,10 +149,10 @@ pub fn write_one<T: SliceWrapper<u8>>(cmd: &interface::Command<T>) {
                 );
             }
         }
-        &interface::Command::Copy(ref copy) => {
+        interface::Command::Copy(copy) => {
             println_stderr!("copy {} from {}", copy.num_bytes, copy.distance);
         }
-        &interface::Command::Dict(ref dict) => {
+        interface::Command::Dict(dict) => {
             let mut transformed_word = [0u8; 38];
             let word_index = dict.word_id as usize * dict.word_size as usize
                 + kBrotliDictionaryOffsetsByLength[dict.word_size as usize] as usize;
@@ -176,7 +176,7 @@ pub fn write_one<T: SliceWrapper<u8>>(cmd: &interface::Command<T>) {
                 SliceU8Ref(transformed_word.split_at(actual_copy_len).0)
             );
         }
-        &interface::Command::Literal(ref lit) => {
+        interface::Command::Literal(lit) => {
             println_stderr!(
                 "{} {} {:x}",
                 if lit.high_entropy { "rndins" } else { "insert" },

--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -400,7 +400,7 @@ impl BroCatli {
             .split_at_mut(to_copy)
             .0
             .clone_from_slice(
-                &new_stream_pending
+                new_stream_pending
                     .bytes_so_far
                     .split_at(usize::from(new_stream_pending.num_bytes_written.unwrap()))
                     .1

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -786,7 +786,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
             }
         }
         if max_length >= 4 && cur_ix_masked.wrapping_add(best_len) <= ring_buffer_mask {
-            let key = self.HashBytes(&data.split_at(cur_ix_masked).1);
+            let key = self.HashBytes(data.split_at(cur_ix_masked).1);
             let bucket = &mut self
                 .buckets_
                 .slice_mut()
@@ -819,8 +819,8 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> AnyHasher for H9<Allo
                 }
                 {
                     let len = FindMatchLengthWithLimit(
-                        &data.split_at(prev_ix).1,
-                        &data.split_at((cur_ix_masked as usize)).1,
+                        data.split_at(prev_ix).1,
+                        data.split_at((cur_ix_masked as usize)).1,
                         max_length,
                     );
                     if (len >= 4) {
@@ -1710,7 +1710,7 @@ impl<
                     }
                     let prev_data = data.split_at(prev_ix).1;
 
-                    let len: usize = FindMatchLengthWithLimit(&prev_data, &cur_data, max_length);
+                    let len: usize = FindMatchLengthWithLimit(prev_data, cur_data, max_length);
                     if len >= 3usize || len == 2usize && (i < 2usize) {
                         let mut score: u64 = BackwardReferenceScoreUsingLastDistance(len, opts);
                         if best_score < score {
@@ -1771,7 +1771,7 @@ impl<
                         break;
                     }
                     let prev_data = data.split_at(prev_ix as usize).1;
-                    let len = FindMatchLengthWithLimitMin4(&prev_data, &cur_data, max_length);
+                    let len = FindMatchLengthWithLimitMin4(prev_data, cur_data, max_length);
                     if len != 0 {
                         let score: u64 = BackwardReferenceScore(len, backward, opts);
                         if best_score < score {

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -181,9 +181,9 @@ impl<'a, Alloc: BrotliAlloc> CommandQueue<'a, Alloc> {
             self.mc,
         );
         self.clear();
-        self.entropy_tally_scratch.free(&mut self.mc);
-        self.entropy_pyramid.free(&mut self.mc);
-        self.context_map_entropy.free(&mut self.mc);
+        self.entropy_tally_scratch.free(self.mc);
+        self.entropy_pyramid.free(self.mc);
+        self.context_map_entropy.free(self.mc);
         <Alloc as Allocator<StaticCommand>>::free_cell(
             self.mc,
             core::mem::replace(
@@ -579,7 +579,7 @@ fn LogMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     let mut best_strides = <Alloc as Allocator<u8>>::AllocatedMemory::default();
     if params.stride_detection_quality > 2 {
         let mut stride_selector =
-            stride_eval::StrideEval::<Alloc>::new(alloc, input, &prediction_mode, &params);
+            stride_eval::StrideEval::<Alloc>::new(alloc, input, &prediction_mode, params);
         process_command_queue(
             &mut stride_selector,
             input,
@@ -648,7 +648,7 @@ fn LogMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
         input,
         entropy_pyramid.stride_last_level_range(),
         context_map_entropy.take_prediction_mode(),
-        &params,
+        params,
     );
     if params.prior_bitmask_detection != 0 {
         process_command_queue(

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -143,11 +143,11 @@ fn BrotliCompareAndPushToQueue<
 pub fn BrotliHistogramCombine<
     HistogramType: SliceWrapperMut<u32> + SliceWrapper<u32> + CostAccessors + Clone,
 >(
-    mut out: &mut [HistogramType],
+    out: &mut [HistogramType],
     cluster_size: &mut [u32],
     symbols: &mut [u32],
     clusters: &mut [u32],
-    mut pairs: &mut [HistogramPair],
+    pairs: &mut [HistogramPair],
     mut num_clusters: usize,
     symbols_size: usize,
     max_clusters: usize,
@@ -201,7 +201,7 @@ pub fn BrotliHistogramCombine<
         /* Take the best pair from the top of heap. */
         best_idx1 = (pairs[(0usize)]).idx1;
         best_idx2 = (pairs[(0usize)]).idx2;
-        HistogramSelfAddHistogram(&mut out, (best_idx1 as (usize)), (best_idx2 as (usize)));
+        HistogramSelfAddHistogram(out, (best_idx1 as (usize)), (best_idx2 as (usize)));
         (out[(best_idx1 as (usize))]).set_bit_cost((pairs[(0usize)]).cost_combo);
         {
             let _rhs = cluster_size[(best_idx2 as (usize))];
@@ -275,7 +275,7 @@ pub fn BrotliHistogramCombine<
                     clusters[(i as (usize))],
                     max_num_pairs,
                     scratch_space,
-                    &mut pairs,
+                    pairs,
                     &mut num_pairs,
                 );
             }

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -507,7 +507,7 @@ pub fn memcpy<T: Sized + Clone>(
 fn BuildAndStoreCommandPrefixCode(
     histogram: &[u32],
     depth: &mut [u8],
-    mut bits: &mut [u16],
+    bits: &mut [u16],
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
@@ -558,30 +558,12 @@ fn BuildAndStoreCommandPrefixCode(
         8usize,
     );
     BrotliConvertBitDepthsToSymbols(&mut cmd_depth[..], 64usize, &mut cmd_bits[..]);
-    memcpy(&mut bits, 0, &cmd_bits[..], 24i32 as (usize), 16usize);
-    memcpy(&mut bits, (8usize), &cmd_bits[..], 40i32 as (usize), 8usize);
-    memcpy(
-        &mut bits,
-        (16usize),
-        &cmd_bits[..],
-        56i32 as (usize),
-        8usize,
-    );
-    memcpy(&mut bits, (24usize), &cmd_bits[..], 0, 48usize);
-    memcpy(
-        &mut bits,
-        (48usize),
-        &cmd_bits[..],
-        32i32 as (usize),
-        8usize,
-    );
-    memcpy(
-        &mut bits,
-        (56usize),
-        &cmd_bits[..],
-        48i32 as (usize),
-        8usize,
-    );
+    memcpy(bits, 0, &cmd_bits[..], 24i32 as (usize), 16usize);
+    memcpy(bits, (8usize), &cmd_bits[..], 40i32 as (usize), 8usize);
+    memcpy(bits, (16usize), &cmd_bits[..], 56i32 as (usize), 8usize);
+    memcpy(bits, (24usize), &cmd_bits[..], 0, 48usize);
+    memcpy(bits, (48usize), &cmd_bits[..], 32i32 as (usize), 8usize);
+    memcpy(bits, (56usize), &cmd_bits[..], 48i32 as (usize), 8usize);
     BrotliConvertBitDepthsToSymbols(&mut depth[(64usize)..], 64usize, &mut bits[(64usize)..]);
     {
         let mut i: usize;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1626,10 +1626,10 @@ pub fn BrotliEncoderCompress<
         {
             let s = &mut s_orig;
             let mut available_in: usize = input_size;
-            let mut next_in_array: &[u8] = input_buffer;
+            let next_in_array: &[u8] = input_buffer;
             let mut next_in_offset: usize = 0;
             let mut available_out: usize = *encoded_size;
-            let mut next_out_array: &mut [u8] = output_start;
+            let next_out_array: &mut [u8] = output_start;
             let mut next_out_offset: usize = 0;
             let mut total_out = Some(0usize);
             BrotliEncoderSetParameter(
@@ -1655,10 +1655,10 @@ pub fn BrotliEncoderCompress<
                 s,
                 BrotliEncoderOperation::BROTLI_OPERATION_FINISH,
                 &mut available_in,
-                &mut next_in_array,
+                next_in_array,
                 &mut next_in_offset,
                 &mut available_out,
-                &mut next_out_array,
+                next_out_array,
                 &mut next_out_offset,
                 &mut total_out,
                 metablock_callback,
@@ -2655,7 +2655,7 @@ where
     } else {
         BrotliCreateBackwardReferences(
             &mut (*s).m8,
-            &dictionary,
+            dictionary,
             bytes as (usize),
             wrapped_last_processed_pos as (usize),
             &mut (*s).ringbuffer_.data_mo.slice_mut()[((*s).ringbuffer_.buffer_index as usize)..],
@@ -2767,7 +2767,7 @@ where
         (*s).num_commands_ = 0usize;
         (*s).num_literals_ = 0usize;
         (*s).saved_dist_cache_
-            .clone_from_slice(&(*s).dist_cache_.split_at(4).0);
+            .clone_from_slice((*s).dist_cache_.split_at(4).0);
         (*s).next_out_ = NextOut::DynamicStorage(0); // this always returns that
         *out_size = storage_ix >> 3i32;
         1i32

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -515,15 +515,13 @@ impl<SliceType: SliceWrapper<u8> + Clone> Clone for Command<SliceType> {
     #[inline]
     fn clone(&self) -> Command<SliceType> {
         match self {
-            &Command::Copy(ref copy) => Command::Copy(copy.clone()),
-            &Command::Dict(ref dict) => Command::Dict(dict.clone()),
-            &Command::Literal(ref literal) => Command::Literal(literal.clone()),
-            &Command::BlockSwitchCommand(ref switch) => Command::BlockSwitchCommand(switch.clone()),
-            &Command::BlockSwitchLiteral(ref switch) => Command::BlockSwitchLiteral(switch.clone()),
-            &Command::BlockSwitchDistance(ref switch) => {
-                Command::BlockSwitchDistance(switch.clone())
-            }
-            &Command::PredictionMode(ref pm) => Command::PredictionMode(pm.clone()),
+            Command::Copy(copy) => Command::Copy(copy.clone()),
+            Command::Dict(dict) => Command::Dict(dict.clone()),
+            Command::Literal(literal) => Command::Literal(literal.clone()),
+            Command::BlockSwitchCommand(switch) => Command::BlockSwitchCommand(switch.clone()),
+            Command::BlockSwitchLiteral(switch) => Command::BlockSwitchLiteral(switch.clone()),
+            Command::BlockSwitchDistance(switch) => Command::BlockSwitchDistance(switch.clone()),
+            Command::PredictionMode(pm) => Command::PredictionMode(pm.clone()),
         }
     }
 }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -744,7 +744,7 @@ fn ContextBlockSplitterFinishBlock<
                 let curr_histo_ix: usize = (*xself).curr_histogram_ix_.wrapping_add(i);
                 let mut j: usize;
                 entropy[i] = BitsEntropy(
-                    &(histograms[(curr_histo_ix as (usize))]).slice(),
+                    (histograms[(curr_histo_ix as (usize))]).slice(),
                     (*xself).alphabet_size_,
                 );
                 j = 0usize;
@@ -1046,7 +1046,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             BlockSplitterAddSymbol(
                 &mut cmd_blocks,
                 &mut (*mb).command_split,
-                &mut (*mb).command_histograms.slice_mut(),
+                (*mb).command_histograms.slice_mut(),
                 &mut (*mb).command_histograms_size,
                 cmd.cmd_prefix_ as (usize),
             );
@@ -1058,7 +1058,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterAddSymbol(
                             lit_blocks_plain,
                             &mut (*mb).literal_split,
-                            &mut (*mb).literal_histograms.slice_mut(),
+                            (*mb).literal_histograms.slice_mut(),
                             &mut (*mb).literal_histograms_size,
                             literal as (usize),
                         ),
@@ -1069,7 +1069,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                                 lit_blocks_ctx,
                                 alloc,
                                 &mut (*mb).literal_split,
-                                &mut (*mb).literal_histograms.slice_mut(),
+                                (*mb).literal_histograms.slice_mut(),
                                 &mut (*mb).literal_histograms_size,
                                 literal as (usize),
                                 static_context_map[(context as (usize))] as (usize),
@@ -1090,7 +1090,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
                     BlockSplitterAddSymbol(
                         &mut dist_blocks,
                         &mut (*mb).distance_split,
-                        &mut (*mb).distance_histograms.slice_mut(),
+                        (*mb).distance_histograms.slice_mut(),
                         &mut (*mb).distance_histograms_size,
                         cmd.dist_prefix_ as (usize) & 0x3ff,
                     );
@@ -1103,7 +1103,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
         &mut LitBlocks::plain(ref mut lit_blocks_plain) => BlockSplitterFinishBlock(
             lit_blocks_plain,
             &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms.slice_mut(),
+            (*mb).literal_histograms.slice_mut(),
             &mut (*mb).literal_histograms_size,
             1i32,
         ),
@@ -1111,7 +1111,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             lit_blocks_ctx,
             alloc,
             &mut (*mb).literal_split,
-            &mut (*mb).literal_histograms.slice_mut(),
+            (*mb).literal_histograms.slice_mut(),
             &mut (*mb).literal_histograms_size,
             1i32,
         ),
@@ -1119,14 +1119,14 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
     BlockSplitterFinishBlock(
         &mut cmd_blocks,
         &mut (*mb).command_split,
-        &mut (*mb).command_histograms.slice_mut(),
+        (*mb).command_histograms.slice_mut(),
         &mut (*mb).command_histograms_size,
         1i32,
     );
     BlockSplitterFinishBlock(
         &mut dist_blocks,
         &mut (*mb).distance_split,
-        &mut (*mb).distance_histograms.slice_mut(),
+        (*mb).distance_histograms.slice_mut(),
         &mut (*mb).distance_histograms_size,
         1i32,
     );

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -43,7 +43,7 @@ pub fn BrotliGetDictionary() -> &'static BrotliDictionary {
 #[inline(always)]
 pub fn BROTLI_UNALIGNED_LOAD32(sl: &[u8]) -> u32 {
     let mut p = [0u8; 4];
-    p[..].clone_from_slice(&sl.split_at(4).0);
+    p[..].clone_from_slice(sl.split_at(4).0);
     return (p[0] as u32) | ((p[1] as u32) << 8) | ((p[2] as u32) << 16) | ((p[3] as u32) << 24);
 }
 #[inline(always)]
@@ -369,8 +369,8 @@ pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_leng
                 && (dict[(0usize)] as (i32) <= b'z' as (i32))
                 && (dict[(0usize)] as (i32) ^ 32i32 == data[(0usize)] as (i32))
                 && (FindMatchLengthWithLimit(
-                    &dict.split_at(1).1,
-                    &data.split_at(1).1,
+                    dict.split_at(1).1,
+                    data.split_at(1).1,
                     (w.len() as (u32)).wrapping_sub(1u32) as (usize),
                 ) == (w.len() as (u32)).wrapping_sub(1u32) as (usize)))
             {
@@ -435,7 +435,7 @@ fn DictMatchLength(
     let offset: usize =
         ((*dictionary).offsets_by_length[len] as (usize)).wrapping_add(len.wrapping_mul(id));
     FindMatchLengthWithLimit(
-        &(*dictionary).data.split_at(offset).1,
+        (*dictionary).data.split_at(offset).1,
         data,
         brotli_min_size_t(len, maxlen),
     )
@@ -1164,7 +1164,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
             0i32
         };
         let mut offset: usize =
-            kStaticDictionaryBuckets[Hash(&data.split_at(1).1) as (usize)] as (usize);
+            kStaticDictionaryBuckets[Hash(data.split_at(1).1) as (usize)] as (usize);
         let mut end: i32 = (offset == 0) as (i32);
         while end == 0 {
             let mut w: DictWord = kStaticDictionaryWords[{
@@ -1182,7 +1182,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 if IsMatch(
                     dictionary,
                     w,
-                    &data.split_at(1).1,
+                    data.split_at(1).1,
                     max_length.wrapping_sub(1usize),
                 ) == 0
                 {
@@ -1291,7 +1291,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 if IsMatch(
                     dictionary,
                     w,
-                    &data.split_at(1).1,
+                    data.split_at(1).1,
                     max_length.wrapping_sub(1usize),
                 ) == 0
                 {
@@ -1407,7 +1407,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
             || data[(0usize)] as (i32) == 0xc2i32 && (data[(1usize)] as (i32) == 0xa0i32)
         {
             let mut offset: usize =
-                kStaticDictionaryBuckets[Hash(&data.split_at(2).1) as (usize)] as (usize);
+                kStaticDictionaryBuckets[Hash(data.split_at(2).1) as (usize)] as (usize);
             let mut end: i32 = (offset == 0) as (i32);
             while end == 0 {
                 let mut w: DictWord = kStaticDictionaryWords[{
@@ -1424,7 +1424,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     && (IsMatch(
                         dictionary,
                         w,
-                        &data.split_at(2).1,
+                        data.split_at(2).1,
                         max_length.wrapping_sub(2usize),
                     ) != 0)
                 {
@@ -1473,7 +1473,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 && (data[(4usize)] as (i32) == b'/' as (i32))
         {
             let mut offset: usize =
-                kStaticDictionaryBuckets[Hash(&data.split_at(5).1) as (usize)] as (usize);
+                kStaticDictionaryBuckets[Hash(data.split_at(5).1) as (usize)] as (usize);
             let mut end: i32 = (offset == 0) as (i32);
             while end == 0 {
                 let mut w: DictWord = kStaticDictionaryWords[{
@@ -1490,7 +1490,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     && (IsMatch(
                         dictionary,
                         w,
-                        &data.split_at(5).1,
+                        data.split_at(5).1,
                         max_length.wrapping_sub(5usize),
                     ) != 0)
                 {
@@ -1510,7 +1510,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     );
                     has_found_match = 1i32;
                     if l.wrapping_add(5usize) < max_length {
-                        let s: &[u8] = &data.split_at(l.wrapping_add(5usize) as (usize)).1;
+                        let s: &[u8] = data.split_at(l.wrapping_add(5usize) as (usize)).1;
                         if data[(0usize)] as (i32) == b' ' as (i32) {
                             if l.wrapping_add(8usize) < max_length
                                 && (s[(0usize)] as (i32) == b' ' as (i32))

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -246,7 +246,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
 {
     fn drop(&mut self) {
         <Alloc as Allocator<floatX>>::free_cell(
-            &mut self.alloc,
+            self.alloc,
             core::mem::replace(
                 &mut self.score,
                 <Alloc as Allocator<floatX>>::AllocatedMemory::default(),
@@ -254,7 +254,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
         );
         for i in 0..8 {
             <Alloc as Allocator<u16>>::free_cell(
-                &mut self.alloc,
+                self.alloc,
                 core::mem::replace(
                     &mut self.stride_priors[i],
                     <Alloc as Allocator<u16>>::AllocatedMemory::default(),

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -225,7 +225,7 @@ fn oneshot_compress(
     return (1, next_out_offset);
 }
 
-fn oneshot_decompress(compressed: &[u8], mut output: &mut [u8]) -> (BrotliResult, usize, usize) {
+fn oneshot_decompress(compressed: &[u8], output: &mut [u8]) -> (BrotliResult, usize, usize) {
     let mut available_in: usize = compressed.len();
     let mut available_out: usize = output.len();
     let mut stack_u8_buffer = define_allocator_memory_pool!(128, u8, [0; 100 * 1024], stack);
@@ -251,7 +251,7 @@ fn oneshot_decompress(compressed: &[u8], mut output: &mut [u8]) -> (BrotliResult
         &compressed[..],
         &mut available_out,
         &mut output_offset,
-        &mut output,
+        output,
         &mut written,
         &mut brotli_state,
     );

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -93,7 +93,7 @@ impl<
 {
     fn drop(&mut self) {
         {
-            let &(ref lock, ref cvar) = &*self.queue.0;
+            let (lock, cvar) = &*self.queue.0;
             let mut local_queue = lock.lock().unwrap();
             local_queue.immediate_shutdown = true;
             cvar.notify_all();
@@ -122,7 +122,7 @@ impl<
                 // after the destructor that decrefs possible_job
                 let possible_job;
                 {
-                    let &(ref lock, ref cvar) = &*queue;
+                    let (lock, cvar) = &*queue;
                     let mut local_queue = lock.lock().unwrap();
                     if local_queue.immediate_shutdown {
                         break;
@@ -156,7 +156,7 @@ impl<
                 };
             }
             {
-                let &(ref lock, ref cvar) = &*queue;
+                let (lock, cvar) = &*queue;
                 let mut local_queue = lock.lock().unwrap();
                 local_queue.num_in_progress -= 1;
                 local_queue.results.push(ret).unwrap();
@@ -165,7 +165,7 @@ impl<
         }
     }
     fn _push_job(&mut self, job: JobRequest<ReturnValue, ExtraInput, Alloc, U>) {
-        let &(ref lock, ref cvar) = &*self.queue.0;
+        let (lock, cvar) = &*self.queue.0;
         let mut local_queue = lock.lock().unwrap();
         loop {
             if local_queue.jobs.size() + local_queue.num_in_progress + local_queue.results.size()
@@ -182,7 +182,7 @@ impl<
         &mut self,
         job: JobRequest<ReturnValue, ExtraInput, Alloc, U>,
     ) -> Result<(), JobRequest<ReturnValue, ExtraInput, Alloc, U>> {
-        let &(ref lock, ref cvar) = &*self.queue.0;
+        let (lock, cvar) = &*self.queue.0;
         let mut local_queue = lock.lock().unwrap();
         if local_queue.jobs.size() + local_queue.num_in_progress + local_queue.results.size()
             < MAX_THREADS
@@ -322,7 +322,7 @@ impl<
     for WorkerJoinable<ReturnValue, ExtraInput, Alloc, U>
 {
     fn join(self) -> Result<ReturnValue, BrotliEncoderThreadError> {
-        let &(ref lock, ref cvar) = &*self.queue.0;
+        let (lock, cvar) = &*self.queue.0;
         let mut local_queue = lock.lock().unwrap();
         loop {
             match local_queue
@@ -370,7 +370,7 @@ where
         f: fn(ExtraInput, usize, usize, &U, Alloc) -> ReturnValue,
     ) {
         assert!(num_threads <= MAX_THREADS);
-        let &(ref lock, ref cvar) = &*self.queue.0;
+        let (lock, cvar) = &*self.queue.0;
         let mut local_queue = lock.lock().unwrap();
         loop {
             if local_queue.jobs.size() + local_queue.num_in_progress + local_queue.results.size()


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::needless_borrow
cargo clippy --fix -- -A clippy::all -W clippy::needless_borrowed_reference
cargo fix
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrow and https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrowed_reference


See CI results in https://github.com/rust-brotli/rust-brotli/pull/15