### PR TITLE
Auto-fixed clippy::deref_addrof

### DIFF
--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -696,10 +696,10 @@ fn RingBufferSetup<AllocU8: alloc::Allocator<u8>>(
 ) {
     let window_bits: i32 = ComputeRbBits(params);
     let tail_bits: i32 = (*params).lgblock;
-    *(&mut (*rb).size_) = 1u32 << window_bits;
-    *(&mut (*rb).mask_) = (1u32 << window_bits).wrapping_sub(1u32);
-    *(&mut (*rb).tail_size_) = 1u32 << tail_bits;
-    *(&mut (*rb).total_size_) = (*rb).size_.wrapping_add((*rb).tail_size_);
+    (*rb).size_ = 1u32 << window_bits;
+    (*rb).mask_ = (1u32 << window_bits).wrapping_sub(1u32);
+    (*rb).tail_size_ = 1u32 << tail_bits;
+    (*rb).total_size_ = (*rb).size_.wrapping_add((*rb).tail_size_);
 }
 
 fn EncodeWindowBits(


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::deref_addrof
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/deref_addrof

See CI results in https://github.com/rust-brotli/rust-brotli/pull/28