### PR TITLE
Auto-fixed clippy::useless_conversion

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -104,11 +104,11 @@ fn detect_varlen_offset(bytes_so_far: &[u8]) -> Result<(usize), ()> {
         offset += 1;
         let mskipbytes = bytes & ((1 << 2) - 1);
         offset += 2;
-        offset += usize::from(mskipbytes as usize) * 8; // next item is byte aligned
+        offset += (mskipbytes as usize) * 8; // next item is byte aligned
         return Ok(offset);
     }
     mnibbles += 4;
-    offset += usize::from(mnibbles as usize) * 4;
+    offset += (mnibbles as usize) * 4;
     bytes >>= mnibbles * 4;
     offset += 1;
     if (bytes & 1) == 0 {
@@ -355,7 +355,7 @@ impl BroCatli {
                 }
                 bytes_so_far >>= window_offset; // mask out the window size
                 bytes_so_far &= (1u64 << (varlen_offset - window_offset)) - 1;
-                let var_len_bytes = ((usize::from(varlen_offset - window_offset) + 7) / 8);
+                let var_len_bytes = (((varlen_offset - window_offset) + 7) / 8);
                 for byte_index in 0..var_len_bytes {
                     let cur_byte = (bytes_so_far >> (byte_index * 8));
                     realigned_header[byte_index] |=

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -338,9 +338,9 @@ impl<'a> CDF<'a> {
     #[inline(always)]
     pub fn cost(&self, nibble_u8: u8) -> floatX {
         let nibble = nibble_u8 as usize & 0xf;
-        let mut pdf = self.cdf.extract(usize::from(nibble));
+        let mut pdf = self.cdf.extract(nibble);
         if nibble_u8 != 0 {
-            pdf -= self.cdf.extract(usize::from(nibble - 1));
+            pdf -= self.cdf.extract((nibble - 1));
         }
         FastLog2u16(self.cdf.extract(15) as u16) - FastLog2u16(pdf as u16)
     }


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::useless_conversion
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/useless_conversion

See CI results in https://github.com/rust-brotli/rust-brotli/pull/24