### PR TITLE
Auto-fixed clippy::clone_on_copy

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -435,7 +435,7 @@ impl BroCatli {
         out_bytes: &mut [u8],
         out_offset: &mut usize,
     ) -> BroCatliResult {
-        if let Some(mut new_stream_pending) = self.new_stream_pending.clone() {
+        if let Some(mut new_stream_pending) = self.new_stream_pending {
             let flush_result = self.flush_previous_stream(out_bytes, out_offset);
             if let BroCatliResult::Success = flush_result {
                 if usize::from(new_stream_pending.num_bytes_read)

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -2006,7 +2006,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
             buckets_: H2Sub::<Alloc> {
                 buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
             },
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         };
         ret.buckets_
             .buckets_
@@ -2024,7 +2024,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
             buckets_: H3Sub::<Alloc> {
                 buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
             },
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         };
         ret.buckets_
             .buckets_
@@ -2042,7 +2042,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
             buckets_: H4Sub::<Alloc> {
                 buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
             },
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         };
         ret.buckets_
             .buckets_
@@ -2060,7 +2060,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
             buckets_: H54Sub::<Alloc> {
                 buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.len()),
             },
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         };
         ret.buckets_
             .buckets_
@@ -2079,7 +2079,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
             num_: num,
             buckets_: buckets,
             dict_search_stats_: self.dict_search_stats_.clone(),
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         }
     }
 }
@@ -2098,7 +2098,7 @@ impl<
             specialization: self.specialization.clone(),
             num: num,
             buckets: buckets,
-            h9_opts: self.h9_opts.clone(),
+            h9_opts: self.h9_opts,
         }
     }
 }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -287,7 +287,7 @@ fn process_command_queue<'a, CmdProcessor: interface::CommandProcessor<'a>>(
     params: &BrotliEncoderParams,
     context_type: Option<ContextType>,
 ) -> RecoderState {
-    let mut input_iter = input.clone();
+    let mut input_iter = input;
     let mut local_dist_cache = [0i32; kNumDistanceCacheEntries];
     local_dist_cache.clone_from_slice(&dist_cache[..]);
     let mut btypel_counter = 0usize;
@@ -1153,8 +1153,8 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                     let mut k: i32;
                     SortHuffmanTreeItems(tree.slice_mut(), n as (usize), SimpleSortHuffmanTree {});
                     sentinel = NewHuffmanTree(!(0u32), -1i16, -1i16);
-                    tree.slice_mut()[(node_index.wrapping_add(1u32) as (usize))] = sentinel.clone();
-                    tree.slice_mut()[(node_index as (usize))] = sentinel.clone();
+                    tree.slice_mut()[(node_index.wrapping_add(1u32) as (usize))] = sentinel;
+                    tree.slice_mut()[(node_index as (usize))] = sentinel;
                     node_index = node_index.wrapping_add(2u32);
                     k = n - 1i32;
                     while k > 0i32 {
@@ -1186,7 +1186,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                             (tree.slice_mut()[tree_ind]).total_count_ = sum_total;
                             (tree.slice_mut()[tree_ind]).index_left_ = left as (i16);
                             (tree.slice_mut()[tree_ind]).index_right_or_value_ = right as (i16);
-                            tree.slice_mut()[(node_index as (usize))] = sentinel.clone();
+                            tree.slice_mut()[(node_index as (usize))] = sentinel;
                             node_index = node_index.wrapping_add(1u32);
                         }
                         k = k - 1;
@@ -2586,7 +2586,7 @@ pub fn BrotliStoreMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))].clone();
+            let cmd: Command = commands[(i as (usize))];
             let cmd_code: usize = cmd.cmd_prefix_ as (usize);
             StoreSymbol(&mut command_enc, cmd_code, storage_ix, storage);
             StoreCommandExtra(&cmd, storage_ix, storage);
@@ -2680,7 +2680,7 @@ fn BuildHistograms(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))].clone();
+            let cmd: Command = commands[(i as (usize))];
             let mut j: usize;
             HistogramAddItem(cmd_histo, cmd.cmd_prefix_ as (usize));
             j = cmd.insert_len_ as (usize);
