### PR TITLE
A few simi-auto clippy lints

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -783,7 +783,7 @@ fn main() {
                     .trim_matches('e')
                     .trim_matches('d')
                     .trim_matches('=');
-                let split = comma_string.split(",");
+                let split = comma_string.split(',');
                 for (index, s) in split.enumerate() {
                     let data = s.parse::<u16>().unwrap();
                     if data > 16384 {
@@ -824,22 +824,22 @@ fn main() {
                 println_stderr!("Decompression:\nbrotli [input_file] [output_file]\nCompression:brotli -c -q9.5 -w22 [input_file] [output_file]\nQuality may be one of -q9.5 -q9.5x -q9.5y or -q[0-11] for standard brotli settings.\nOptional size hint -s<size> to direct better compression\n\nThe -i parameter produces a cross human readdable IR representation of the file.\nThis can be ingested by other compressors.\nIR-specific options include:\n-findprior\n-speed=<inc,max,inc,max,inc,max,inc,max>");
                 return;
             }
-            if filenames[0] == "" {
+            if filenames[0].is_empty() {
                 filenames[0] = argument.clone();
                 continue;
             }
-            if filenames[1] == "" {
+            if filenames[1].is_empty() {
                 filenames[1] = argument.clone();
                 continue;
             }
             panic!("Unknown Argument {:}", argument);
         }
-        if filenames[0] != "" {
+        if !filenames[0].is_empty() {
             let mut input = match File::open(Path::new(&filenames[0])) {
                 Err(why) => panic!("couldn't open {:}\n{:}", filenames[0], why),
                 Ok(file) => file,
             };
-            if filenames[1] != "" {
+            if !filenames[1].is_empty() {
                 let mut output = match File::create(Path::new(&filenames[1])) {
                     Err(why) => panic!(
                         "couldn't open file for writing: {:}\n{:}",

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -341,7 +341,7 @@ fn total_roundtrip_helper(data: &[u8]) {
     }
     roundtrip_helper(data, 10, 23, true);
 }
-static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
+static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
 #[test]
 fn test_random_then_unicode_0() {
     roundtrip_helper(RANDOM_THEN_UNICODE, 0, 13, false);
@@ -1016,7 +1016,7 @@ fn test_1024k() {
     );
 }
 
-static UKKONOOA: &'static [u8] = include_bytes!("../../testdata/ukkonooa");
+static UKKONOOA: &[u8] = include_bytes!("../../testdata/ukkonooa");
 #[test]
 fn test_ukkonooa() {
     let td = UKKONOOA;
@@ -1165,8 +1165,8 @@ fn test_negative_hypothesis() {
         3,
     );
 }
-static ALICE29_BR: &'static [u8] = include_bytes!("../../testdata/alice29.txt.compressed");
-static ALICE29: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
+static ALICE29_BR: &[u8] = include_bytes!("../../testdata/alice29.txt.compressed");
+static ALICE29: &[u8] = include_bytes!("../../testdata/alice29.txt");
 #[test]
 fn test_alice29() {
     assert_decompressed_input_matches_output(ALICE29_BR, ALICE29, 65536, 65536);

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -274,7 +274,7 @@ impl io::Write for UnlimitedBuffer {
 #[allow(non_snake_case)]
 #[test]
 fn test_roundtrip_64x() {
-    let X = 'X' as u8;
+    let X = b'X';
     let in_buf: [u8; 64] = [
         X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X,
         X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X, X,
@@ -742,8 +742,8 @@ fn test_10x_10y() {
     }
     let mut i: usize = 0;
     while i < 10 {
-        assert_eq!(output.data[i], 'X' as u8);
-        assert_eq!(output.data[i + 10], 'Y' as u8);
+        assert_eq!(output.data[i], b'X');
+        assert_eq!(output.data[i + 10], b'Y');
         i += 1;
     }
     assert_eq!(output.data.len(), 20);
@@ -764,8 +764,8 @@ fn test_10x_10y_one_out_byte() {
     }
     let mut i: usize = 0;
     while i < 10 {
-        assert_eq!(output.data[i], 'X' as u8);
-        assert_eq!(output.data[i + 10], 'Y' as u8);
+        assert_eq!(output.data[i], b'X');
+        assert_eq!(output.data[i + 10], b'Y');
         i += 1;
     }
     assert_eq!(output.data.len(), 20);
@@ -786,8 +786,8 @@ fn test_10x_10y_byte_by_byte() {
     }
     let mut i: usize = 0;
     while i < 10 {
-        assert_eq!(output.data[i], 'X' as u8);
-        assert_eq!(output.data[i + 10], 'Y' as u8);
+        assert_eq!(output.data[i], b'X');
+        assert_eq!(output.data[i + 10], b'Y');
         i += 1;
     }
     assert_eq!(output.data.len(), 20);

--- a/src/bin/test_broccoli.rs
+++ b/src/bin/test_broccoli.rs
@@ -7,16 +7,16 @@ use super::brotli::concat::{BroCatli, BroCatliResult};
 use super::brotli::enc::BrotliEncoderParams;
 use super::integration_tests::UnlimitedBuffer;
 use brotli_decompressor::{CustomRead, CustomWrite};
-static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
-static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
-static UKKONOOA: &'static [u8] = include_bytes!("../../testdata/ukkonooa");
-static ASYOULIKE: &'static [u8] = include_bytes!("../../testdata/asyoulik.txt");
-static BACKWARD65536: &'static [u8] = include_bytes!("../../testdata/backward65536");
-static DICTWORD: &'static [u8] = include_bytes!("../../testdata/ends_with_truncated_dictionary");
-static RANDOM10K: &'static [u8] = include_bytes!("../../testdata/random_org_10k.bin");
-static RANDOMTHENUNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
-static QUICKFOX: &'static [u8] = include_bytes!("../../testdata/quickfox_repeated");
-static EMPTY: &'static [u8] = &[];
+static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
+static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
+static UKKONOOA: &[u8] = include_bytes!("../../testdata/ukkonooa");
+static ASYOULIKE: &[u8] = include_bytes!("../../testdata/asyoulik.txt");
+static BACKWARD65536: &[u8] = include_bytes!("../../testdata/backward65536");
+static DICTWORD: &[u8] = include_bytes!("../../testdata/ends_with_truncated_dictionary");
+static RANDOM10K: &[u8] = include_bytes!("../../testdata/random_org_10k.bin");
+static RANDOMTHENUNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
+static QUICKFOX: &[u8] = include_bytes!("../../testdata/quickfox_repeated");
+static EMPTY: &[u8] = &[];
 use super::Rebox;
 fn concat(
     files: &mut [UnlimitedBuffer],

--- a/src/bin/test_custom_dict.rs
+++ b/src/bin/test_custom_dict.rs
@@ -7,8 +7,8 @@ use super::brotli::concat::{BroCatli, BroCatliResult};
 use super::brotli::enc::BrotliEncoderParams;
 use super::integration_tests::UnlimitedBuffer;
 use std::io::{Read, Write};
-static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
-static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
+static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
+static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
 use super::Rebox;
 
 #[test]

--- a/src/bin/test_threading.rs
+++ b/src/bin/test_threading.rs
@@ -12,8 +12,8 @@ use brotli::enc::threading::{Owned, SendAlloc};
 use brotli_decompressor::{SliceWrapper, SliceWrapperMut};
 
 use super::integration_tests::UnlimitedBuffer;
-static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
-static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
+static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
+static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
 use super::Rebox;
 
 struct SliceRef<'a>(&'a [u8]);

--- a/src/bin/tests.rs
+++ b/src/bin/tests.rs
@@ -85,8 +85,8 @@ fn test_10x_10y() {
     }
     let mut i: usize = 0;
     while i < 10 {
-        assert_eq!(output.data[i], 'X' as u8);
-        assert_eq!(output.data[i + 10], 'Y' as u8);
+        assert_eq!(output.data[i], b'X');
+        assert_eq!(output.data[i + 10], b'Y');
         i += 1;
     }
     assert_eq!(output.data.len(), 20);

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -121,7 +121,7 @@ fn make_sha_writer() -> ShaWriter {
 #[cfg(feature = "validation")]
 const VALIDATION_FAILED: &'static str = "Validation failed";
 #[cfg(not(feature = "validation"))]
-const VALIDATION_FAILED: &'static str =
+const VALIDATION_FAILED: &str =
     "Validation module not enabled: build with cargo build --features=validation";
 
 pub fn compress_validate<InputType: Read, OutputType: Write>(

--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -121,6 +121,7 @@ fn detect_varlen_offset(bytes_so_far: &[u8]) -> Result<(usize), ()> {
 }
 
 // eat your vegetables
+#[derive(Default)]
 pub struct BroCatli {
     last_bytes: [u8; 2],
     last_bytes_len: u8,
@@ -131,23 +132,12 @@ pub struct BroCatli {
     window_size: u8,
     new_stream_pending: Option<NewStreamData>,
 }
-impl Default for BroCatli {
-    fn default() -> BroCatli {
-        BroCatli::new()
-    }
-}
+
 impl BroCatli {
-    pub fn new() -> BroCatli {
-        BroCatli {
-            last_bytes: [0, 0],
-            last_bytes_len: 0,
-            last_byte_bit_offset: 0,
-            last_byte_sanitized: false,
-            any_bytes_emitted: false,
-            new_stream_pending: None,
-            window_size: 0,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
+
     pub fn deserialize_from_buffer(buffer: &[u8]) -> Result<BroCatli, ()> {
         if 16 + NUM_STREAM_HEADER_BYTES > buffer.len() {
             return Err(());

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use alloc_stdlib::StandardAlloc;
 use enc::{Allocator, SliceWrapper};
-static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
+static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
 #[cfg(feature = "std")]
 #[test]
 fn test_bulk_store_range() {

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -74,6 +74,7 @@ const vectorize_population_cost: bool = true;
 #[cfg(not(feature = "vector_scratch_space"))]
 const vectorize_population_cost: bool = false;
 
+#[allow(clippy::excessive_precision)]
 fn CostComputation<T: SliceWrapper<Mem256i>>(
     depth_histo: &mut [u32; BROTLI_CODE_LENGTH_CODES],
     nnz_data: &T,

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -10,14 +10,20 @@ pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub lengths: <Alloc as Allocator<u32>>::AllocatedMemory,
 }
 
-impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
-    pub fn new() -> BlockSplit<Alloc> {
-        BlockSplit {
+impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> Default for BlockSplit<Alloc> {
+    fn default() -> Self {
+        Self {
             num_types: 0,
             num_blocks: 0,
             types: <Alloc as Allocator<u8>>::AllocatedMemory::default(),
             lengths: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
         }
+    }
+}
+
+impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> BlockSplit<Alloc> {
+    pub fn new() -> BlockSplit<Alloc> {
+        Self::default()
     }
     pub fn destroy(&mut self, m: &mut Alloc) {
         <Alloc as Allocator<u8>>::free_cell(m, core::mem::take(&mut self.types));

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -2862,6 +2862,7 @@ struct BlockSplitRef<'a> {
     lengths: &'a [u32],
     num_types: u32,
 }
+
 impl<'a> Default for BlockSplitRef<'a> {
     fn default() -> Self {
         BlockSplitRef {
@@ -2947,22 +2948,14 @@ fn block_split_reference<'a, Alloc: BrotliAlloc>(
     };
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct RecoderState {
     pub num_bytes_encoded: usize,
 }
 
-impl Default for RecoderState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RecoderState {
     pub fn new() -> Self {
-        RecoderState {
-            num_bytes_encoded: 0,
-        }
+        Self::default()
     }
 }
 

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1327,10 +1327,10 @@ impl<
             + alloc::Allocator<HistogramLiteral>
             + alloc::Allocator<HistogramCommand>
             + alloc::Allocator<HistogramDistance>,
-    > MetaBlockSplit<Alloc>
+    > Default for MetaBlockSplit<Alloc>
 {
-    pub fn new() -> Self {
-        MetaBlockSplit {
+    fn default() -> Self {
+        Self {
             literal_split: BlockSplit::<Alloc>::new(),
             command_split: BlockSplit::<Alloc>::new(),
             distance_split: BlockSplit::<Alloc>::new(),
@@ -1347,6 +1347,20 @@ impl<
             distance_histograms_size: 0,
         }
     }
+}
+
+impl<
+        Alloc: alloc::Allocator<u8>
+            + alloc::Allocator<u32>
+            + alloc::Allocator<HistogramLiteral>
+            + alloc::Allocator<HistogramCommand>
+            + alloc::Allocator<HistogramDistance>,
+    > MetaBlockSplit<Alloc>
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn destroy(&mut self, alloc: &mut Alloc) {
         self.literal_split.destroy(alloc);
         self.command_split.destroy(alloc);
@@ -2936,6 +2950,12 @@ fn block_split_reference<'a, Alloc: BrotliAlloc>(
 #[derive(Clone, Copy)]
 pub struct RecoderState {
     pub num_bytes_encoded: usize,
+}
+
+impl Default for RecoderState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RecoderState {

--- a/src/enc/fast_log.rs
+++ b/src/enc/fast_log.rs
@@ -1,4 +1,5 @@
 #[allow(dead_code)]
+#[allow(clippy::excessive_precision)]
 static mut kLog2Table: [f32; 256] = [
     0.0000000000000000f32,
     0.0000000000000000f32,

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -591,7 +591,7 @@ where
     }
     if let Ok(retrieved_owned_input) = spawner_and_input.unwrap() {
         *owned_input = Owned::new(retrieved_owned_input.0); // return the input to its rightful owner before returning
-    } else if let Ok(_) = compression_result {
+    } else if compression_result.is_ok() {
         compression_result = Err(BrotliEncoderThreadError::OtherThreadPanic);
     }
     compression_result

--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -40,9 +40,9 @@ impl From<BroCatli> for BroccoliState {
         }
     }
 }
-impl Into<BroCatli> for BroccoliState {
-    fn into(self) -> BroCatli {
-        BroCatli::deserialize_from_buffer(&self.current_data[..]).unwrap()
+impl From<BroccoliState> for BroCatli {
+    fn from(val: BroccoliState) -> Self {
+        BroCatli::deserialize_from_buffer(&val.current_data[..]).unwrap()
     }
 }
 


### PR DESCRIPTION
```
cargo clippy --fix -- -A clippy::all \
   -W clippy::redundant_static_lifetimes \
   -W clippy::redundant_pattern_matching \
   -W clippy::from_over_into
```

Also, a few manual changes:
* allow `clippy::excessive_precision` to not warn. Not worth converting these.
* add manual `clippy::new_without_default` implementation
* a few more random ones that were discovered with `cargo clippy --fix`