### PR TITLE
Auto-fixed clippy::redundant_pattern_matching

### DIFF
--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -341,7 +341,7 @@ fn process_command_queue<'a, CmdProcessor: interface::CommandProcessor<'a>>(
                 // we have to divide some:
                 let (in_a, in_b) = tmp_inserts.split_at(btypel_sub as usize);
                 if in_a.len() != 0 {
-                    if let Some(_) = context_type {
+                    if context_type.is_some() {
                         command_queue.push_literals(&in_a);
                     } else if params.high_entropy_detection_quality == 0 {
                         command_queue.push_literals(&in_a);
@@ -360,7 +360,7 @@ fn process_command_queue<'a, CmdProcessor: interface::CommandProcessor<'a>>(
                     btypel_sub = 1u32 << 31;
                 }
             }
-            if let Some(_) = context_type {
+            if context_type.is_some() {
                 command_queue.push_literals(&tmp_inserts);
             } else if params.high_entropy_detection_quality == 0 {
                 command_queue.push_literals(&tmp_inserts);

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -335,7 +335,7 @@ where
                 next_out_offset = 0;
             }
             if result <= 0 {
-                if let Ok(_) = read_err {
+                if read_err.is_ok() {
                     read_err = Err(unexpected_eof_error_constant);
                 }
                 break;

--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn BrotliEncoderDestroyInstance(state_ptr: *mut BrotliEnco
         return;
     }
     ::enc::encode::BrotliEncoderDestroyInstance(&mut (*state_ptr).compressor);
-    if let Some(_) = (*state_ptr).custom_allocator.alloc_func {
+    if (*state_ptr).custom_allocator.alloc_func.is_some() {
         if let Some(free_fn) = (*state_ptr).custom_allocator.free_func {
             let _to_free = core::ptr::read(state_ptr);
             let ptr = core::mem::transmute::<*mut BrotliEncoderState, *mut c_void>(state_ptr);

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -298,7 +298,7 @@ impl panic::RefUnwindSafe for UnsafeUnwindBox {}
 pub unsafe extern "C" fn BrotliEncoderDestroyWorkPool(work_pool_ptr: *mut BrotliEncoderWorkPool) {
     let wpp = UnsafeUnwindBox(work_pool_ptr);
     if let Err(panic_err) = compressor::catch_panic(|| {
-        if let Some(_) = (*wpp.0).custom_allocator.alloc_func {
+        if (*wpp.0).custom_allocator.alloc_func.is_some() {
             if let Some(free_fn) = (*wpp.0).custom_allocator.free_func {
                 let _to_free = core::ptr::read(wpp.0);
                 let ptr = core::mem::transmute::<*mut BrotliEncoderWorkPool, *mut c_void>(wpp.0);


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::redundant_pattern_matching
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_pattern_matching

See CI results in https://github.com/rust-brotli/rust-brotli/pull/23