### PR TITLE
Auto-fixed multiple small clippy lints

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -64,7 +64,7 @@ fn parse_window_size(bytes_so_far: &[u8]) -> Result<(u8, usize), ()> {
         return Err(());
     }
     let ret = bytes_so_far[1] & 0x3f;
-    if ret < 10 || ret > 30 {
+    if !(10..=30).contains(&ret) {
         return Err(());
     }
     Ok((ret, 14))

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -23,9 +23,10 @@ pub fn HuffmanCost(population: &[u32]) -> floatY {
         sum += *pop as floatY;
         buckets += 1.0 as floatY;
     }
-    let cost = 16.0 as floatY * buckets + cost + sum * FastLog2(sum as u64) as floatY;
+
     //println!("Observed {} nonzero buckets with a sum of {}, hc={}", buckets, sum, cost);
-    cost
+
+    16.0 as floatY * buckets + cost + sum * FastLog2(sum as u64) as floatY
 }
 
 // this holds a population of data assuming 1 byte of prior for that data
@@ -380,9 +381,9 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyPyramid<AllocU32> {
         scratch: &mut EntropyTally<AllocU32>,
     ) -> floatY {
         assert!(stride as usize <= NUM_STRIDES);
-        let cost = self.pop[self.byte_index_to_pyramid_index(start_index as usize, metablock_len)]
-            .bit_cost_of_data_subset(data0, stride, previous_bytes, &mut scratch.pop[0]);
-        cost
+
+        self.pop[self.byte_index_to_pyramid_index(start_index as usize, metablock_len)]
+            .bit_cost_of_data_subset(data0, stride, previous_bytes, &mut scratch.pop[0])
     }
     fn populate_entry_stride1(&mut self, input: InputPair, index: u32) {
         let mut prev_val = 0;
@@ -871,15 +872,15 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyTally<AllocU32> {
             }
         }
 
-        let best_stride = if stride_detection_quality > 1 {
+        //println!("ENTROPY PYRAMID {:?} selected {}", entropy_pyramid.stride, best_stride);
+
+        if stride_detection_quality > 1 {
             self.identify_best_population_and_update_cache() + 1
         } else {
             entropy_pyramid.stride[entropy_pyramid
                 .byte_index_to_pyramid_index(pyramid_byte_index, input0.len() + input1.len())]
                 + 1
-        };
-        //println!("ENTROPY PYRAMID {:?} selected {}", entropy_pyramid.stride, best_stride);
-        best_stride
+        }
     }
     pub fn free(&mut self, m32: &mut AllocU32) {
         for item in self.pop.iter_mut() {

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -189,9 +189,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
                 params.dist = new_params.dist;
                 ndirect_msb += 1;
             }
-            if ndirect_msb > 0 {
-                ndirect_msb -= 1;
-            }
+            ndirect_msb = ndirect_msb.saturating_sub(1);
             ndirect_msb /= 2;
         }
         if check_orig {

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -457,23 +457,22 @@ where
             0,
         );
         for thread_index in 1..num_threads {
-            let res =
-                spawner_and_input.view(|input_and_params: &(SliceW, BrotliEncoderParams)| -> () {
-                    let range = get_range(thread_index - 1, num_threads, input_and_params.0.len());
-                    let overlap = hasher.StoreLookahead().wrapping_sub(1usize);
-                    if range.end - range.start > overlap {
-                        hasher.BulkStoreRange(
-                            input_and_params.0.slice(),
-                            !(0usize),
-                            if range.start > overlap {
-                                range.start - overlap
-                            } else {
-                                0
-                            },
-                            range.end - overlap,
-                        );
-                    }
-                });
+            let res = spawner_and_input.view(|input_and_params: &(SliceW, BrotliEncoderParams)| {
+                let range = get_range(thread_index - 1, num_threads, input_and_params.0.len());
+                let overlap = hasher.StoreLookahead().wrapping_sub(1usize);
+                if range.end - range.start > overlap {
+                    hasher.BulkStoreRange(
+                        input_and_params.0.slice(),
+                        !(0usize),
+                        if range.start > overlap {
+                            range.start - overlap
+                        } else {
+                            0
+                        },
+                        range.end - overlap,
+                    );
+                }
+            });
             if let Err(_e) = res {
                 return Err(BrotliEncoderThreadError::OtherThreadPanic);
             }


### PR DESCRIPTION
This was automatic change using these commands

```sh
cargo clippy --fix -- -A clippy::all \
   -W clippy::implicit_saturating_sub \
   -W clippy::len_without_is_empty \
   -W clippy::let_and_return \
   -W clippy::manual_range_contains \
   -W clippy::unused_unit
cargo fmt --all
```

* https://rust-lang.github.io/rust-clippy/master/index.html#/implicit_saturating_sub
* https://rust-lang.github.io/rust-clippy/master/index.html#/len_without_is_empty
* https://rust-lang.github.io/rust-clippy/master/index.html#/let_and_return
* https://rust-lang.github.io/rust-clippy/master/index.html#/manual_range_contains
* https://rust-lang.github.io/rust-clippy/master/index.html#/unused_unit

See CI results in https://github.com/rust-brotli/rust-brotli/pull/36