### PR TITLE
migrate to 2018 edition, use cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
 categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
+edition = "2018"
 rust-version = "1.56.0"
 
 [[bin]]
@@ -26,6 +27,8 @@ lto = true
 incremental = false
 
 [dependencies]
+# TODO:  Would it make sense to alias it here like this?
+# "alloc" = { package = "alloc-no-stdlib", version = "2.0" }
 "alloc-no-stdlib" = { version = "2.0" }
 "alloc-stdlib" = { version = "~0.2", optional = true }
 "brotli-decompressor" = { version = "~2.5", default-features = false }

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["brotli", "decompression", "lz77", "huffman", "nostd"]
 categories = ["compression", "no-std", "external-ffi-bindings"]
 readme = "README.md"
 autobins = false
+edition = "2021"
 
 [lib]
 path = "src/lib.rs"

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1,14 +1,16 @@
 #![no_std]
 #![cfg_attr(not(feature = "std"), feature(lang_items))]
+
 #[cfg(feature = "std")]
 extern crate std;
 
-pub extern crate brotli;
+// FIXME: Big issue here, should not pub use with a wildcard, especially that they conflict with each other
 pub use brotli::ffi::compressor::*;
 pub use brotli::ffi::decompressor::*;
 pub use brotli::ffi::multicompress::*;
 pub use brotli::*;
 use core::ptr::null_mut;
