### PR TITLE
Auto-fixed clippy::len_zero

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -397,7 +397,7 @@ where
     InputType: Read,
     OutputType: Write,
 {
-    if num_threads > 1 && custom_dictionary.len() == 0 && !params.log_meta_block {
+    if num_threads > 1 && custom_dictionary.is_empty() && !params.log_meta_block {
         if has_stdlib() {
             return compress_multi(
                 r,

--- a/src/bin/catbrotli.rs
+++ b/src/bin/catbrotli.rs
@@ -37,7 +37,7 @@ fn write_no_interrupt<W: Write>(w: &mut W, mut buf: &[u8]) -> Result<usize, io::
             Ok(cur_read) => {
                 buf = &buf[cur_read..];
                 total_read += cur_read;
-                if buf.len() == 0 {
+                if buf.is_empty() {
                     return Ok(total_read);
                 }
             }

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -596,7 +596,7 @@ fn writer_helper(mut in_buf: &[u8], buf_size: usize, q: u32, lgwin: u32, do_flus
             let wdec = DecompressorWriter::new(&mut output, 257);
             {
                 let mut wenc = CompressorWriter::new(wdec, 255, q, lgwin);
-                while in_buf.len() > 0 {
+                while !in_buf.is_empty() {
                     match wenc.write(&in_buf[..cmp::min(in_buf.len(), buf_size)]) {
                         Ok(size) => {
                             if size == 0 {
@@ -622,7 +622,7 @@ fn writer_helper(mut in_buf: &[u8], buf_size: usize, q: u32, lgwin: u32, do_flus
         let mut compressed = UnlimitedBuffer::new(&[]);
         {
             let mut wenc = CompressorWriter::new(&mut compressed, 255, q, lgwin);
-            while in_buf.len() > 0 {
+            while !in_buf.is_empty() {
                 match wenc.write(&in_buf[..cmp::min(in_buf.len(), buf_size)]) {
                     Ok(size) => {
                         if size == 0 {
@@ -644,7 +644,7 @@ fn into_inner_writer_helper(mut in_buf: &[u8], buf_size: usize, q: u32, lgwin: u
     let orig_buf = in_buf;
     let mut compressed = UnlimitedBuffer::new(&[]);
     let mut wenc = CompressorWriter::new(&mut compressed, 255, q, lgwin);
-    while in_buf.len() > 0 {
+    while !in_buf.is_empty() {
         match wenc.write(&in_buf[..cmp::min(in_buf.len(), buf_size)]) {
             Ok(size) => {
                 if size == 0 {
@@ -658,7 +658,7 @@ fn into_inner_writer_helper(mut in_buf: &[u8], buf_size: usize, q: u32, lgwin: u
     let c2 = wenc.into_inner();
 
     let pct_ratio = 95usize;
-    assert!(c2.data.len() > 0);
+    assert!(!c2.data.is_empty());
     assert!(c2.data.len() < orig_buf.len() * pct_ratio / 100);
     let mut compressed_in = UnlimitedBuffer::new(&c2.data[..]);
     let mut output = UnlimitedBuffer::new(&[]);

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -28,7 +28,7 @@ pub fn ShannonEntropy(
     let mut sum: usize = 0usize;
     let mut retval: super::util::floatX = 0i32 as super::util::floatX;
     let mut p: usize;
-    if size & 1usize != 0 && population.len() != 0 {
+    if size & 1usize != 0 && !population.is_empty() {
         p = population[0] as usize;
         population = population.split_at(1).1;
         sum = sum.wrapping_add(p);

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1513,7 +1513,7 @@ fn NewBlockEncoder<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
     num_blocks: usize,
 ) -> BlockEncoder<'a, Alloc> {
     let block_len: usize;
-    if num_blocks != 0 && block_lengths.len() != 0 {
+    if num_blocks != 0 && !block_lengths.is_empty() {
         block_len = block_lengths[0] as usize;
     } else {
         block_len = 0;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -816,7 +816,7 @@ fn RingBufferInitBuffer<AllocU8: alloc::Allocator<u8>>(
         ((2u32).wrapping_add(buflen) as (usize)).wrapping_add(kSlackForEightByteHashingEverywhere),
     );
     let mut i: usize;
-    if (*rb).data_mo.slice().len() != 0 {
+    if !(*rb).data_mo.slice().is_empty() {
         let lim: usize = ((2u32).wrapping_add((*rb).cur_size_) as (usize))
             .wrapping_add(kSlackForEightByteHashingEverywhere);
         new_data.slice_mut()[..lim].clone_from_slice(&(*rb).data_mo.slice()[..lim]);
@@ -2512,7 +2512,7 @@ where
         delta = UnprocessedInputSize(s);
     }
     let mut wrapped_last_processed_pos: u32 = WrapPosition((*s).last_processed_pos_);
-    if (*s).params.quality == 1i32 && (*s).command_buf_.slice().len() == 0 {
+    if (*s).params.quality == 1i32 && (*s).command_buf_.slice().is_empty() {
         let new_buf =
             <Alloc as Allocator<u32>>::alloc_cell(&mut (*s).m8, kCompressFragmentTwoPassBlockSize);
         (*s).command_buf_ = new_buf;
@@ -2584,7 +2584,7 @@ where
             newsize = newsize.wrapping_add(bytes.wrapping_div(4u32).wrapping_add(16u32) as (usize));
             (*s).cmd_alloc_size_ = newsize;
             let mut new_commands = <Alloc as Allocator<Command>>::alloc_cell(&mut s.m8, newsize);
-            if (*s).commands_.slice().len() != 0 {
+            if !(*s).commands_.slice().is_empty() {
                 new_commands.slice_mut()[..(*s).num_commands_]
                     .clone_from_slice(&(*s).commands_.slice()[..(*s).num_commands_]);
                 <Alloc as Allocator<Command>>::free_cell(
@@ -2973,13 +2973,13 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
         return 0i32;
     }
     if (*s).params.quality == 1i32 {
-        if (*s).command_buf_.slice().len() == 0 && (buf_size == kCompressFragmentTwoPassBlockSize) {
+        if (*s).command_buf_.slice().is_empty() && (buf_size == kCompressFragmentTwoPassBlockSize) {
             (*s).command_buf_ =
                 <Alloc as Allocator<u32>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
             (*s).literal_buf_ =
                 <Alloc as Allocator<u8>>::alloc_cell(&mut s.m8, kCompressFragmentTwoPassBlockSize);
         }
-        if (*s).command_buf_.slice().len() != 0 {
+        if !(*s).command_buf_.slice().is_empty() {
             command_buf = core::mem::replace(
                 &mut (*s).command_buf_,
                 <Alloc as Allocator<u32>>::AllocatedMemory::default(),
@@ -3106,7 +3106,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
         }
     }
     if command_buf.slice().len() == kCompressFragmentTwoPassBlockSize
-        && s.command_buf_.slice().len() == 0
+        && s.command_buf_.slice().is_empty()
     {
         // undo temporary aliasing of command_buf and literal_buf
         (*s).command_buf_ = core::mem::replace(

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -890,6 +890,6 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyTally<AllocU32> {
         }
     }
     pub fn is_free(&mut self) -> bool {
-        self.pop[0].bucket_populations.slice().len() == 0
+        self.pop[0].bucket_populations.slice().is_empty()
     }
 }

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -340,7 +340,7 @@ fn NewBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>
         split_: split,
         idx_: 0i32 as (usize),
         type_: 0i32 as (usize),
-        length_: if (*split).lengths.slice().len() != 0 {
+        length_: if !(*split).lengths.slice().is_empty() {
             (*split).lengths.slice()[0] as usize
         } else {
             0i32 as (usize)
@@ -355,7 +355,7 @@ fn InitBlockSplitIterator<'a, Alloc: alloc::Allocator<u8> + alloc::Allocator<u32
     (*xself).split_ = split;
     (*xself).idx_ = 0i32 as (usize);
     (*xself).type_ = 0i32 as (usize);
-    (*xself).length_ = if (*split).lengths.slice().len() != 0 {
+    (*xself).length_ = if !(*split).lengths.slice().is_empty() {
         (*split).lengths.slice()[0] as u32
     } else {
         0i32 as (u32)
@@ -519,7 +519,7 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
                 {
                     let context: usize;
                     BlockSplitIteratorNext(&mut literal_it);
-                    context = if context_modes.len() != 0 {
+                    context = if !context_modes.is_empty() {
                         (literal_it.type_ << 6i32).wrapping_add(Context(
                             prev_byte,
                             prev_byte2,

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -429,7 +429,7 @@ fn InitBlockSplitter<
     };
     {
         if (*split).types.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).types.slice().len() == 0usize {
+            let mut _new_size: usize = if (*split).types.slice().is_empty() {
                 max_num_blocks
             } else {
                 (*split).types.slice().len()
@@ -439,7 +439,7 @@ fn InitBlockSplitter<
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
-            if ((*split).types.slice().len() != 0usize) {
+            if (!(*split).types.slice().is_empty()) {
                 new_array.slice_mut()[..(*split).types.slice().len()]
                     .clone_from_slice((*split).types.slice());
             }
@@ -451,7 +451,7 @@ fn InitBlockSplitter<
     }
     {
         if (*split).lengths.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).lengths.slice().len() == 0usize {
+            let mut _new_size: usize = if (*split).lengths.slice().is_empty() {
                 max_num_blocks
             } else {
                 (*split).lengths.slice().len()
@@ -516,7 +516,7 @@ fn InitContextBlockSplitter<
     max_num_types = brotli_min_size_t(max_num_blocks, xself.max_block_types_.wrapping_add(1usize));
     {
         if (*split).types.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).types.slice().len() == 0usize {
+            let mut _new_size: usize = if (*split).types.slice().is_empty() {
                 max_num_blocks
             } else {
                 (*split).types.slice().len()
@@ -525,7 +525,7 @@ fn InitContextBlockSplitter<
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
-            if ((*split).types.slice().len() != 0usize) {
+            if (!(*split).types.slice().is_empty()) {
                 new_array.slice_mut()[..(*split).types.slice().len()]
                     .clone_from_slice((*split).types.slice());
             }
@@ -537,7 +537,7 @@ fn InitContextBlockSplitter<
     }
     {
         if (*split).lengths.slice().len() < max_num_blocks {
-            let mut _new_size: usize = if (*split).lengths.slice().len() == 0usize {
+            let mut _new_size: usize = if (*split).lengths.slice().is_empty() {
                 max_num_blocks
             } else {
                 (*split).lengths.slice().len()
@@ -546,7 +546,7 @@ fn InitContextBlockSplitter<
                 _new_size = _new_size.wrapping_mul(2usize);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
-            if ((*split).lengths.slice().len() != 0usize) {
+            if (!(*split).lengths.slice().is_empty()) {
                 new_array.slice_mut()[..(*split).lengths.slice().len()]
                     .clone_from_slice((*split).lengths.slice());
             }

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -256,11 +256,11 @@ where
     InputType: CustomRead<ErrType>,
     OutputType: CustomWrite<ErrType>,
 {
-    assert!(input_buffer.len() != 0);
-    assert!(output_buffer.len() != 0);
+    assert!(!input_buffer.is_empty());
+    assert!(!output_buffer.is_empty());
     let mut s_orig = BrotliEncoderCreateInstance(alloc);
     s_orig.params = params.clone();
-    if dict.len() != 0 {
+    if !dict.is_empty() {
         BrotliEncoderSetCustomDictionary(&mut s_orig, dict.len(), dict);
     }
     let mut next_in_offset: usize = 0;

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -133,7 +133,7 @@ pub fn write_all<ErrType, W: CustomWrite<ErrType>>(
     writer: &mut W,
     mut buf: &[u8],
 ) -> Result<(), ErrType> {
-    while buf.len() != 0 {
+    while !buf.is_empty() {
         match writer.write(buf) {
             Ok(bytes_written) => buf = &buf[bytes_written..],
             Err(e) => return Err(e),


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::len_zero
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/len_zero

See CI results in https://github.com/rust-brotli/rust-brotli/pull/18