### PR TITLE
Auto-fixed several clippy boolean checks

### DIFF
--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -461,7 +461,7 @@ where
                 &mut dict_matches[..],
             ) != 0
         {
-            assert_eq!(params.use_dictionary, true);
+            assert!(params.use_dictionary);
             let maxlen: usize = brotli_min_size_t(37usize, max_length);
             let mut l: usize;
             l = minlen;

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -48,15 +48,9 @@ fn brotli_max_double(a: super::util::floatX, b: super::util::floatX) -> super::u
 #[inline(always)]
 fn HistogramPairIsLess(p1: &HistogramPair, p2: &HistogramPair) -> bool {
     if (*p1).cost_diff != (*p2).cost_diff {
-        if !!((*p1).cost_diff > (*p2).cost_diff) {
-            true
-        } else {
-            false
-        }
-    } else if !!((*p1).idx2.wrapping_sub((*p1).idx1) > (*p2).idx2.wrapping_sub((*p2).idx1)) {
-        true
+        !!((*p1).cost_diff > (*p2).cost_diff)
     } else {
-        false
+        !!((*p1).idx2.wrapping_sub((*p1).idx1) > (*p2).idx2.wrapping_sub((*p2).idx1))
     }
 }
 
@@ -123,9 +117,7 @@ fn BrotliCompareAndPushToQueue<
         }
         if is_good_pair != 0 {
             p.cost_diff = p.cost_diff + p.cost_combo;
-            if *num_pairs > 0i32 as (usize)
-                && (HistogramPairIsLess(&pairs[0i32 as (usize)], &p) != false)
-            {
+            if *num_pairs > 0i32 as (usize) && HistogramPairIsLess(&pairs[0i32 as (usize)], &p) {
                 /* Replace the top of the queue if needed. */
                 if *num_pairs < max_num_pairs {
                     pairs[*num_pairs as (usize)] = pairs[0i32 as (usize)];
@@ -248,7 +240,7 @@ pub fn BrotliHistogramCombine<
                                 break 'continue12;
                             }
                         }
-                        if HistogramPairIsLess(&pairs[(0usize)], &p) != false {
+                        if HistogramPairIsLess(&pairs[(0usize)], &p) {
                             /* Replace the top of the queue if needed. */
                             let front: HistogramPair = pairs[(0usize)];
                             pairs[(0usize)] = p;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -291,7 +291,7 @@ pub fn set_parameter(
         return 1i32;
     }
     if p as (i32) == BrotliEncoderParameter::BROTLI_METABLOCK_CALLBACK as (i32) {
-        params.log_meta_block = if value != 0 { true } else { false };
+        params.log_meta_block = value != 0;
         return 1i32;
     }
     if p as (i32) == BrotliEncoderParameter::BROTLI_PARAM_LGWIN as (i32) {
@@ -2163,7 +2163,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
     if params.appendable {
         is_last = 0;
     } else {
-        assert_eq!(params.catable, false); // Sanitize Params senforces this constraint
+        assert!(!params.catable); // Sanitize Params senforces this constraint
     }
     let wrapped_last_flush_pos: u32 = WrapPosition(last_flush_pos);
     let last_bytes: u16;

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -76,15 +76,9 @@ pub struct SortHuffmanTree {}
 impl HuffmanComparator for SortHuffmanTree {
     fn Cmp(self: &Self, v0: &HuffmanTree, v1: &HuffmanTree) -> bool {
         if (*v0).total_count_ != (*v1).total_count_ {
-            if !!((*v0).total_count_ < (*v1).total_count_) {
-                true
-            } else {
-                false
-            }
-        } else if !!((*v0).index_right_or_value_ as (i32) > (*v1).index_right_or_value_ as (i32)) {
-            true
+            !!((*v0).total_count_ < (*v1).total_count_)
         } else {
-            false
+            !!((*v0).index_right_or_value_ as (i32) > (*v1).index_right_or_value_ as (i32))
         }
     }
 }


### PR DESCRIPTION
This was automatic change using these commands, plus a few newlines to help fmt

```sh
cargo clippy --fix -- -A clippy::all -W clippy::bool_comparison -W clippy::bool_assert_comparison -W clippy::needless_bool
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/bool_comparison
* https://rust-lang.github.io/rust-clippy/master/index.html#/bool_assert_comparison
* https://rust-lang.github.io/rust-clippy/master/index.html#/needless_bool

See CI results in https://github.com/rust-brotli/rust-brotli/pull/26