### PR TITLE
Auto-fixed clippy self lints

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -134,7 +134,7 @@ pub struct IoWriterWrapper<'a, OutputType: Write + 'a>(&'a mut OutputType);
 pub struct IoReaderWrapper<'a, OutputType: Read + 'a>(&'a mut OutputType);
 
 impl<'a, OutputType: Write> brotli::CustomWrite<io::Error> for IoWriterWrapper<'a, OutputType> {
-    fn flush(self: &mut Self) -> Result<(), io::Error> {
+    fn flush(&mut self) -> Result<(), io::Error> {
         loop {
             match self.0.flush() {
                 Err(e) => match e.kind() {
@@ -145,7 +145,7 @@ impl<'a, OutputType: Write> brotli::CustomWrite<io::Error> for IoWriterWrapper<'
             }
         }
     }
-    fn write(self: &mut Self, buf: &[u8]) -> Result<usize, io::Error> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         loop {
             match self.0.write(buf) {
                 Err(e) => match e.kind() {
@@ -159,7 +159,7 @@ impl<'a, OutputType: Write> brotli::CustomWrite<io::Error> for IoWriterWrapper<'
 }
 
 impl<'a, InputType: Read> brotli::CustomRead<io::Error> for IoReaderWrapper<'a, InputType> {
-    fn read(self: &mut Self, buf: &mut [u8]) -> Result<usize, io::Error> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         loop {
             match self.0.read(buf) {
                 Err(e) => match e.kind() {
@@ -175,7 +175,7 @@ impl<'a, InputType: Read> brotli::CustomRead<io::Error> for IoReaderWrapper<'a, 
 struct IntoIoReader<OutputType: Read>(OutputType);
 
 impl<InputType: Read> brotli::CustomRead<io::Error> for IntoIoReader<InputType> {
-    fn read(self: &mut Self, buf: &mut [u8]) -> Result<usize, io::Error> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         loop {
             match self.0.read(buf) {
                 Err(e) => match e.kind() {

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -224,7 +224,7 @@ impl UnlimitedBuffer {
     }
 }
 impl io::Read for Buffer {
-    fn read(self: &mut Self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.read_offset == self.data.len() {
             self.read_offset = 0;
         }
@@ -238,19 +238,19 @@ impl io::Read for Buffer {
     }
 }
 impl io::Write for Buffer {
-    fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.read_offset == self.data.len() {
             return Ok(buf.len());
         }
         self.data.extend(buf);
         return Ok(buf.len());
     }
-    fn flush(self: &mut Self) -> io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         return Ok(());
     }
 }
 impl io::Read for UnlimitedBuffer {
-    fn read(self: &mut Self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let bytes_to_read = cmp::min(buf.len(), self.data.len() - self.read_offset);
         if bytes_to_read > 0 {
             buf[0..bytes_to_read]
@@ -262,11 +262,11 @@ impl io::Read for UnlimitedBuffer {
 }
 
 impl io::Write for UnlimitedBuffer {
-    fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.data.extend(buf);
         return Ok(buf.len());
     }
-    fn flush(self: &mut Self) -> io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         return Ok(());
     }
 }
@@ -877,7 +877,7 @@ impl<'a> LimitedBuffer<'a> {
     }
 }
 impl<'a> io::Read for LimitedBuffer<'a> {
-    fn read(self: &mut Self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let bytes_to_read = cmp::min(buf.len(), self.data.len() - self.read_offset);
         if bytes_to_read > 0 {
             buf[0..bytes_to_read]
@@ -889,7 +889,7 @@ impl<'a> io::Read for LimitedBuffer<'a> {
 }
 
 impl<'a> io::Write for LimitedBuffer<'a> {
-    fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let bytes_to_write = cmp::min(buf.len(), self.data.len() - self.write_offset);
         if bytes_to_write > 0 {
             self.data[self.write_offset..self.write_offset + bytes_to_write]
@@ -900,7 +900,7 @@ impl<'a> io::Write for LimitedBuffer<'a> {
         self.write_offset += bytes_to_write;
         Ok(bytes_to_write)
     }
-    fn flush(self: &mut Self) -> io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         return Ok(());
     }
 }

--- a/src/bin/tests.rs
+++ b/src/bin/tests.rs
@@ -18,7 +18,7 @@ impl Buffer {
     }
 }
 impl io::Read for Buffer {
-    fn read(self: &mut Self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let bytes_to_read = cmp::min(buf.len(), self.data.len() - self.read_offset);
         if bytes_to_read > 0 {
             buf[0..bytes_to_read]
@@ -29,11 +29,11 @@ impl io::Read for Buffer {
     }
 }
 impl io::Write for Buffer {
-    fn write(self: &mut Self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.data.extend(buf);
         return Ok(buf.len());
     }
-    fn flush(self: &mut Self) -> io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         return Ok(());
     }
 }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1068,7 +1068,7 @@ fn StoreStaticCodeLengthCode(storage_ix: &mut usize, storage: &mut [u8]) {
 pub struct SimpleSortHuffmanTree {}
 
 impl HuffmanComparator for SimpleSortHuffmanTree {
-    fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
+    fn Cmp(&self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
         return (*v0).total_count_ < (*v1).total_count_;
     }
 }

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -70,11 +70,11 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
 }
 
 pub trait HuffmanComparator {
-    fn Cmp(self: &Self, a: &HuffmanTree, b: &HuffmanTree) -> bool;
+    fn Cmp(&self, a: &HuffmanTree, b: &HuffmanTree) -> bool;
 }
 pub struct SortHuffmanTree {}
 impl HuffmanComparator for SortHuffmanTree {
-    fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
+    fn Cmp(&self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
         if (*v0).total_count_ != (*v1).total_count_ {
             if !!((*v0).total_count_ < (*v1).total_count_) {
                 true


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::wrong_self_convention -W clippy::needless_arbitrary_self_type
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/wrong_self_convention See https://rust-lang.github.io/rust-clippy/master/index.html#/needless_arbitrary_self_type

See CI results in https://github.com/rust-brotli/rust-brotli/pull/20