### PR TITLE
Re-enable simd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ incremental = false
 "alloc-stdlib" = { version = "~0.2", optional = true }
 "brotli-decompressor" = { version = "~2.5", default-features = false }
 "sha2" = { version = "~0.10", optional = true }
-# Uncomment once this packed_simd
-# "packed_simd_2" = {version="0.3", optional=true}
+"packed_simd" = { git = "https://github.com/programingjd/packed_simd.git", rev = "53efe013875b7f23ecc1edd840a20c4cbce3f302", default-features = false, features = ["into_bits"], optional = true }
 
 [features]
 default = ["std", "ffi-api"]
@@ -44,4 +43,4 @@ seccomp = ["brotli-decompressor/seccomp"]
 std = ["alloc-stdlib", "brotli-decompressor/std"]
 validation = ["sha2"]
 vector_scratch_space = []
-# simd = ["packed_simd_2/into_bits"]
+simd = ["packed_simd/into_bits"]

--- a/justfile
+++ b/justfile
@@ -8,11 +8,15 @@ clean:
     cargo clean
 
 # Build everything
-build: build-brotli build-ffi
+build: build-brotli build-simd build-ffi
 
 # Build the main crate
 build-brotli:
     RUSTFLAGS='-D warnings' cargo build --workspace --all-targets --bins --tests --lib --benches --examples
+
+# Build simd with nightly
+build-simd:
+    RUSTFLAGS='-D warnings' cargo +nightly build --features simd
 
 # Build the brotli-ffi crate (in ./c dir)
 build-ffi:

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -6,7 +6,7 @@ use core;
 use super::util::{brotli_max_uint32_t, floatX, FastLog2, FastLog2u16};
 use super::vectorization::{cast_f32_to_i32, cast_i32_to_f32, log2i, sum8, v256, v256i, Mem256i};
 #[cfg(feature = "simd")]
-use packed_simd_2::IntoBits;
+use packed_simd::IntoBits;
 
 static kCopyBase: [u32; 24] = [
     2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 22, 30, 38, 54, 70, 102, 134, 198, 326, 582, 1094, 2118,

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -15,7 +15,7 @@ use super::histogram::{
 use super::util::{brotli_max_uint8_t, brotli_min_size_t, FastLog2};
 use core;
 #[cfg(feature = "simd")]
-use packed_simd_2::IntoBits;
+use packed_simd::IntoBits;
 static kMaxLiteralHistograms: usize = 100usize;
 
 static kMaxCommandHistograms: usize = 50usize;

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -43,7 +43,7 @@ pub mod singlethreading;
 pub mod threading;
 pub mod worker_pool;
 #[cfg(feature = "simd")]
-use packed_simd_2::{f32x8, i16x16, i32x8};
+use packed_simd::{f32x8, i16x16, i32x8};
 #[cfg(feature = "simd")]
 pub type s16 = i16x16;
 #[cfg(feature = "simd")]

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -9,7 +9,7 @@ use super::util::{floatX, FastLog2u16};
 use super::{s16, v8};
 use core;
 #[cfg(feature = "simd")]
-use packed_simd_2::IntoBits;
+use packed_simd::IntoBits;
 // the high nibble, followed by the low nibbles
 pub const CONTEXT_MAP_PRIOR_SIZE: usize = 256 * 17;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * 2;

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -134,7 +134,7 @@ impl<
                     } else if local_queue.shutdown {
                         break;
                     } else {
-                        let _ = cvar.wait(local_queue); // unlock immediately, unfortunately
+                        let _lock = cvar.wait(local_queue); // unlock immediately, unfortunately
                         continue;
                     };
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate std;
 #[cfg(feature = "std")]
 extern crate alloc_stdlib;
 #[cfg(feature = "simd")]
-extern crate packed_simd_2;
+extern crate packed_simd;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc_no_stdlib as alloc;


### PR DESCRIPTION
I made a fork of the packed_simd repo to fix the compilation issues (stdsimd has been renamed).
I then modified the dependency to point to that fork with the revision number (as suggested).

I am having trouble with the just file to add the nightly toolchain though.