### PR TITLE
Auto-fixed clippy::question_mark

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -330,9 +330,7 @@ pub fn compress_multi<InputType: Read, OutputType: Write>(
     >,
 ) -> Result<usize, io::Error> {
     let mut input: Vec<u8> = Vec::<u8>::new();
-    if let Err(err) = r.read_to_end(&mut input) {
-        return Err(err);
-    }
+    r.read_to_end(&mut input)?;
     let mut output = Rebox::from(vec![
         0u8;
         BrotliEncoderMaxCompressedSizeMulti(

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -79,9 +79,7 @@ struct SliceU8Ref<'a>(pub &'a [u8]);
 impl<'a> fmt::LowerHex for SliceU8Ref<'a> {
     fn fmt(&self, fmtr: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         for item in self.0 {
-            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
-                return Err(e);
-            }
+            fmtr.write_fmt(format_args!("{:02x}", item))?
         }
         Ok(())
     }

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -96,14 +96,10 @@ impl<'a> core::ops::Index<usize> for InputPair<'a> {
 impl<'a> core::fmt::LowerHex for InputPair<'a> {
     fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> Result<(), core::fmt::Error> {
         for item in self.0.data {
-            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
-                return Err(e);
-            }
+            fmtr.write_fmt(format_args!("{:02x}", item))?
         }
         for item in self.1.data {
-            if let Err(e) = fmtr.write_fmt(format_args!("{:02x}", item)) {
-                return Err(e);
-            }
+            fmtr.write_fmt(format_args!("{:02x}", item))?
         }
         Ok(())
     }

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -321,9 +321,7 @@ where
                     match w.write(&mut output_buffer[next_out_offset..lim]) {
                         Err(e) => {
                             BrotliEncoderDestroyInstance(s);
-                            if let Err(err) = read_err {
-                                return Err(err);
-                            }
+                            read_err?;
                             return Err(e);
                         }
                         Ok(size) => {
@@ -346,8 +344,6 @@ where
         }
         BrotliEncoderDestroyInstance(s);
     }
-    if let Err(err) = read_err {
-        return Err(err);
-    }
+    read_err?;
     Ok(total_out.unwrap())
 }

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -581,9 +581,7 @@ where
         }
         thread.0 = InternalSendAlloc::A(cur_result.alloc, UnionHasher::Uninit);
     }
-    if let Err(e) = compression_result {
-        return Err(e);
-    }
+    compression_result?;
     match bro_cat_li.finish(output, &mut out_file_size) {
         BroCatliResult::Success => compression_result = Ok(out_file_size),
         err => {


### PR DESCRIPTION
This was fully automatic change using

```sh
cargo clippy --fix -- -A clippy::all -W clippy::question_mark
cargo fmt --all
```

See https://rust-lang.github.io/rust-clippy/master/index.html#/question_mark

See CI results in https://github.com/rust-brotli/rust-brotli/pull/25