@@ -2719,7 +2719,7 @@ fn StoreDataWithHuffmanCodes(
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))].clone();
+            let cmd: Command = commands[(i as (usize))];
             let cmd_code: usize = cmd.cmd_prefix_ as (usize);
             let mut j: usize;
             BrotliWriteBits(
@@ -3054,7 +3054,7 @@ pub fn BrotliStoreMetaBlockFast<Cb, Alloc: BrotliAlloc>(
         i = 0usize;
         while i < n_commands {
             {
-                let cmd: Command = commands[(i as (usize))].clone();
+                let cmd: Command = commands[(i as (usize))];
                 let mut j: usize;
                 j = cmd.insert_len_ as (usize);
                 while j != 0usize {

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -132,7 +132,7 @@ impl SliceWrapper<Mem256i> for Array264i {
 impl Default for Array264i {
     #[inline(always)]
     fn default() -> Array264i {
-        return Array264i([Mem256i::default().clone(); 33]);
+        return Array264i([Mem256i::default(); 33]);
     }
 }
 pub struct Array528i([Mem256i; 66]);

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -412,7 +412,7 @@ impl<SliceType: SliceWrapper<u8> + Default> Default for FeatureFlagSliceType<Sli
 impl<SliceType: SliceWrapper<u8> + Clone> Clone for FeatureFlagSliceType<SliceType> {
     #[inline(always)]
     fn clone(&self) -> Self {
-        FeatureFlagSliceType::<SliceType>(self.0.clone())
+        FeatureFlagSliceType::<SliceType>(self.0)
     }
 }
 impl<SliceType: SliceWrapper<u8> + Clone + Copy> Copy for FeatureFlagSliceType<SliceType> {}
@@ -456,7 +456,7 @@ impl<SliceType: SliceWrapper<u8> + Clone> Clone for LiteralCommand<SliceType> {
         LiteralCommand::<SliceType> {
             data: self.data.clone(),
             prob: self.prob.clone(),
-            high_entropy: self.high_entropy.clone(),
+            high_entropy: self.high_entropy,
         }
     }
 }
@@ -515,14 +515,12 @@ impl<SliceType: SliceWrapper<u8> + Clone> Clone for Command<SliceType> {
     #[inline]
     fn clone(&self) -> Command<SliceType> {
         match self {
-            &Command::Copy(ref copy) => Command::Copy(copy.clone()),
-            &Command::Dict(ref dict) => Command::Dict(dict.clone()),
+            &Command::Copy(ref copy) => Command::Copy(*copy),
+            &Command::Dict(ref dict) => Command::Dict(*dict),
             &Command::Literal(ref literal) => Command::Literal(literal.clone()),
-            &Command::BlockSwitchCommand(ref switch) => Command::BlockSwitchCommand(switch.clone()),
-            &Command::BlockSwitchLiteral(ref switch) => Command::BlockSwitchLiteral(switch.clone()),
-            &Command::BlockSwitchDistance(ref switch) => {
-                Command::BlockSwitchDistance(switch.clone())
-            }
+            &Command::BlockSwitchCommand(ref switch) => Command::BlockSwitchCommand(*switch),
+            &Command::BlockSwitchLiteral(ref switch) => Command::BlockSwitchLiteral(*switch),
+            &Command::BlockSwitchDistance(ref switch) => Command::BlockSwitchDistance(*switch),
             &Command::PredictionMode(ref pm) => Command::PredictionMode(pm.clone()),
         }
     }
@@ -701,11 +699,11 @@ pub fn thaw_pair<'a, SliceType: Unfreezable + SliceWrapper<u8>>(
                 .thaw_pair(data)
                 .unwrap(),
         }),
-        Command::Dict(ref d) => Command::Dict(d.clone()),
-        Command::Copy(ref c) => Command::Copy(c.clone()),
-        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(c.clone()),
-        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(c.clone()),
-        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(c.clone()),
+        Command::Dict(ref d) => Command::Dict(*d),
+        Command::Copy(ref c) => Command::Copy(*c),
+        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
+        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
+        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
     }
 }
 
@@ -725,11 +723,11 @@ pub fn thaw<'a, SliceType: Unfreezable + SliceWrapper<u8>>(
                 .predmode_speed_and_distance_context_map
                 .thaw(data),
         }),
-        Command::Dict(ref d) => Command::Dict(d.clone()),
-        Command::Copy(ref c) => Command::Copy(c.clone()),
-        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(c.clone()),
-        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(c.clone()),
-        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(c.clone()),
+        Command::Dict(ref d) => Command::Dict(*d),
+        Command::Copy(ref c) => Command::Copy(*c),
+        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
+        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
+        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
     }
 }
 
@@ -747,11 +745,11 @@ impl<SliceType: SliceWrapper<u8> + Freezable> Command<SliceType> {
                     .predmode_speed_and_distance_context_map
                     .freeze(),
             }),
-            Command::Dict(ref d) => Command::Dict(d.clone()),
-            Command::Copy(ref c) => Command::Copy(c.clone()),
-            Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(c.clone()),
-            Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(c.clone()),
-            Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(c.clone()),
+            Command::Dict(ref d) => Command::Dict(*d),
+            Command::Copy(ref c) => Command::Copy(*c),
+            Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
+            Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
+            Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
         }
     }
 }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -1041,7 +1041,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
     i = 0usize;
     while i < n_commands {
         {
-            let cmd: Command = commands[(i as (usize))].clone();
+            let cmd: Command = commands[(i as (usize))];
             let mut j: usize;
             BlockSplitterAddSymbol(
                 &mut cmd_blocks,


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::clone_on_copy
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/clone_on_copy

See CI results in https://github.com/rust-brotli/rust-brotli/pull/16