### PR TITLE
Auto-fixed clippy::precedence

### DIFF
--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -274,7 +274,7 @@ where
     #[inline(always)]
     fn HashBytes(&self, data: &[u8]) -> usize {
         let h = BROTLI_UNALIGNED_LOAD32(data).wrapping_mul(kHashMul32);
-        (h >> 32i32 - BUCKET_BITS as i32) as usize
+        (h >> (32i32 - BUCKET_BITS as i32)) as usize
     }
     #[inline(always)]
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -299,7 +299,7 @@ fn InitStartPosQueue() -> StartPosQueue {
 #[inline(always)]
 fn HashBytesH10(data: &[u8]) -> u32 {
     let h: u32 = BROTLI_UNALIGNED_LOAD32(data).wrapping_mul(kHashMul32);
-    h >> 32i32 - 17i32
+    h >> (32i32 - 17i32)
 }
 
 #[inline(always)]

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -475,8 +475,8 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
 impl<AllocU32: alloc::Allocator<u32>> BasicHashComputer for H2Sub<AllocU32> {
     fn HashBytes(&self, data: &[u8]) -> u32 {
         let h: u64 =
-            (BROTLI_UNALIGNED_LOAD64(data) << 64i32 - 8i32 * 5i32).wrapping_mul(kHashMul64);
-        (h >> 64i32 - 16i32) as (u32)
+            (BROTLI_UNALIGNED_LOAD64(data) << (64i32 - 8i32 * 5i32)).wrapping_mul(kHashMul64);
+        (h >> (64i32 - 16i32)) as (u32)
     }
     fn BUCKET_BITS(&self) -> i32 {
         16
@@ -523,8 +523,8 @@ impl<AllocU32: alloc::Allocator<u32>> BasicHashComputer for H3Sub<AllocU32> {
     }
     fn HashBytes(&self, data: &[u8]) -> u32 {
         let h: u64 =
-            (BROTLI_UNALIGNED_LOAD64(data) << 64i32 - 8i32 * 5i32).wrapping_mul(kHashMul64);
-        (h >> 64i32 - 16i32) as (u32)
+            (BROTLI_UNALIGNED_LOAD64(data) << (64i32 - 8i32 * 5i32)).wrapping_mul(kHashMul64);
+        (h >> (64i32 - 16i32)) as (u32)
     }
 }
 pub struct H4Sub<AllocU32: alloc::Allocator<u32>> {
@@ -542,8 +542,8 @@ impl<AllocU32: alloc::Allocator<u32>> BasicHashComputer for H4Sub<AllocU32> {
     }
     fn HashBytes(&self, data: &[u8]) -> u32 {
         let h: u64 =
-            (BROTLI_UNALIGNED_LOAD64(data) << 64i32 - 8i32 * 5i32).wrapping_mul(kHashMul64);
-        (h >> 64i32 - 17i32) as (u32)
+            (BROTLI_UNALIGNED_LOAD64(data) << (64i32 - 8i32 * 5i32)).wrapping_mul(kHashMul64);
+        (h >> (64i32 - 17i32)) as (u32)
     }
 }
 impl<AllocU32: alloc::Allocator<u32>> SliceWrapperMut<u32> for H4Sub<AllocU32> {
@@ -571,8 +571,8 @@ impl<AllocU32: alloc::Allocator<u32>> BasicHashComputer for H54Sub<AllocU32> {
     }
     fn HashBytes(&self, data: &[u8]) -> u32 {
         let h: u64 =
-            (BROTLI_UNALIGNED_LOAD64(data) << 64i32 - 8i32 * 7i32).wrapping_mul(kHashMul64);
-        (h >> 64i32 - 20i32) as (u32)
+            (BROTLI_UNALIGNED_LOAD64(data) << (64i32 - 8i32 * 7i32)).wrapping_mul(kHashMul64);
+        (h >> (64i32 - 20i32)) as (u32)
     }
 }
 
@@ -1117,7 +1117,7 @@ impl AdvHashSpecialization for H6Sub {
     }
     #[inline(always)]
     fn set_hash_mask(&mut self, params_hash_len: i32) {
-        self.hash_mask = !(0u32 as (u64)) >> 64i32 - 8i32 * params_hash_len;
+        self.hash_mask = !(0u32 as (u64)) >> (64i32 - 8i32 * params_hash_len);
     }
     #[inline(always)]
     fn get_k_hash_mul(&self) -> u64 {
@@ -1895,7 +1895,7 @@ fn BackwardReferenceScore(
 
 fn Hash14(data: &[u8]) -> u32 {
     let h: u32 = BROTLI_UNALIGNED_LOAD32(data).wrapping_mul(kHashMul32);
-    h >> 32i32 - 14i32
+    h >> (32i32 - 14i32)
 }
 
 fn TestStaticDictionaryItem(

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -511,7 +511,7 @@ fn EmitCopyLenLastDistance(
 
 fn HashBytesAtOffset(v: u64, offset: i32, shift: usize) -> u32 {
     {
-        let h: u64 = (v >> 8i32 * offset << 24i32).wrapping_mul(kHashMul32 as (u64));
+        let h: u64 = (v >> (8i32 * offset) << 24i32).wrapping_mul(kHashMul32 as (u64));
         (h >> shift) as (u32)
     }
 }

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -117,7 +117,7 @@ fn HashBytesAtOffset(v: u64, offset: i32, shift: usize, length: usize) -> u32 {
     0i32;
     0i32;
     {
-        let h: u64 = (v >> 8i32 * offset << ((8 - length) * 8)).wrapping_mul(kHashMul32 as (u64));
+        let h: u64 = (v >> (8i32 * offset) << ((8 - length) * 8)).wrapping_mul(kHashMul32 as (u64));
         (h >> shift) as (u32)
     }
 }

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -37,7 +37,7 @@ fn get_stride_cdf_low(
         * (cm_prior as usize
             | ((stride_prior as usize & 0xf) << 8)
             | ((high_nibble as usize) << 12));
-    data.split_at_mut(NUM_SPEEDS_TO_TRY * index << 4)
+    data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
         .0
@@ -45,7 +45,7 @@ fn get_stride_cdf_low(
 
 fn get_stride_cdf_high(data: &mut [u16], stride_prior: u8, cm_prior: usize) -> &mut [u16] {
     let index: usize = 2 * (cm_prior as usize | ((stride_prior as usize) << 8));
-    data.split_at_mut(NUM_SPEEDS_TO_TRY * index << 4)
+    data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
         .0
@@ -53,7 +53,7 @@ fn get_stride_cdf_high(data: &mut [u16], stride_prior: u8, cm_prior: usize) -> &
 
 fn get_cm_cdf_low(data: &mut [u16], cm_prior: usize, high_nibble: u8) -> &mut [u16] {
     let index: usize = (high_nibble as usize + 1) + 17 * cm_prior as usize;
-    data.split_at_mut(NUM_SPEEDS_TO_TRY * index << 4)
+    data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
         .0
@@ -61,7 +61,7 @@ fn get_cm_cdf_low(data: &mut [u16], cm_prior: usize, high_nibble: u8) -> &mut [u
 
 fn get_cm_cdf_high(data: &mut [u16], cm_prior: usize) -> &mut [u16] {
     let index: usize = 17 * cm_prior as usize;
-    data.split_at_mut(NUM_SPEEDS_TO_TRY * index << 4)
+    data.split_at_mut((NUM_SPEEDS_TO_TRY * index) << 4)
         .1
         .split_at_mut(16 * NUM_SPEEDS_TO_TRY)
         .0

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -719,10 +719,10 @@ fn EncodeWindowBits(
             *last_bytes = 1i32 as (u16);
             *last_bytes_bits = 7i32 as (u8);
         } else if lgwin > 17i32 {
-            *last_bytes = (lgwin - 17i32 << 1i32 | 1i32) as (u16);
+            *last_bytes = ((lgwin - 17i32) << 1i32 | 1i32) as (u16);
             *last_bytes_bits = 4i32 as (u8);
         } else {
-            *last_bytes = (lgwin - 8i32 << 4i32 | 1i32) as (u16);
+            *last_bytes = ((lgwin - 8i32) << 4i32 | 1i32) as (u16);
             *last_bytes_bits = 7i32 as (u8);
         }
     }
@@ -1178,7 +1178,7 @@ fn InitializeH6<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
             bucket_size_: 1u32 << params.hasher.bucket_bits,
             block_bits_: params.hasher.block_bits,
             block_mask_: block_size.wrapping_sub(1) as u32,
-            hash_mask: 0xffffffffffffffffu64 >> 64i32 - 8i32 * params.hasher.hash_len,
+            hash_mask: 0xffffffffffffffffu64 >> (64i32 - 8i32 * params.hasher.hash_len),
             hash_shift_: 64i32 - params.hasher.bucket_bits,
         },
     })

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -694,7 +694,7 @@ pub fn BrotliConvertBitDepthsToSymbols(depth: &[u8], len: usize, bits: &mut [u16
     i = 1usize;
     while i < MAX_HUFFMAN_BITS {
         {
-            code = code + bl_count[i.wrapping_sub(1usize)] as (i32) << 1i32;
+            code = (code + bl_count[i.wrapping_sub(1usize)] as (i32)) << 1i32;
             next_code[i] = code as (u16);
         }
         i = i.wrapping_add(1 as (usize));

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -49,7 +49,7 @@ pub fn BROTLI_UNALIGNED_LOAD32(sl: &[u8]) -> u32 {
 #[inline(always)]
 pub fn Hash(data: &[u8]) -> u32 {
     let h: u32 = BROTLI_UNALIGNED_LOAD32(data).wrapping_mul(kDictHashMul32);
-    h >> 32i32 - kDictNumBits
+    h >> (32i32 - kDictNumBits)
 }
 #[inline(always)]
 pub fn BROTLI_UNALIGNED_LOAD64(sl: &[u8]) -> u64 {


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::precedence
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/precedence

See CI results in https://github.com/rust-brotli/rust-brotli/pull/17