+
 #[cfg(feature = "std")]
 unsafe fn std_only_functions() {
     let _ =

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -1,12 +1,13 @@
-extern crate brotli;
 #[cfg(not(feature = "std"))]
 fn main() {
     panic!("For no-stdlib examples please see the tests")
 }
+
 #[cfg(feature = "std")]
 fn main() {
     use std::io;
     use std::io::{Read, Write};
+
     let stdout = &mut io::stdout();
     {
         let mut writer = brotli::CompressorWriter::new(stdout, 4096, 11, 22);

--- a/examples/decompress.rs
+++ b/examples/decompress.rs
@@ -1,11 +1,12 @@
-extern crate brotli;
 #[cfg(not(feature = "std"))]
 fn main() {
     panic!("For no-stdlib examples please see the tests")
 }
+
 #[cfg(feature = "std")]
 fn main() {
     use std::io;
+
     let stdin = &mut io::stdin();
     {
         use std::io::{Read, Write};

--- a/justfile
+++ b/justfile
@@ -26,6 +26,10 @@ fmt *ARGS:
     cargo fmt --all -- {{ ARGS }}
     cd c && cargo fmt --all -- {{ ARGS }}
 
+# Run Nightly cargo fmt, ordering imports by groups
+fmt2:
+    cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate
+
 # Run cargo clippy
 clippy:
     cargo clippy -- -D warnings

--- a/src/bin/catbrotli.rs
+++ b/src/bin/catbrotli.rs
@@ -1,12 +1,10 @@
-extern crate brotli;
-extern crate core;
-use std::env;
 use std::fs::File;
-use std::io;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::{env, io};
 
 use brotli::concat::{BroCatli, BroCatliResult};
+
 fn usage() {
     writeln!(
         &mut ::std::io::stderr(),

--- a/src/bin/test_broccoli.rs
+++ b/src/bin/test_broccoli.rs
@@ -1,12 +1,14 @@
 #![cfg(test)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
-extern crate brotli_decompressor;
-extern crate core;
-use super::brotli::concat::{BroCatli, BroCatliResult};
-use super::brotli::enc::BrotliEncoderParams;
-use super::integration_tests::UnlimitedBuffer;
+
+use brotli::concat::{BroCatli, BroCatliResult};
+use brotli::enc::BrotliEncoderParams;
 use brotli_decompressor::{CustomRead, CustomWrite};
+
+use super::Rebox;
+use crate::integration_tests::UnlimitedBuffer;
+
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
 static UKKONOOA: &'static [u8] = include_bytes!("../../testdata/ukkonooa");
@@ -17,7 +19,7 @@ static RANDOM10K: &'static [u8] = include_bytes!("../../testdata/random_org_10k.
 static RANDOMTHENUNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
 static QUICKFOX: &'static [u8] = include_bytes!("../../testdata/quickfox_repeated");
 static EMPTY: &'static [u8] = &[];
-use super::Rebox;
+
 fn concat(
     files: &mut [UnlimitedBuffer],
     brotli_files: &mut [UnlimitedBuffer],

--- a/src/bin/test_custom_dict.rs
+++ b/src/bin/test_custom_dict.rs
@@ -1,15 +1,17 @@
 #![cfg(test)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
-extern crate brotli_decompressor;
-extern crate core;
-use super::brotli::concat::{BroCatli, BroCatliResult};
-use super::brotli::enc::BrotliEncoderParams;
-use super::integration_tests::UnlimitedBuffer;
+
 use std::io::{Read, Write};
+
+use brotli::concat::{BroCatli, BroCatliResult};
+use brotli::enc::BrotliEncoderParams;
+
+use super::Rebox;
+use crate::integration_tests::UnlimitedBuffer;
+
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
-use super::Rebox;
 
 #[test]
 fn test_custom_dict() {

--- a/src/bin/test_threading.rs
+++ b/src/bin/test_threading.rs
@@ -1,20 +1,19 @@
 #![cfg(test)]
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
-extern crate brotli_decompressor;
-extern crate core;
-use super::brotli::enc::{
+
+use brotli::enc::threading::{Owned, SendAlloc};
+use brotli::enc::{
     compress_multi, compress_multi_no_threadpool, BrotliEncoderMaxCompressedSizeMulti,
     BrotliEncoderParams, UnionHasher,
 };
-use super::new_brotli_heap_alloc;
-use brotli::enc::threading::{Owned, SendAlloc};
 use brotli_decompressor::{SliceWrapper, SliceWrapperMut};
 
-use super::integration_tests::UnlimitedBuffer;
+use crate::integration_tests::UnlimitedBuffer;
+use crate::{new_brotli_heap_alloc, Rebox};
+
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &'static [u8] = include_bytes!("../../testdata/alice29.txt");
-use super::Rebox;
 
 struct SliceRef<'a>(&'a [u8]);
 impl<'a> SliceWrapper<u8> for SliceRef<'a> {

--- a/src/bin/tests.rs
+++ b/src/bin/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-extern crate core;
+
 use core::cmp;
 use std::io;
 

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -1,6 +1,9 @@
 use core::marker::PhantomData;
 use core::mem;
 use std;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::RwLock;
 use std::thread::JoinHandle;
 
 use alloc_no_stdlib::{Allocator, SliceWrapper};
@@ -13,9 +16,8 @@ use brotli::enc::threading::{
 };
 use brotli::enc::BrotliAlloc;
 use brotli::interface;
+use brotli::interface::LiteralPredictionModeNibble;
 use brotli::transform::TransformDictionaryWord;
-use std::collections::BTreeMap;
-use std::fmt;
 
 struct HexSlice<'a>(&'a [u8]);
 
@@ -59,9 +61,7 @@ macro_rules! println_stderr(
     } }
 );
 
-fn prediction_mode_str(
-    prediction_mode_nibble: interface::LiteralPredictionModeNibble,
-) -> &'static str {
+fn prediction_mode_str(prediction_mode_nibble: LiteralPredictionModeNibble) -> &'static str {
     match prediction_mode_nibble.prediction_mode() {
         interface::LITERAL_PREDICTION_MODE_SIGN => "sign",
         interface::LITERAL_PREDICTION_MODE_LSB6 => "lsb6",
@@ -183,8 +183,6 @@ pub fn write_one<T: SliceWrapper<u8>>(cmd: &interface::Command<T>) {
 }
 
 // in-place thread create
-
-use std::sync::RwLock;
 
 pub struct MTJoinable<T: Send + 'static, U: Send + 'static>(JoinHandle<T>, PhantomData<U>);
 #[cfg(not(feature = "std"))]

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -1,12 +1,15 @@
-use super::{HeapAllocator, IoWriterWrapper, Rebox};
+#[cfg(feature = "validation")]
+use core;
+use std::io::{self, Error, ErrorKind, Read, Write};
+
 use alloc_no_stdlib::{Allocator, SliceWrapper};
 use brotli::enc::BrotliEncoderParams;
 use brotli::{CustomWrite, DecompressorWriterCustomIo};
 #[cfg(feature = "validation")]
-use core;
-#[cfg(feature = "validation")]
 use sha2::{Digest, Sha256};
-use std::io::{self, Error, ErrorKind, Read, Write};
+
+use super::{HeapAllocator, IoWriterWrapper, Rebox};
+
 #[cfg(feature = "validation")]
 type Checksum = Sha256;
 

--- a/src/enc/backward_references/benchmark.rs
+++ b/src/enc/backward_references/benchmark.rs
@@ -1,8 +1,12 @@
 #![cfg(feature = "benchmark")]
 #![cfg(feature = "std")]
+
 extern crate test;
-use super::*;
+
 use alloc_stdlib::StandardAlloc;
+
+use super::*;
+
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../../testdata/random_then_unicode");
 static FINALIZE_DATA: &'static [u8] = &[
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -1,26 +1,26 @@
 #![allow(dead_code, unused_imports)]
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+
+use {alloc, core};
+
 use super::{
     kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
     kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams, CloneWithAlloc, H9Opts,
     HasherSearchResult, HowPrepared, Struct1,
 };
-use alloc;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
-use enc::command::{
+use crate::enc::command::{
     CombineLengthCodes, Command, CommandCopyLen, ComputeDistanceCode, GetCopyLengthCode,
     GetInsertLengthCode, InitCommand, PrefixEncodeCopyDistance,
 };
-use enc::constants::{kCopyExtra, kInsExtra};
-use enc::dictionary_hash::kStaticDictionaryHash;
-use enc::literal_cost::BrotliEstimateBitCostsForLiterals;
-use enc::static_dict::{
+use crate::enc::constants::{kCopyExtra, kInsExtra};
+use crate::enc::dictionary_hash::kStaticDictionaryHash;
+use crate::enc::literal_cost::BrotliEstimateBitCostsForLiterals;
+use crate::enc::static_dict::{
     kBrotliEncDictionary, BrotliDictionary, BrotliFindAllStaticDictionaryMatches,
-};
-use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
-use enc::util::{brotli_max_size_t, floatX, FastLog2, Log2FloorNonZero};
+use crate::enc::util::{brotli_max_size_t, floatX, FastLog2, Log2FloorNonZero};
 
 pub const kInfinity: floatX = 1.7e38 as floatX;
 #[derive(Clone, Copy, Debug)]

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -1,4 +1,9 @@
 #![allow(dead_code, unused_imports)]
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+
+use {alloc, core};
+
 use super::hash_to_binary_tree::{
     kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, InitBackwardMatch,
     StoreAndFindMatchesH10, Union1, ZopfliNode, H10,
@@ -7,24 +12,19 @@ use super::{
     kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
     kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams,
 };
-use alloc;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
-use enc::command::{
+use crate::enc::command::{
     BrotliDistanceParams, CombineLengthCodes, Command, CommandCopyLen, ComputeDistanceCode,
     GetCopyLengthCode, GetInsertLengthCode, InitCommand, PrefixEncodeCopyDistance,
 };
-use enc::constants::{kCopyExtra, kInsExtra};
-use enc::dictionary_hash::kStaticDictionaryHash;
-use enc::encode;
-use enc::literal_cost::BrotliEstimateBitCostsForLiterals;
-use enc::static_dict::{
+use crate::enc::constants::{kCopyExtra, kInsExtra};
+use crate::enc::dictionary_hash::kStaticDictionaryHash;
+use crate::enc::encode;
+use crate::enc::literal_cost::BrotliEstimateBitCostsForLiterals;
+use crate::enc::static_dict::{
     kBrotliEncDictionary, BrotliDictionary, BrotliFindAllStaticDictionaryMatches,
-};
-use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
-use enc::util::{brotli_max_size_t, floatX, FastLog2, FastLog2f64, Log2FloorNonZero};
+use crate::enc::util::{brotli_max_size_t, floatX, FastLog2, FastLog2f64, Log2FloorNonZero};
 
 const BROTLI_WINDOW_GAP: usize = 16;
 const BROTLI_MAX_STATIC_DICTIONARY_MATCH_LEN: usize = 37;

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -3,18 +3,19 @@ mod benchmark;
 pub mod hash_to_binary_tree;
 pub mod hq;
 mod test;
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
 use super::command::{BrotliDistanceParams, Command, ComputeDistanceCode, InitCommand};
 use super::dictionary_hash::kStaticDictionaryHash;
 use super::hash_to_binary_tree::{H10Buckets, H10DefaultParams, ZopfliNode, H10};
-use super::static_dict::BrotliDictionary;
 use super::static_dict::{
-    FindMatchLengthWithLimit, FindMatchLengthWithLimitMin4, BROTLI_UNALIGNED_LOAD32,
-    BROTLI_UNALIGNED_LOAD64,
+    BrotliDictionary, FindMatchLengthWithLimit, FindMatchLengthWithLimitMin4,
+    BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use super::util::{brotli_max_size_t, floatX, Log2FloorNonZero};
-use core;
+
 static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -1,11 +1,15 @@
 #![cfg(feature = "std")]
 #![cfg(test)]
-use super::{
-    AdvHasher, AnyHasher, BrotliHasherParams, CloneWithAlloc, H5Sub, H9Opts, HQ7Sub, Struct1,
-};
+
 use alloc_stdlib::StandardAlloc;
-use enc::{Allocator, SliceWrapper};
+
+use super::{
+    AdvHasher, Allocator, AnyHasher, BrotliHasherParams, CloneWithAlloc, H5Sub, H9Opts, HQ7Sub,
+    SliceWrapper, Struct1,
+};
+
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
+
 #[cfg(feature = "std")]
 #[test]
 fn test_bulk_store_range() {

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -1,12 +1,14 @@
 #![allow(dead_code)]
-use super::super::alloc::SliceWrapper;
-use super::histogram::CostAccessors;
+
+use alloc::{SliceWrapper, SliceWrapperMut};
 use core;
 
-use super::util::{brotli_max_uint32_t, floatX, FastLog2, FastLog2u16};
-use super::vectorization::{cast_f32_to_i32, cast_i32_to_f32, log2i, sum8, v256, v256i, Mem256i};
 #[cfg(feature = "simd")]
 use packed_simd_2::IntoBits;
+
+use super::histogram::CostAccessors;
+use super::util::{brotli_max_uint32_t, floatX, FastLog2, FastLog2u16};
+use super::vectorization::{cast_f32_to_i32, cast_i32_to_f32, log2i, sum8, v256, v256i, Mem256i};
 
 static kCopyBase: [u32; 24] = [
     2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 22, 30, 38, 54, 70, 102, 134, 198, 326, 582, 1094, 2118,
@@ -237,7 +239,6 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
     //println_stderr!("{:?} {:?}", depth_histo, bits);
     bits
 }
-use alloc::SliceWrapperMut;
 
 pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     histogram: &HistogramType,

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
-use super::super::alloc;
-use super::super::alloc::Allocator;
-use super::super::alloc::SliceWrapper;
+
+use alloc::{Allocator, SliceWrapper};
+use core;
 
 pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub num_types: usize,

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -1,9 +1,12 @@
 #![allow(dead_code)]
-use super::backward_references::BrotliEncoderParams;
-use super::vectorization::{sum8i, v256, v256i, Mem256f};
 
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
+#[cfg(feature = "simd")]
+use packed_simd_2::IntoBits;
+
+use super::backward_references::BrotliEncoderParams;
 use super::bit_cost::BrotliPopulationCost;
 use super::block_split::BlockSplit;
 use super::cluster::{BrotliHistogramBitCostDistance, BrotliHistogramCombine, HistogramPair};
@@ -13,9 +16,8 @@ use super::histogram::{
     HistogramClear, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
 use super::util::{brotli_max_uint8_t, brotli_min_size_t, FastLog2};
-use core;
-#[cfg(feature = "simd")]
-use packed_simd_2::IntoBits;
+use super::vectorization::{sum8i, v256, v256i, Mem256f};
+
 static kMaxLiteralHistograms: usize = 100usize;
 
 static kMaxCommandHistograms: usize = 50usize;

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -1,13 +1,15 @@
 #![allow(dead_code)]
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+
+use {alloc, core};
+
 use super::bit_cost::BrotliPopulationCost;
 use super::histogram::{
     CostAccessors, HistogramAddHistogram, HistogramClear, HistogramSelfAddHistogram,
 };
-use super::util::brotli_min_size_t;
-use super::util::FastLog2;
-use alloc;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
+use super::util::{brotli_min_size_t, FastLog2};
+
 #[derive(Clone, Copy)]
 pub struct HistogramPair {
     pub idx1: u32,

--- a/src/enc/combined_alloc.rs
+++ b/src/enc/combined_alloc.rs
@@ -1,17 +1,17 @@
-use super::cluster::HistogramPair;
-use super::command::Command;
-use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
-use super::interface::StaticCommand;
-use super::s16;
-use super::util::floatX;
-use super::v8;
-use super::PDF;
 pub use alloc::Allocator;
 
-use super::entropy_encode::HuffmanTree;
-use super::hash_to_binary_tree::ZopfliNode;
 #[cfg(feature = "std")]
 use alloc_stdlib::StandardAlloc;
+
+use super::cluster::HistogramPair;
+use super::command::Command;
+use super::entropy_encode::HuffmanTree;
+use super::hash_to_binary_tree::ZopfliNode;
+use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
+use super::interface::StaticCommand;
+use super::util::floatX;
+use super::{s16, v8, PDF};
+
 /*
 struct CombiningAllocator<T1, T2, AllocT1:Allocator<T1>, AllocT2:Allocator<T2>>(AllocT1, AllocT2);
 

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -1,5 +1,6 @@
 use super::encode::BROTLI_NUM_DISTANCE_SHORT_CODES;
 use super::util::Log2FloorNonZero;
+
 #[derive(Copy, Clone, Debug)]
 pub struct BrotliDistanceParams {
     pub distance_postfix_bits: u32,

--- a/src/enc/compat.rs
+++ b/src/enc/compat.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "simd", allow(unused))]
 use core::ops::{Add, AddAssign, BitAnd, Mul, Shr, Sub};
+
 #[derive(Default, Copy, Clone, Debug)]
 pub struct Compat16x16([i16; 16]);
 impl Compat16x16 {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -1,15 +1,15 @@
 #![allow(dead_code)]
-use super::backward_references::kHashMul32;
-//use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 
-use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 //caution: lots of the functions look structurally the same as two_pass,
 // but have subtle index differences
 // examples: IsMatch checks p1[4] and p1[5]
 // the hoops that BuildAndStoreCommandPrefixCode goes through are subtly different in order
 // (eg memcpy x+24, y instead of +24, y+40
 // pretty much assume compress_fragment_two_pass is a trap! except for BrotliStoreMetaBlockHeader
-use super::super::alloc;
+
+use super::backward_references::kHashMul32;
+//use alloc::{SliceWrapper, SliceWrapperMut};
+use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 use super::compress_fragment_two_pass::{memcpy, BrotliStoreMetaBlockHeader, BrotliWriteBits};
 use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree, NewHuffmanTree,

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
+
+use core;
+
+//use alloc::{SliceWrapper, SliceWrapperMut};
 use super::backward_references::kHashMul32;
-//use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-use super::super::alloc;
 use super::bit_cost::BitsEntropy;
 use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 use super::entropy_encode::{
@@ -12,7 +14,7 @@ use super::static_dict::{
     BROTLI_UNALIGNED_STORE64,
 };
 use super::util::{brotli_min_size_t, Log2FloorNonZero};
-use core;
+
 static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17i32) as (usize);
 
 // returns number of commands inserted

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -1,12 +1,12 @@
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::find_stride;
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
 use super::input_pair::{InputPair, InputReference, InputReferenceMut};
-use super::interface;
 pub use super::ir_interpret::{push_base, Context, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::weights::{Weights, BLEND_FIXED_POINT_PRECISION};
-use core;
+use super::{find_stride, interface};
+use crate::interface::LiteralPredictionModeNibble;
 
 const DEFAULT_CM_SPEED_INDEX: usize = 8;
 const NUM_SPEEDS_TO_TRY: usize = 16;
@@ -541,7 +541,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
     fn literal_context_map(&self) -> &[u8] {
         self.context_map.literal_context_map.slice()
     }
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     fn update_cost(

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1,4 +1,8 @@
 #![allow(dead_code)]
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
 use super::backward_references::{
     AdvHashSpecialization, AdvHasher, AnyHasher, BasicHasher, BrotliCreateBackwardReferences,
     BrotliEncoderMode, BrotliEncoderParams, BrotliHasherParams, H2Sub, H3Sub, H4Sub, H54Sub, H5Sub,
@@ -16,36 +20,32 @@ use super::brotli_bit_stream::{
     MetaBlockSplit, RecoderState,
 };
 use super::combined_alloc::BrotliAlloc;
+use super::command::{BrotliDistanceParams, Command, GetLengthCode};
+use super::compress_fragment::BrotliCompressFragmentFast;
+use super::compress_fragment_two_pass::{BrotliCompressFragmentTwoPass, BrotliWriteBits};
 use super::constants::{
     BROTLI_CONTEXT, BROTLI_CONTEXT_LUT, BROTLI_MAX_NDIRECT, BROTLI_MAX_NPOSTFIX,
     BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS, BROTLI_WINDOW_GAP,
 };
-use super::hash_to_binary_tree::InitializeH10;
-use super::interface;
-pub use super::parameters::BrotliEncoderParameter;
-use alloc::Allocator;
-
-use super::super::alloc;
-use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-use super::command::{BrotliDistanceParams, Command, GetLengthCode};
-use super::compress_fragment::BrotliCompressFragmentFast;
-use super::compress_fragment_two_pass::{BrotliCompressFragmentTwoPass, BrotliWriteBits};
 #[allow(unused_imports)]
 use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree,
 };
+use super::hash_to_binary_tree::InitializeH10;
 use super::histogram::{
     ContextType, CostAccessors, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
+use super::input_pair::InputReferenceMut;
+use super::interface;
 use super::metablock::{
     BrotliBuildMetaBlock, BrotliBuildMetaBlockGreedy, BrotliInitDistanceParams,
     BrotliOptimizeHistograms,
 };
+pub use super::parameters::BrotliEncoderParameter;
 use super::static_dict::{kNumDistanceCacheEntries, BrotliGetDictionary};
 use super::utf8_util::BrotliIsMostlyUTF8;
 use super::util::{brotli_min_size_t, Log2FloorNonZero};
-use core;
-use enc::input_pair::InputReferenceMut;
+
 //fn BrotliCreateHqZopfliBackwardReferences(m: &mut [MemoryManager],
 //                                          dictionary: &[BrotliDictionary],
 //                                          num_bytes: usize,

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -1,11 +1,11 @@
-use super::super::alloc;
-use super::super::alloc::{SliceWrapper, SliceWrapperMut};
+use alloc::{SliceWrapper, SliceWrapperMut};
+use core::cmp;
+use core::ops::{Index, IndexMut, Range};
+
 use super::input_pair::{InputPair, InputReference};
 use super::interface;
 use super::util::FastLog2;
-use core::cmp;
 
-use core::ops::{Index, IndexMut, Range};
 // float32 doesn't have enough resolution for blocks of data more than 3.5 megs
 pub type floatY = f64;
 // the cost of storing a particular population of data including the approx

--- a/src/enc/fixed_queue.rs
+++ b/src/enc/fixed_queue.rs
@@ -1,4 +1,5 @@
 use core;
+
 pub const MAX_THREADS: usize = 16;
 
 pub struct FixedQueue<T: Sized> {

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -1,13 +1,14 @@
 #![allow(dead_code)]
 
-use super::super::alloc;
-use super::super::alloc::{SliceWrapper, SliceWrapperMut};
+use alloc::{SliceWrapper, SliceWrapperMut};
+use core;
+use core::cmp::min;
+
 use super::block_split::BlockSplit;
 use super::command::{Command, CommandCopyLen, CommandDistanceContext};
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
 use super::vectorization::Mem256i;
-use core;
-use core::cmp::min;
+
 static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -1,7 +1,8 @@
-use super::super::alloc::SliceWrapper;
-use super::super::alloc::SliceWrapperMut;
-use super::interface::Freezable;
+use alloc::{SliceWrapper, SliceWrapperMut};
 use core;
+
+use super::interface::Freezable;
+
 #[derive(Copy, Clone, Default, Debug)]
 pub struct InputReference<'a> {
     pub data: &'a [u8],

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -1,8 +1,10 @@
-use super::histogram;
-pub use super::input_pair::{InputPair, InputReference, InputReferenceMut};
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 #[allow(unused_imports)] // right now just used in feature flag
 use core;
+
+use super::histogram;
+pub use super::input_pair::{InputPair, InputReference, InputReferenceMut};
+
 #[derive(Debug, Copy, Clone, Default)]
 pub struct BlockSwitch(pub u8);
 // Commands that can instantiate as a no-op should implement this.
@@ -765,11 +767,12 @@ pub fn u8_to_speed(data: u8) -> u16 {
 }
 #[cfg(test)]
 mod test {
-    use super::speed_to_u8;
-    use super::u8_to_speed;
+    use super::{speed_to_u8, u8_to_speed};
+
     fn tst_u8_to_speed(data: u16) {
         assert_eq!(u8_to_speed(speed_to_u8(data)), data);
     }
+
     #[test]
     fn test_u8_to_speed() {
         tst_u8_to_speed(0);

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -1,9 +1,11 @@
-use super::super::alloc::SliceWrapper;
+use alloc::SliceWrapper;
+
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
 use super::histogram::ContextType;
 use super::input_pair::InputReference;
 use super::interface;
 use super::interface::LiteralPredictionModeNibble;
+
 pub trait IRInterpreter {
     fn inc_local_byte_offset(&mut self, inc: usize);
     fn local_byte_offset(&self) -> usize;
@@ -11,7 +13,7 @@ pub trait IRInterpreter {
     fn block_type(&self) -> u8;
     fn literal_data_at_offset(&self, index: usize) -> u8;
     fn literal_context_map(&self) -> &[u8];
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble;
+    fn prediction_mode(&self) -> LiteralPredictionModeNibble;
     fn update_cost(
         &mut self,
         stride_prior: [u8; 8],

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
 use super::backward_references::BrotliEncoderParams;
 use super::bit_cost::{BitsEntropy, BrotliPopulationCost};
 use super::block_split::BlockSplit;
@@ -24,7 +26,6 @@ use super::histogram::{
     HistogramLiteral,
 };
 use super::util::{brotli_max_size_t, brotli_min_size_t};
-use core;
 
 pub fn BrotliInitDistanceParams(params: &mut BrotliEncoderParams, npostfix: u32, ndirect: u32) {
     let dist_params = &mut params.dist;

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -4,46 +4,85 @@ pub mod vectorization;
 pub mod backward_references;
 pub mod bit_cost;
 pub mod block_split;
+pub mod block_splitter;
 pub mod brotli_bit_stream;
 pub mod cluster;
 pub mod combined_alloc;
 pub mod command;
-pub mod constants;
-pub mod dictionary_hash;
-pub mod entropy_encode;
-pub mod fast_log;
-pub mod histogram;
-pub mod input_pair;
-pub mod literal_cost;
-pub mod static_dict;
-pub mod static_dict_lut;
-pub mod utf8_util;
-pub mod util;
-pub use self::backward_references::hash_to_binary_tree;
-pub use self::backward_references::hq as backward_references_hq;
-pub mod block_splitter;
+mod compat;
 pub mod compress_fragment;
 pub mod compress_fragment_two_pass;
+pub mod constants;
 pub mod context_map_entropy;
+pub mod dictionary_hash;
 pub mod encode;
+pub mod entropy_encode;
+pub mod fast_log;
 pub mod find_stride;
+pub mod fixed_queue;
+pub mod histogram;
+pub mod input_pair;
 pub mod interface;
 pub mod ir_interpret;
+pub mod literal_cost;
 pub mod metablock;
+pub mod multithreading;
+mod parameters;
 pub mod pdf;
 pub mod prior_eval;
 pub mod reader;
-pub mod stride_eval;
-pub mod writer;
-pub use self::combined_alloc::{BrotliAlloc, CombiningAllocator};
-mod compat;
-pub mod fixed_queue;
-pub mod multithreading;
 pub mod singlethreading;
+pub mod static_dict;
+pub mod static_dict_lut;
+pub mod stride_eval;
+mod test;
 pub mod threading;
+pub mod utf8_util;
+pub mod util;
+mod weights;
 pub mod worker_pool;
+pub mod writer;
+
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Read, Write};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::{CustomRead, CustomWrite};
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
+pub use interface::{InputPair, InputReference, InputReferenceMut};
 #[cfg(feature = "simd")]
 use packed_simd_2::{f32x8, i16x16, i32x8};
+
+pub use self::backward_references::{
+    hash_to_binary_tree, hq as backward_references_hq, BrotliEncoderParams, UnionHasher,
+};
+pub use self::combined_alloc::{BrotliAlloc, CombiningAllocator};
+use self::encode::{
+    BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
+    BrotliEncoderIsFinished, BrotliEncoderOperation, BrotliEncoderSetCustomDictionary,
+};
+pub use self::encode::{
+    BrotliEncoderInitParams, BrotliEncoderMaxCompressedSize, BrotliEncoderMaxCompressedSizeMulti,
+    BrotliEncoderSetParameter,
+};
+pub use self::hash_to_binary_tree::ZopfliNode;
+pub use self::interface::StaticCommand;
+pub use self::pdf::PDF;
+#[cfg(not(feature = "std"))]
+pub use self::singlethreading::{compress_worker_pool, new_work_pool, WorkerPool};
+pub use self::threading::{
+    BatchSpawnableLite, BrotliEncoderThreadError, CompressionThreadResult, Owned, SendAlloc,
+};
+pub use self::util::floatX;
+pub use self::vectorization::{v256, v256i, Mem256f};
+#[cfg(feature = "std")]
+pub use self::worker_pool::{compress_worker_pool, new_work_pool, WorkerPool};
+
 #[cfg(feature = "simd")]
 pub type s16 = i16x16;
 #[cfg(feature = "simd")]
@@ -57,44 +96,6 @@ pub type v8 = compat::CompatF8;
 #[cfg(not(feature = "simd"))]
 pub type s8 = compat::Compat32x8;
 
-mod parameters;
-mod test;
-mod weights;
-pub use self::backward_references::{BrotliEncoderParams, UnionHasher};
-use self::encode::{
-    BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
-    BrotliEncoderIsFinished, BrotliEncoderOperation, BrotliEncoderSetCustomDictionary,
-};
-pub use self::encode::{
-    BrotliEncoderInitParams, BrotliEncoderMaxCompressedSize, BrotliEncoderMaxCompressedSizeMulti,
-    BrotliEncoderSetParameter,
-};
-pub use self::hash_to_binary_tree::ZopfliNode;
-pub use self::interface::StaticCommand;
-pub use self::pdf::PDF;
-pub use self::util::floatX;
-pub use self::vectorization::{v256, v256i, Mem256f};
-use brotli_decompressor::{CustomRead, CustomWrite};
-pub use interface::{InputPair, InputReference, InputReferenceMut};
-
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-#[cfg(feature = "std")]
-use std::io;
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Read, Write};
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-
-#[cfg(not(feature = "std"))]
-pub use self::singlethreading::{compress_worker_pool, new_work_pool, WorkerPool};
-pub use self::threading::{
-    BatchSpawnableLite, BrotliEncoderThreadError, CompressionThreadResult, Owned, SendAlloc,
-};
-#[cfg(feature = "std")]
-pub use self::worker_pool::{compress_worker_pool, new_work_pool, WorkerPool};
 #[cfg(feature = "std")]
 pub fn compress_multi<
     Alloc: BrotliAlloc + Send + 'static,

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -1,15 +1,16 @@
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::backward_references::BrotliEncoderParams;
-use super::find_stride;
-use super::input_pair::{InputPair, InputReference, InputReferenceMut};
-use super::interface;
-use super::ir_interpret::{push_base, IRInterpreter};
-use super::util::{floatX, FastLog2u16};
-use super::{s16, v8};
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use core;
+
 #[cfg(feature = "simd")]
 use packed_simd_2::IntoBits;
+
+use super::backward_references::BrotliEncoderParams;
+use super::input_pair::{InputPair, InputReference, InputReferenceMut};
+use super::interface::LiteralPredictionModeNibble;
+use super::ir_interpret::{push_base, IRInterpreter};
+use super::util::{floatX, FastLog2u16};
+use super::{find_stride, interface, s16, v8};
+
 // the high nibble, followed by the low nibbles
 pub const CONTEXT_MAP_PRIOR_SIZE: usize = 256 * 17;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * 2;
@@ -860,7 +861,7 @@ impl<'a, Alloc: alloc::Allocator<s16> + alloc::Allocator<u32> + alloc::Allocator
         self.context_map.literal_context_map.slice()
     }
     #[inline]
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     #[inline]

--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -1,5 +1,17 @@
 #![cfg_attr(not(feature = "std"), allow(unused_imports))]
 
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Read};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::CustomRead;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
+
 use super::backward_references::BrotliEncoderParams;
 use super::combined_alloc::BrotliAlloc;
 use super::encode::{
@@ -8,19 +20,6 @@ use super::encode::{
     BrotliEncoderSetParameter, BrotliEncoderStateStruct,
 };
 use super::interface;
-use brotli_decompressor::CustomRead;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Read};
 
 #[cfg(feature = "std")]
 pub struct CompressorReaderCustomAlloc<R: Read, BufferType: SliceWrapperMut<u8>, Alloc: BrotliAlloc>(

--- a/src/enc/singlethreading.rs
+++ b/src/enc/singlethreading.rs
@@ -1,16 +1,16 @@
-use super::backward_references::UnionHasher;
 use alloc::{Allocator, SliceWrapper};
 use core::marker::PhantomData;
 use core::mem;
-use enc::threading::{
+#[cfg(feature = "std")]
+use std;
+
+use super::backward_references::UnionHasher;
+use super::threading::{
     BatchSpawnable, BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti,
     CompressionThreadResult, InternalOwned, InternalSendAlloc, Joinable, Owned, OwnedRetriever,
     PoisonedThreadError, SendAlloc,
 };
-use enc::BrotliAlloc;
-use enc::BrotliEncoderParams;
-#[cfg(feature = "std")]
-use std;
+use super::{BrotliAlloc, BrotliEncoderParams};
 
 pub struct SingleThreadedJoinable<T: Send + 'static, U: Send + 'static> {
     result: Result<T, U>,

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -1,5 +1,4 @@
 use core;
-pub const kNumDistanceCacheEntries: usize = 4;
 
 use super::super::dictionary::{
     kBrotliDictionary, kBrotliDictionaryOffsetsByLength, kBrotliDictionarySizeBitsByLength,
@@ -7,6 +6,8 @@ use super::super::dictionary::{
 use super::static_dict_lut::{
     kDictHashMul32, kDictNumBits, kStaticDictionaryBuckets, kStaticDictionaryWords, DictWord,
 };
+
+pub const kNumDistanceCacheEntries: usize = 4;
 #[allow(unused)]
 static kUppercaseFirst: u8 = 10i32 as (u8);
 

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -1,12 +1,14 @@
-use super::super::alloc;
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
+
 use super::backward_references::BrotliEncoderParams;
 use super::input_pair::{InputPair, InputReference, InputReferenceMut};
 use super::interface;
+use super::interface::LiteralPredictionModeNibble;
 use super::ir_interpret::{push_base, IRInterpreter};
 use super::prior_eval::DEFAULT_SPEED;
 use super::util::{floatX, FastLog2u16};
-use core;
+
 const NIBBLE_PRIOR_SIZE: usize = 16;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * NIBBLE_PRIOR_SIZE * 2;
 
@@ -295,7 +297,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
     fn literal_context_map(&self) -> &[u8] {
         self.context_map.literal_context_map.slice()
     }
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     fn update_cost(

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -1,35 +1,35 @@
 #![cfg(test)]
-use super::{s16, v8};
-use core;
-extern crate alloc_no_stdlib;
-extern crate brotli_decompressor;
-use super::super::alloc::{
-    bzero, AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator,
+
+use alloc::{
+    bzero, declare_stack_allocator_struct, AllocatedStackMemory, Allocator, SliceWrapper,
+    SliceWrapperMut, StackAllocator,
 };
+use core;
+use core::ops;
+
+use brotli_decompressor::HuffmanCode;
+
+pub use super::super::{BrotliDecompressStream, BrotliResult, BrotliState};
 use super::cluster::HistogramPair;
+use super::combined_alloc::CombiningAllocator;
+use super::command::Command;
 use super::encode::{
     BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
     BrotliEncoderIsFinished, BrotliEncoderOperation, BrotliEncoderParameter,
     BrotliEncoderSetParameter,
 };
+use super::entropy_encode::HuffmanTree;
 use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
-use super::StaticCommand;
-use super::ZopfliNode;
-use enc::util::brotli_min_size_t;
+use super::pdf::PDF;
+use super::util::brotli_min_size_t;
+use super::{interface, s16, v8, StaticCommand, ZopfliNode};
+
 extern "C" {
     fn calloc(n_elem: usize, el_size: usize) -> *mut u8;
 }
 extern "C" {
     fn free(ptr: *mut u8);
 }
-pub use super::super::{BrotliDecompressStream, BrotliResult, BrotliState};
-use super::combined_alloc::CombiningAllocator;
-use super::command::Command;
-use super::entropy_encode::HuffmanTree;
-use super::interface;
-use super::pdf::PDF;
-use brotli_decompressor::HuffmanCode;
-use core::ops;
 
 declare_stack_allocator_struct!(MemPool, 128, stack);
 declare_stack_allocator_struct!(CallocatedFreelist4096, 128, calloc);

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -1,3 +1,10 @@
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core::marker::PhantomData;
+use core::ops::Range;
+use core::{any, mem};
+#[cfg(feature = "std")]
+use std;
+
 use super::backward_references::{AnyHasher, BrotliEncoderParams, CloneWithAlloc, UnionHasher};
 use super::encode::{
     BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
@@ -5,14 +12,8 @@ use super::encode::{
     BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher, HasherSetup, SanitizeParams,
 };
 use super::BrotliAlloc;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use concat::{BroCatli, BroCatliResult};
-use core::any;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::Range;
-#[cfg(feature = "std")]
-use std;
+use crate::concat::{BroCatli, BroCatliResult};
+
 pub type PoisonedThreadError = ();
 
 #[cfg(feature = "std")]
@@ -493,10 +494,10 @@ where
         let (alloc, _extra) = alloc_per_thread[num_threads - 1].replace_with_default();
         compression_last_thread_result = spawner_and_input.view(move |input_and_params:&(SliceW, BrotliEncoderParams)| -> CompressionThreadResult<Alloc> {
         compress_part(hasher,
-                      num_threads - 1,
-                      num_threads,
-                      input_and_params,
-                      alloc,
+          num_threads - 1,
+          num_threads,
+          input_and_params,
+          alloc,
         )
       });
     } else {
@@ -514,10 +515,10 @@ where
         let (alloc, _extra) = alloc_per_thread[num_threads - 1].replace_with_default();
         compression_last_thread_result = spawner_and_input.view(move |input_and_params:&(SliceW, BrotliEncoderParams)| -> CompressionThreadResult<Alloc> {
         compress_part(UnionHasher::Uninit,
-                      num_threads - 1,
-                      num_threads,
-                      input_and_params,
-                      alloc,
+          num_threads - 1,
+          num_threads,
+          input_and_params,
+          alloc,
         )
       });
     }

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -1,12 +1,14 @@
 #![allow(unknown_lints)]
 #![allow(unused_macros)]
 
-use enc::util::FastLog2;
-use enc::{s8, v8};
+use super::util::FastLog2;
+use super::{s8, v8};
+
 pub type Mem256f = v8;
 pub type Mem256i = s8;
 pub type v256 = v8;
 pub type v256i = s8;
+
 pub fn sum8(x: v256) -> f32 {
     x.extract(0)
         + x.extract(1)

--- a/src/enc/weights.rs
+++ b/src/enc/weights.rs
@@ -1,4 +1,5 @@
 use core;
+
 pub type Prob = u16;
 
 pub const BLEND_FIXED_POINT_PRECISION: i8 = 15;

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -1,20 +1,18 @@
 #![cfg(feature = "std")]
-use core::mem;
-use std;
 
 use alloc::{Allocator, SliceWrapper};
-use enc::backward_references::UnionHasher;
-use enc::fixed_queue::{FixedQueue, MAX_THREADS};
-use enc::threading::{
+use core::mem;
+// in-place thread create
+use std::sync::RwLock;
+use std::sync::{Arc, Condvar, Mutex};
+
+use super::backward_references::UnionHasher;
+use super::fixed_queue::{FixedQueue, MAX_THREADS};
+use super::threading::{
     BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti, CompressionThreadResult,
     InternalOwned, InternalSendAlloc, Joinable, Owned, SendAlloc,
 };
-use enc::BrotliAlloc;
-use enc::BrotliEncoderParams;
-use std::sync::{Arc, Condvar, Mutex};
-// in-place thread create
-
-use std::sync::RwLock;
+use super::{BrotliAlloc, BrotliEncoderParams};
 
 struct JobReply<T: Send + 'static> {
     result: T,

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -1,4 +1,17 @@
 #![cfg_attr(not(feature = "std"), allow(unused_imports))]
+
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Write};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::CustomWrite;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoWriter, IoWriterWrapper};
+
 use super::backward_references::BrotliEncoderParams;
 use super::combined_alloc::BrotliAlloc;
 use super::encode::{
@@ -7,18 +20,6 @@ use super::encode::{
     BrotliEncoderParameter, BrotliEncoderSetParameter, BrotliEncoderStateStruct,
 };
 use super::interface;
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-use brotli_decompressor::CustomWrite;
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoWriter, IoWriterWrapper};
-
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Write};
 
 #[cfg(feature = "std")]
 pub struct CompressorWriterCustomAlloc<

--- a/src/ffi/alloc_util.rs
+++ b/src/ffi/alloc_util.rs
@@ -1,7 +1,8 @@
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
-use enc::BrotliAlloc;
+
+use crate::enc::BrotliAlloc;
 
 pub struct BrotliSubclassableAllocator(SubclassableAllocator);
 

--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -1,8 +1,11 @@
+use core;
+
 pub use brotli_decompressor::ffi::interface::c_void;
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
-use concat::BroCatli;
-pub use concat::BroCatliResult;
-use core;
+
+use crate::concat::BroCatli;
+pub use crate::concat::BroCatliResult;
+
 pub type BroccoliResult = BroCatliResult;
 // a tool to concatenate brotli files together
 

--- a/src/ffi/decompressor.rs
+++ b/src/ffi/decompressor.rs
@@ -1,6 +1,5 @@
-pub use brotli_decompressor::ffi;
 pub use brotli_decompressor::ffi::interface::{brotli_alloc_func, brotli_free_func, c_void};
-pub use brotli_decompressor::{BrotliDecoderReturnInfo, HuffmanCode};
+pub use brotli_decompressor::{ffi, BrotliDecoderReturnInfo, HuffmanCode};
 
 pub unsafe extern "C" fn CBrotliDecoderCreateInstance(
     alloc_func: brotli_alloc_func,

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -1,29 +1,32 @@
 #![cfg(not(feature = "safe"))]
+mod test;
+
+use alloc::SliceWrapper;
+use core;
 #[cfg(feature = "std")]
 use std::io::Write;
 #[cfg(feature = "std")]
 use std::{io, panic, thread};
-mod test;
-use super::compressor;
-#[allow(unused_imports)]
+
+#[cfg(feature = "std")]
 use brotli_decompressor;
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
 use brotli_decompressor::ffi::interface::{
     brotli_alloc_func, brotli_free_func, c_void, CAllocator,
 };
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
-use core;
-use enc::encode::{
-    BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
-    BrotliEncoderIsFinished, BrotliEncoderOperation, BrotliEncoderSetParameter,
-};
 
 use super::alloc_util::BrotliSubclassableAllocator;
-use alloc::SliceWrapper;
-use enc;
-use enc::backward_references::{BrotliEncoderParams, UnionHasher};
-use enc::encode::{set_parameter, BrotliEncoderParameter};
-use enc::threading::{Owned, SendAlloc};
+use super::compressor;
+use crate::enc;
+use crate::enc::backward_references::{BrotliEncoderParams, UnionHasher};
+use crate::enc::encode::{
+    set_parameter, BrotliEncoderCompressStream, BrotliEncoderCreateInstance,
+    BrotliEncoderDestroyInstance, BrotliEncoderIsFinished, BrotliEncoderOperation,
+    BrotliEncoderParameter, BrotliEncoderSetParameter,
+};
+use crate::enc::threading::{Owned, SendAlloc};
+
 pub const MAX_THREADS: usize = 16;
 
 struct SliceRef<'a>(&'a [u8]);
@@ -50,7 +53,7 @@ pub extern "C" fn BrotliEncoderMaxCompressedSizeMulti(
     input_size: usize,
     num_threads: usize,
 ) -> usize {
-    ::enc::encode::BrotliEncoderMaxCompressedSizeMulti(input_size, num_threads)
+    enc::encode::BrotliEncoderMaxCompressedSizeMulti(input_size, num_threads)
 }
 
 fn help_brotli_encoder_compress_single(

--- a/src/ffi/multicompress/test.rs
+++ b/src/ffi/multicompress/test.rs
@@ -1,8 +1,11 @@
 #![cfg(test)]
 #![cfg(feature = "std")]
-use super::*;
+
 use core;
-use enc::encode::BrotliEncoderParameter;
+
+use super::*;
+use crate::enc::encode::BrotliEncoderParameter;
+
 #[test]
 fn test_compress_workpool() {
     let input = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,54 +9,60 @@
     feature = "no-stdlib-ffi-binding",
     cfg_attr(not(feature = "std"), feature(lang_items))
 )]
+
 #[macro_use]
 // <-- for debugging, remove xprintln from bit_reader and replace with println
 #[cfg(feature = "std")]
 extern crate std;
 #[cfg(feature = "std")]
 extern crate alloc_stdlib;
-#[cfg(feature = "simd")]
-extern crate packed_simd_2;
-#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc_no_stdlib as alloc;
-extern crate brotli_decompressor;
+
+pub mod concat;
+pub mod enc;
+#[cfg(feature = "ffi-api")]
+pub mod ffi;
+
 pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-pub const VERSION: u8 = 1;
+
 #[cfg(feature = "std")]
 pub use alloc_stdlib::HeapAlloc;
-pub mod enc;
-pub use self::enc::combined_alloc::CombiningAllocator;
-pub mod concat;
-pub use brotli_decompressor::dictionary;
-pub use brotli_decompressor::reader;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::copy_from_to;
+pub use brotli_decompressor::io_wrappers::{CustomRead, CustomWrite};
+#[cfg(feature = "std")]
+pub use brotli_decompressor::io_wrappers::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
 #[cfg(feature = "std")]
 pub use brotli_decompressor::reader::Decompressor;
 pub use brotli_decompressor::reader::DecompressorCustomIo;
-pub use brotli_decompressor::transform;
 pub use brotli_decompressor::transform::TransformDictionaryWord;
-pub use brotli_decompressor::writer;
-pub use brotli_decompressor::BrotliState;
-pub use brotli_decompressor::HuffmanCode; // so we can make custom allocator for decompression
-
-pub use brotli_decompressor::writer::DecompressorWriterCustomIo;
-
 #[cfg(feature = "std")]
 pub use brotli_decompressor::writer::DecompressorWriter;
-
-pub use brotli_decompressor::io_wrappers::{CustomRead, CustomWrite};
-
+pub use brotli_decompressor::writer::DecompressorWriterCustomIo;
 #[cfg(feature = "std")]
-pub use brotli_decompressor::io_wrappers::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-pub use enc::input_pair::InputPair;
-pub use enc::input_pair::InputReference;
-pub use enc::input_pair::InputReferenceMut;
-pub use enc::interface;
-pub use enc::interface::thaw;
-pub use enc::interface::thaw_pair;
-pub use enc::interface::SliceOffset;
-#[cfg(feature = "ffi-api")]
-pub mod ffi;
+pub use brotli_decompressor::BrotliDecompress;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::BrotliDecompressCustomAlloc;
+pub use brotli_decompressor::HuffmanCode; // so we can make custom allocator for decompression
+pub use brotli_decompressor::{
+    dictionary, reader, transform, writer, BrotliDecompressCustomIo,
+    BrotliDecompressCustomIoCustomDict, BrotliDecompressStream, BrotliResult, BrotliState,
+};
+
+pub use self::enc::combined_alloc::CombiningAllocator;
+pub use crate::enc::input_pair::{InputPair, InputReference, InputReferenceMut};
+pub use crate::enc::interface::{thaw, thaw_pair, SliceOffset};
+#[cfg(feature = "std")]
+pub use crate::enc::reader::CompressorReader;
+pub use crate::enc::reader::CompressorReaderCustomIo;
+#[cfg(feature = "std")]
+pub use crate::enc::writer::CompressorWriter;
+pub use crate::enc::writer::CompressorWriterCustomIo;
+pub use crate::enc::{interface, BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};
+#[cfg(feature = "std")]
+pub use crate::enc::{BrotliCompress, BrotliCompressCustomAlloc};
+
 // interface
 // pub fn BrotliDecompressStream(mut available_in: &mut usize,
 //                               input_offset: &mut usize,
@@ -67,27 +73,4 @@ pub mod ffi;
 //                               mut total_out: &mut usize,
 //                               mut s: &mut BrotliState<AllocU8, AllocU32, AllocHC>);
 
-pub use brotli_decompressor::{BrotliDecompressStream, BrotliResult};
-#[cfg(feature = "std")]
-pub use enc::{BrotliCompress, BrotliCompressCustomAlloc};
-pub use enc::{BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};
-
-#[cfg(feature = "std")]
-pub use enc::reader::CompressorReader;
-pub use enc::reader::CompressorReaderCustomIo;
-
-#[cfg(feature = "std")]
-pub use enc::writer::CompressorWriter;
-pub use enc::writer::CompressorWriterCustomIo;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::BrotliDecompress;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::BrotliDecompressCustomAlloc;
-
-pub use brotli_decompressor::BrotliDecompressCustomIo;
-pub use brotli_decompressor::BrotliDecompressCustomIoCustomDict;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::copy_from_to;
+pub const VERSION: u8 = 1;


### PR DESCRIPTION
Move ffi to 2021, and the primary crate to 2018 edition - I ran into a compilation issue with 2021 for the main one - will need to deal with it separately.

Also, cleanup the `use` statements a bit - there is a lot more work needed there, and the "extern" keyword should probably be removed at most places, but that's for another PR.

CI results in https://github.com/rust-brotli/rust-brotli/pull/7