### PR TITLE
Auto-fixed clippy::derivable_impls

### DIFF
--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -8,7 +8,7 @@ pub struct BrotliDistanceParams {
     pub max_distance: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Command {
     // stores copy_len in low 25 bits and copy_code - copy_len in high 7 bit
     pub insert_len_: u32,
@@ -19,17 +19,7 @@ pub struct Command {
     // stores distance code in low 10 bits and num extra bits in high 6 bits
     pub dist_prefix_: u16,
 }
-impl Default for Command {
-    fn default() -> Command {
-        Command {
-            insert_len_: 0,
-            copy_len_: 0,
-            dist_extra_: 0,
-            cmd_prefix_: 0,
-            dist_prefix_: 0,
-        }
-    }
-}
+
 pub fn CommandCopyLen(xself: &Command) -> u32 {
     xself.copy_len_ & 0x1ffffffi32 as (u32)
 }

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -8,20 +8,11 @@
 #![allow(dead_code)]
 use super::util::brotli_max_uint32_t;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct HuffmanTree {
     pub total_count_: u32,
     pub index_left_: i16,
     pub index_right_or_value_: i16,
-}
-impl Default for HuffmanTree {
-    fn default() -> HuffmanTree {
-        HuffmanTree {
-            total_count_: 0,
-            index_left_: 0,
-            index_right_or_value_: 0,
-        }
-    }
 }
 
 pub fn NewHuffmanTree(count: u32, left: i16, right: i16) -> HuffmanTree {

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -20,6 +20,7 @@ impl<'a> Freezable for InputReference<'a> {
     }
 }
 
+#[derive(Default)]
 pub struct InputReferenceMut<'a> {
     pub data: &'a mut [u8],
     pub orig_offset: usize, // offset into the original slice of data
@@ -35,14 +36,7 @@ impl<'a> SliceWrapperMut<u8> for InputReferenceMut<'a> {
         self.data
     }
 }
-impl<'a> Default for InputReferenceMut<'a> {
-    fn default() -> Self {
-        InputReferenceMut {
-            data: &mut [],
-            orig_offset: 0,
-        }
-    }
-}
+
 impl<'a> From<InputReferenceMut<'a>> for InputReference<'a> {
     fn from(val: InputReferenceMut<'a>) -> InputReference<'a> {
         InputReference {


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all -W clippy::derivable_impls
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls

See CI results in https://github.com/rust-brotli/rust-brotli/pull/29