### PR TITLE
Auto-fixed clippy::identity_op

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -290,8 +290,8 @@ impl BroCatli {
             }
             index -= 1; // discard the final two bits
             last_bytes &= (1 << index) - 1; // mask them out
-            self.last_bytes[0] = last_bytes as u8 & 0xff; // reset the last_bytes pair
-            self.last_bytes[1] = (last_bytes >> 8) as u8 & 0xff;
+            self.last_bytes[0] = last_bytes as u8; // reset the last_bytes pair
+            self.last_bytes[1] = (last_bytes >> 8) as u8;
             if index >= 8 {
                 // if both bits and one useful bit were in the second block, then write that
                 if out_bytes.len() > *out_offset {
@@ -551,8 +551,8 @@ impl BroCatli {
         let mut last_bytes = self.last_bytes[0] as u16 | ((self.last_bytes[1] as u16) << 8);
         let bit_end = (self.last_bytes_len - 1) * 8 + self.last_byte_bit_offset;
         last_bytes |= 3 << bit_end;
-        self.last_bytes[0] = last_bytes as u8 & 0xff;
-        self.last_bytes[1] = (last_bytes >> 8) as u8 & 0xff;
+        self.last_bytes[0] = last_bytes as u8;
+        self.last_bytes[1] = (last_bytes >> 8) as u8;
         self.last_byte_sanitized = false;
         self.last_byte_bit_offset += 2;
         if self.last_byte_bit_offset >= 8 {

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -227,6 +227,8 @@ fn update_cdf(cdfs: &mut [u16], nibble_u8: u8) {
 fn extract_single_cdf(cdf_bundle: &[u16], index: usize) -> [u16; 16] {
     assert_eq!(cdf_bundle.len(), 16 * NUM_SPEEDS_TO_TRY);
     assert!(index < NUM_SPEEDS_TO_TRY);
+
+    #[allow(clippy::identity_op)]
     [
         cdf_bundle[index + 0 * NUM_SPEEDS_TO_TRY],
         cdf_bundle[index + 1 * NUM_SPEEDS_TO_TRY],


### PR DESCRIPTION
Note that this one might point to the underlying bug in the original implementation -- the masking of a `u8` values happens after casting it to a `u8`.

This was automatic change using these commands, and later excluded one that does not look that good.

```sh
cargo clippy --fix -- -A clippy::all -W clippy::identity_op
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/identity_op

See CI results in https://github.com/rust-brotli/rust-brotli/pull/31