### PR TITLE
Simplify constant func params and index access

### DIFF
--- a/corrosion/backward_references_hq.rs
+++ b/corrosion/backward_references_hq.rs
@@ -128,7 +128,7 @@ pub unsafe extern fn BrotliInitZopfliNodes(
     i = 0usize;
     while i < length {
         *array.offset(i as isize) = stub;
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -220,7 +220,7 @@ unsafe extern fn ZopfliNodeLengthCode(
     mut self : *const ZopfliNode
 ) -> u32 {
     let modifier : u32 = (*self).length >> 25i32;
-    ZopfliNodeCopyLength(self).wrapping_add(9u32).wrapping_sub(
+    ZopfliNodeCopyLength(self).wrapping_add(9).wrapping_sub(
         modifier
     )
 }
@@ -242,7 +242,7 @@ unsafe extern fn ZopfliNodeDistanceCode(
             1u32
         )
     } else {
-        short_code.wrapping_sub(1u32)
+        short_code.wrapping_sub(1)
     }
 }
 
@@ -252,7 +252,7 @@ unsafe extern fn Log2FloorNonZero(mut n : usize) -> u32 {
               n = n >> 1i32;
               n
           } != 0 {
-        result = result.wrapping_add(1 as u32);
+        result = result.wrapping_add(1);
     }
     result
 }
@@ -274,16 +274,16 @@ unsafe extern fn PrefixEncodeCopyDistance(
             = (1usize << postfix_bits.wrapping_add(
                                       2u32 as usize
                                   )).wrapping_add(
-                  distance_code.wrapping_sub(16usize).wrapping_sub(
+                  distance_code.wrapping_sub(16).wrapping_sub(
                       num_direct_codes
                   )
               );
         let mut bucket
             : usize
-            = Log2FloorNonZero(dist).wrapping_sub(1u32) as usize;
+            = Log2FloorNonZero(dist).wrapping_sub(1) as usize;
         let mut postfix_mask
             : usize
-            = (1u32 << postfix_bits).wrapping_sub(1u32) as usize;
+            = (1u32 << postfix_bits).wrapping_sub(1) as usize;
         let mut postfix : usize = dist & postfix_mask;
         let mut prefix : usize = dist >> bucket & 1usize;
         let mut offset
@@ -294,7 +294,7 @@ unsafe extern fn PrefixEncodeCopyDistance(
                                       num_direct_codes
                                   ).wrapping_add(
                                       (2usize).wrapping_mul(
-                                          nbits.wrapping_sub(1usize)
+                                          nbits.wrapping_sub(1)
                                       ).wrapping_add(
                                           prefix
                                       ) << postfix_bits
@@ -314,18 +314,18 @@ unsafe extern fn GetInsertLengthCode(
         let mut nbits
             : u32
             = Log2FloorNonZero(
-                  insertlen.wrapping_sub(2usize)
+                  insertlen.wrapping_sub(2)
               ).wrapping_sub(
                   1u32
               );
         ((nbits << 1i32) as usize).wrapping_add(
-            insertlen.wrapping_sub(2usize) >> nbits
+            insertlen.wrapping_sub(2) >> nbits
         ).wrapping_add(
             2usize
         ) as u16
     } else if insertlen < 2114usize {
         Log2FloorNonZero(
-            insertlen.wrapping_sub(66usize)
+            insertlen.wrapping_sub(66)
         ).wrapping_add(
             10u32
         ) as u16
@@ -340,23 +340,23 @@ unsafe extern fn GetInsertLengthCode(
 
 unsafe extern fn GetCopyLengthCode(mut copylen : usize) -> u16 {
     if copylen < 10usize {
-        copylen.wrapping_sub(2usize) as u16
+        copylen.wrapping_sub(2) as u16
     } else if copylen < 134usize {
         let mut nbits
             : u32
             = Log2FloorNonZero(
-                  copylen.wrapping_sub(6usize)
+                  copylen.wrapping_sub(6)
               ).wrapping_sub(
                   1u32
               );
         ((nbits << 1i32) as usize).wrapping_add(
-            copylen.wrapping_sub(6usize) >> nbits
+            copylen.wrapping_sub(6) >> nbits
         ).wrapping_add(
             4usize
         ) as u16
     } else if copylen < 2118usize {
         Log2FloorNonZero(
-            copylen.wrapping_sub(70usize)
+            copylen.wrapping_sub(70)
         ).wrapping_add(
             12u32
         ) as u16
@@ -440,7 +440,7 @@ pub unsafe extern fn BrotliZopfliCreateCommands(
     mut num_literals : *mut usize
 ) {
     let mut pos : usize = 0usize;
-    let mut offset : u32 = (*nodes.offset(0isize)).u.next;
+    let mut offset : u32 = (*nodes.offset(0)).u.next;
     let mut i : usize;
     let mut gap : usize = 0usize;
     i = 0usize;
@@ -491,22 +491,22 @@ pub unsafe extern fn BrotliZopfliCreateCommands(
                     dist_code
                 );
                 if is_dictionary == 0 && (dist_code > 0usize) {
-                    *dist_cache.offset(3isize) = *dist_cache.offset(
+                    *dist_cache.offset(3) = *dist_cache.offset(
                                                                2isize
                                                            );
-                    *dist_cache.offset(2isize) = *dist_cache.offset(
+                    *dist_cache.offset(2) = *dist_cache.offset(
                                                                1isize
                                                            );
-                    *dist_cache.offset(1isize) = *dist_cache.offset(
+                    *dist_cache.offset(1) = *dist_cache.offset(
                                                                0isize
                                                            );
-                    *dist_cache.offset(0isize) = distance as i32;
+                    *dist_cache.offset(0) = distance as i32;
                 }
             }
             *num_literals = (*num_literals).wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     *last_insert_len = (*last_insert_len).wrapping_add(
                            num_bytes.wrapping_sub(pos)
@@ -583,7 +583,7 @@ unsafe extern fn InitZopfliCostModel(
                                 ) > 0usize {
                                  BrotliAllocate(
                                      m,
-                                     num_bytes.wrapping_add(2usize).wrapping_mul(
+                                     num_bytes.wrapping_add(2).wrapping_mul(
                                          core::mem::size_of::<f32>()
                                      )
                                  ) as (*mut f32)
@@ -630,23 +630,23 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
         num_bytes,
         ringbuffer_mask,
         ringbuffer,
-        &mut *literal_costs.offset(1isize) as (*mut f32)
+        &mut *literal_costs.offset(1) as (*mut f32)
     );
-    *literal_costs.offset(0isize) = 0.0f64 as (f32);
+    *literal_costs.offset(0) = 0.0f64 as (f32);
     i = 0usize;
     while i < num_bytes {
         {
             literal_carry = literal_carry + *literal_costs.offset(
-                                                 i.wrapping_add(1usize) as isize
+                                                 i.wrapping_add(1) as isize
                                              );
             *literal_costs.offset(
-                 i.wrapping_add(1usize) as isize
+                 i.wrapping_add(1) as isize
              ) = *literal_costs.offset(i as isize) + literal_carry;
             literal_carry = literal_carry - (*literal_costs.offset(
-                                                  i.wrapping_add(1usize) as isize
+                                                  i.wrapping_add(1) as isize
                                               ) - *literal_costs.offset(i as isize));
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < 704usize {
@@ -657,7 +657,7 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
                                                  ) as usize
                                              ) as (f32);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < (*self).distance_histogram_size as usize {
@@ -668,7 +668,7 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
                                                   ) as usize
                                               ) as (f32);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     (*self).min_cost_cmd_ = FastLog2(11usize) as (f32);
 }
@@ -689,9 +689,9 @@ unsafe extern fn FindMatchLengthWithLimit(
     let mut matched : usize = 0usize;
     let mut limit2
         : usize
-        = (limit >> 3i32).wrapping_add(1usize);
+        = (limit >> 3i32).wrapping_add(1);
     while {
-              limit2 = limit2.wrapping_sub(1 as usize);
+              limit2 = limit2.wrapping_sub(1);
               limit2
           } != 0 {
         if BrotliUnalignedRead64(
@@ -699,8 +699,8 @@ unsafe extern fn FindMatchLengthWithLimit(
            ) == BrotliUnalignedRead64(
                     s1.offset(matched as isize) as (*const std::os::raw::c_void)
                 ) {
-            s2 = s2.offset(8isize);
-            matched = matched.wrapping_add(8usize);
+            s2 = s2.offset(8);
+            matched = matched.wrapping_add(8);
         } else {
             let mut x
                 : usize
@@ -714,14 +714,14 @@ unsafe extern fn FindMatchLengthWithLimit(
             return matched;
         }
     }
-    limit = (limit & 7usize).wrapping_add(1usize);
+    limit = (limit & 7usize).wrapping_add(1);
     while {
-              limit = limit.wrapping_sub(1 as usize);
+              limit = limit.wrapping_sub(1);
               limit
           } != 0 {
         if *s1.offset(matched as isize) as i32 == *s2 as i32 {
-            s2 = s2.offset(1 as isize);
-            matched = matched.wrapping_add(1 as usize);
+            s2 = s2.offset(1);
+            matched = matched.wrapping_add(1);
         } else {
             return matched;
         }
@@ -762,7 +762,7 @@ unsafe extern fn HashBytesH10(mut data : *const u8) -> u32 {
 }
 
 unsafe extern fn ForestH10(mut self : *mut H10) -> *mut u32 {
-    &mut *self.offset(1isize) as (*mut H10) as (*mut u32)
+    &mut *self.offset(1) as (*mut H10) as (*mut u32)
 }
 
 unsafe extern fn LeftChildIndexH10(
@@ -848,7 +848,7 @@ unsafe extern fn StoreAndFindMatchesH10(
                     InitBackwardMatch(
                         {
                             let _old = matches;
-                            matches = matches.offset(1 as isize);
+                            matches = matches.offset(1);
                             _old
                         },
                         backward,
@@ -893,7 +893,7 @@ unsafe extern fn StoreAndFindMatchesH10(
                 }
             }
         }
-        depth_remaining = depth_remaining.wrapping_sub(1 as usize);
+        depth_remaining = depth_remaining.wrapping_sub(1);
     }
     matches
 }
@@ -969,7 +969,7 @@ unsafe extern fn FindAllMatchesH10(
     if cur_ix < short_match_max_backward {
         stop = 0usize;
     }
-    i = cur_ix.wrapping_sub(1usize);
+    i = cur_ix.wrapping_sub(1);
     'break14: while i > stop && (best_len <= 2usize) {
         'continue15: loop {
             {
@@ -1005,7 +1005,7 @@ unsafe extern fn FindAllMatchesH10(
                         InitBackwardMatch(
                             {
                                 let _old = matches;
-                                matches = matches.offset(1 as isize);
+                                matches = matches.offset(1);
                                 _old
                             },
                             backward,
@@ -1016,7 +1016,7 @@ unsafe extern fn FindAllMatchesH10(
             }
             break;
         }
-        i = i.wrapping_sub(1 as usize);
+        i = i.wrapping_sub(1);
     }
     if best_len < max_length {
         matches = StoreAndFindMatchesH10(
@@ -1035,21 +1035,21 @@ unsafe extern fn FindAllMatchesH10(
         {
             *dict_matches.offset(i as isize) = kInvalidMatch;
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     {
         let mut minlen
             : usize
             = brotli_max_size_t(
                   4usize,
-                  best_len.wrapping_add(1usize)
+                  best_len.wrapping_add(1)
               );
         if BrotliFindAllStaticDictionaryMatches(
                dictionary,
                &*data.offset(cur_ix_masked as isize) as (*const u8),
                minlen,
                max_length,
-               &mut *dict_matches.offset(0isize) as (*mut u32)
+               &mut *dict_matches.offset(0) as (*mut u32)
            ) != 0 {
             let mut maxlen
                 : usize
@@ -1071,7 +1071,7 @@ unsafe extern fn FindAllMatchesH10(
                             InitDictionaryBackwardMatch(
                                 {
                                     let _old = matches;
-                                    matches = matches.offset(1 as isize);
+                                    matches = matches.offset(1);
                                     _old
                                 },
                                 distance,
@@ -1081,7 +1081,7 @@ unsafe extern fn FindAllMatchesH10(
                         }
                     }
                 }
-                l = l.wrapping_add(1 as usize);
+                l = l.wrapping_add(1);
             }
         }
     }
@@ -1218,7 +1218,7 @@ unsafe extern fn StartPosQueuePush(
         : usize
         = !{
                let _old = (*self).idx_;
-               (*self).idx_ = (*self).idx_.wrapping_add(1 as usize);
+               (*self).idx_ = (*self).idx_.wrapping_add(1);
                _old
            } & 7usize;
     let mut len
@@ -1246,12 +1246,12 @@ unsafe extern fn StartPosQueuePush(
                                                                          ) & 7usize) as isize
                                                                     );
                 *q.offset(
-                     (offset.wrapping_add(1usize) & 7usize) as isize
+                     (offset.wrapping_add(1) & 7usize) as isize
                  ) = __brotli_swap_tmp;
             }
-            offset = offset.wrapping_add(1 as usize);
+            offset = offset.wrapping_add(1);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -1328,11 +1328,11 @@ unsafe extern fn ComputeMinimumCopyLength(
     while pos.wrapping_add(len) <= num_bytes && ((*nodes.offset(
                                                        pos.wrapping_add(len) as isize
                                                    )).u.cost <= min_cost) {
-        len = len.wrapping_add(1 as usize);
+        len = len.wrapping_add(1);
         if len == next_len_offset {
             min_cost = min_cost + 1.0f32;
             next_len_offset = next_len_offset.wrapping_add(next_len_bucket);
-            next_len_bucket = next_len_bucket.wrapping_mul(2usize);
+            next_len_bucket = next_len_bucket.wrapping_mul(2);
         }
     }
     len
@@ -1468,7 +1468,7 @@ unsafe extern fn UpdateNodes(
                                                         0usize,
                                                         pos
                                                     );
-                let mut best_len : usize = min_len.wrapping_sub(1usize);
+                let mut best_len : usize = min_len.wrapping_sub(1);
                 let mut j : usize = 0usize;
                 'break29: while j < 16usize && (best_len < max_len) {
                     'continue30: loop {
@@ -1523,7 +1523,7 @@ unsafe extern fn UpdateNodes(
                                     : f32
                                     = base_cost + ZopfliCostModelGetDistanceCost(model,j);
                                 let mut l : usize;
-                                l = best_len.wrapping_add(1usize);
+                                l = best_len.wrapping_add(1);
                                 while l <= len {
                                     {
                                         let copycode : u16 = GetCopyLengthCode(l);
@@ -1556,20 +1556,20 @@ unsafe extern fn UpdateNodes(
                                                 l,
                                                 l,
                                                 backward,
-                                                j.wrapping_add(1usize),
+                                                j.wrapping_add(1),
                                                 cost
                                             );
                                             result = brotli_max_size_t(result,l);
                                         }
                                         best_len = l;
                                     }
-                                    l = l.wrapping_add(1 as usize);
+                                    l = l.wrapping_add(1);
                                 }
                             }
                         }
                         break;
                     }
-                    j = j.wrapping_add(1 as usize);
+                    j = j.wrapping_add(1);
                 }
                 if k >= 2usize {
                     break 'continue28;
@@ -1590,7 +1590,7 @@ unsafe extern fn UpdateNodes(
                                   };
                             let mut dist_code
                                 : usize
-                                = dist.wrapping_add(16usize).wrapping_sub(
+                                = dist.wrapping_add(16).wrapping_sub(
                                       1usize
                                   );
                             let mut dist_symbol : u16;
@@ -1653,16 +1653,16 @@ unsafe extern fn UpdateNodes(
                                         result = brotli_max_size_t(result,len);
                                     }
                                 }
-                                len = len.wrapping_add(1 as usize);
+                                len = len.wrapping_add(1);
                             }
                         }
-                        j = j.wrapping_add(1 as usize);
+                        j = j.wrapping_add(1);
                     }
                 }
             }
             break;
         }
-        k = k.wrapping_add(1 as usize);
+        k = k.wrapping_add(1);
     }
     result
 }
@@ -1676,7 +1676,7 @@ unsafe extern fn StoreH10(
     let mut self : *mut H10 = SelfH10(handle);
     let max_backward
         : usize
-        = (*self).window_mask_.wrapping_sub(16usize).wrapping_add(
+        = (*self).window_mask_.wrapping_sub(16).wrapping_add(
               1usize
           );
     StoreAndFindMatchesH10(
@@ -1700,22 +1700,22 @@ unsafe extern fn StoreRangeH10(
 ) {
     let mut i : usize = ix_start;
     let mut j : usize = ix_start;
-    if ix_start.wrapping_add(63usize) <= ix_end {
-        i = ix_end.wrapping_sub(63usize);
+    if ix_start.wrapping_add(63) <= ix_end {
+        i = ix_end.wrapping_sub(63);
     }
-    if ix_start.wrapping_add(512usize) <= i {
+    if ix_start.wrapping_add(512) <= i {
         while j < i {
             {
                 StoreH10(handle,data,mask,j);
             }
-            j = j.wrapping_add(8usize);
+            j = j.wrapping_add(8);
         }
     }
     while i < ix_end {
         {
             StoreH10(handle,data,mask,i);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -1755,7 +1755,7 @@ unsafe extern fn ComputeShortestPathFromNodes(
             )).dcode_insert_length & 0x7ffffffu32 == 0u32 && ((*nodes.offset(
                                                                                       index as isize
                                                                                   )).length == 1u32) {
-        index = index.wrapping_sub(1 as usize);
+        index = index.wrapping_sub(1);
     }
     (*nodes.offset(index as isize)).u.next = !(0u32);
     while index != 0usize {
@@ -1768,7 +1768,7 @@ unsafe extern fn ComputeShortestPathFromNodes(
               ) as usize;
         index = index.wrapping_sub(len);
         (*nodes.offset(index as isize)).u.next = len as u32;
-        num_commands = num_commands.wrapping_add(1 as usize);
+        num_commands = num_commands.wrapping_add(1);
     }
     num_commands
 }
@@ -1804,8 +1804,8 @@ pub unsafe extern fn BrotliZopfliComputeShortestPath(
     let mut i : usize;
     let mut gap : usize = 0usize;
     let mut lz_matches_offset : usize = 0usize;
-    (*nodes.offset(0isize)).length = 0u32;
-    (*nodes.offset(0isize)).u.cost = 0 as f32;
+    (*nodes.offset(0)).length = 0u32;
+    (*nodes.offset(0)).u.cost = 0 as f32;
     InitZopfliCostModel(
         m,
         &mut model as (*mut ZopfliCostModel),
@@ -1855,7 +1855,7 @@ pub unsafe extern fn BrotliZopfliComputeShortestPath(
                                                                ) as isize
                                                            ) as (*mut BackwardMatch) as (*const BackwardMatch)
                                                  ) > max_zopfli_len) {
-                *matches.offset(0isize) = *matches.offset(
+                *matches.offset(0) = *matches.offset(
                                                         num_matches.wrapping_sub(
                                                             1usize
                                                         ) as isize
@@ -1899,12 +1899,12 @@ pub unsafe extern fn BrotliZopfliComputeShortestPath(
                     hasher,
                     ringbuffer,
                     ringbuffer_mask,
-                    pos.wrapping_add(1usize),
+                    pos.wrapping_add(1),
                     brotli_min_size_t(pos.wrapping_add(skip),store_end)
                 );
-                skip = skip.wrapping_sub(1 as usize);
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as usize);
+                    i = i.wrapping_add(1);
                     if i.wrapping_add(HashTypeLengthH10()).wrapping_sub(
                            1usize
                        ) >= num_bytes {
@@ -1920,11 +1920,11 @@ pub unsafe extern fn BrotliZopfliComputeShortestPath(
                         &mut queue as (*mut StartPosQueue),
                         nodes
                     );
-                    skip = skip.wrapping_sub(1 as usize);
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     CleanupZopfliCostModel(m,&mut model as (*mut ZopfliCostModel));
     ComputeShortestPathFromNodes(num_bytes,nodes)
@@ -1956,7 +1956,7 @@ pub unsafe extern fn BrotliCreateZopfliBackwardReferences(
                ) > 0usize {
                 BrotliAllocate(
                     m,
-                    num_bytes.wrapping_add(1usize).wrapping_mul(
+                    num_bytes.wrapping_add(1).wrapping_mul(
                         core::mem::size_of::<ZopfliNode>()
                     )
                 ) as (*mut ZopfliNode)
@@ -1968,7 +1968,7 @@ pub unsafe extern fn BrotliCreateZopfliBackwardReferences(
     }
     BrotliInitZopfliNodes(
         nodes,
-        num_bytes.wrapping_add(1usize)
+        num_bytes.wrapping_add(1)
     );
     *num_commands = (*num_commands).wrapping_add(
                         BrotliZopfliComputeShortestPath(
@@ -2024,7 +2024,7 @@ unsafe extern fn SetCost(
         {
             sum = sum.wrapping_add(*histogram.offset(i as isize) as usize);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     log2sum = FastLog2(sum) as (f32);
     missing_symbol_sum = sum;
@@ -2033,10 +2033,10 @@ unsafe extern fn SetCost(
         while i < histogram_size {
             {
                 if *histogram.offset(i as isize) == 0u32 {
-                    missing_symbol_sum = missing_symbol_sum.wrapping_add(1 as usize);
+                    missing_symbol_sum = missing_symbol_sum.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as usize);
+            i = i.wrapping_add(1);
         }
     }
     missing_symbol_cost = FastLog2(
@@ -2061,7 +2061,7 @@ unsafe extern fn SetCost(
             }
             break;
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -2145,11 +2145,11 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
                                 );
                     *_lhs = (*_lhs).wrapping_add(_rhs as u32);
                 }
-                j = j.wrapping_add(1 as usize);
+                j = j.wrapping_add(1);
             }
             pos = pos.wrapping_add(inslength.wrapping_add(copylength));
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     SetCost(
         histogram_literal as (*const u32),
@@ -2177,14 +2177,14 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
                                *cost_cmd.offset(i as isize)
                            );
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     (*self).min_cost_cmd_ = min_cost_cmd;
     {
         let mut literal_costs : *mut f32 = (*self).literal_costs_;
         let mut literal_carry : f32 = 0.0f64 as (f32);
         let mut num_bytes : usize = (*self).num_bytes_;
-        *literal_costs.offset(0isize) = 0.0f64 as (f32);
+        *literal_costs.offset(0) = 0.0f64 as (f32);
         i = 0usize;
         while i < num_bytes {
             {
@@ -2196,13 +2196,13 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
                                                       ) as isize
                                                  );
                 *literal_costs.offset(
-                     i.wrapping_add(1usize) as isize
+                     i.wrapping_add(1) as isize
                  ) = *literal_costs.offset(i as isize) + literal_carry;
                 literal_carry = literal_carry - (*literal_costs.offset(
-                                                      i.wrapping_add(1usize) as isize
+                                                      i.wrapping_add(1) as isize
                                                   ) - *literal_costs.offset(i as isize));
             }
-            i = i.wrapping_add(1 as usize);
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -2225,11 +2225,11 @@ unsafe extern fn ZopfliIterate(
     let mut queue : StartPosQueue;
     let mut cur_match_pos : usize = 0usize;
     let mut i : usize;
-    (*nodes.offset(0isize)).length = 0u32;
-    (*nodes.offset(0isize)).u.cost = 0 as f32;
+    (*nodes.offset(0)).length = 0u32;
+    (*nodes.offset(0)).u.cost = 0 as f32;
     InitStartPosQueue(&mut queue as (*mut StartPosQueue));
     i = 0usize;
-    while i.wrapping_add(3usize) < num_bytes {
+    while i.wrapping_add(3) < num_bytes {
         {
             let mut skip
                 : usize
@@ -2268,17 +2268,17 @@ unsafe extern fn ZopfliIterate(
                 skip = brotli_max_size_t(
                            BackwardMatchLength(
                                &*matches.offset(
-                                     cur_match_pos.wrapping_sub(1usize) as isize
+                                     cur_match_pos.wrapping_sub(1) as isize
                                  ) as (*const BackwardMatch)
                            ),
                            skip
                        );
             }
             if skip > 1usize {
-                skip = skip.wrapping_sub(1 as usize);
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as usize);
-                    if i.wrapping_add(3usize) >= num_bytes {
+                    i = i.wrapping_add(1);
+                    if i.wrapping_add(3) >= num_bytes {
                         break;
                     }
                     EvaluateNode(
@@ -2294,11 +2294,11 @@ unsafe extern fn ZopfliIterate(
                     cur_match_pos = cur_match_pos.wrapping_add(
                                         *num_matches.offset(i as isize) as usize
                                     );
-                    skip = skip.wrapping_sub(1 as usize);
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     ComputeShortestPathFromNodes(num_bytes,nodes)
 }
@@ -2392,7 +2392,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                     let mut _new_size
                         : usize
                         = if matches_size == 0usize {
-                              cur_match_pos.wrapping_add(128usize).wrapping_add(
+                              cur_match_pos.wrapping_add(128).wrapping_add(
                                   shadow_matches
                               )
                           } else {
@@ -2404,7 +2404,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                                       ).wrapping_add(
                                           shadow_matches
                                       ) {
-                        _new_size = _new_size.wrapping_mul(2usize);
+                        _new_size = _new_size.wrapping_mul(2);
                     }
                     new_array = if _new_size > 0usize {
                                     BrotliAllocate(
@@ -2448,9 +2448,9 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                                 );
             cur_match_end = cur_match_pos.wrapping_add(num_found_matches);
             j = cur_match_pos;
-            while j.wrapping_add(1usize) < cur_match_end {
+            while j.wrapping_add(1) < cur_match_end {
                 { }
-                j = j.wrapping_add(1 as usize);
+                j = j.wrapping_add(1);
             }
             *num_matches.offset(i as isize) = num_found_matches as u32;
             if num_found_matches > 0usize {
@@ -2458,31 +2458,31 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                     : usize
                     = BackwardMatchLength(
                           &mut *matches.offset(
-                                    cur_match_end.wrapping_sub(1usize) as isize
+                                    cur_match_end.wrapping_sub(1) as isize
                                 ) as (*mut BackwardMatch) as (*const BackwardMatch)
                       );
                 if match_len > 325usize {
-                    let skip : usize = match_len.wrapping_sub(1usize);
+                    let skip : usize = match_len.wrapping_sub(1);
                     *matches.offset(
                          {
                              let _old = cur_match_pos;
-                             cur_match_pos = cur_match_pos.wrapping_add(1 as usize);
+                             cur_match_pos = cur_match_pos.wrapping_add(1);
                              _old
                          } as isize
                      ) = *matches.offset(
-                              cur_match_end.wrapping_sub(1usize) as isize
+                              cur_match_end.wrapping_sub(1) as isize
                           );
                     *num_matches.offset(i as isize) = 1u32;
                     StoreRangeH10(
                         hasher,
                         ringbuffer,
                         ringbuffer_mask,
-                        pos.wrapping_add(1usize),
+                        pos.wrapping_add(1),
                         brotli_min_size_t(pos.wrapping_add(match_len),store_end)
                     );
                     memset(
                         &mut *num_matches.offset(
-                                  i.wrapping_add(1usize) as isize
+                                  i.wrapping_add(1) as isize
                               ) as (*mut u32) as (*mut std::os::raw::c_void),
                         0i32,
                         skip.wrapping_mul(core::mem::size_of::<u32>())
@@ -2493,7 +2493,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     orig_num_literals = *num_literals;
     orig_last_insert_len = *last_insert_len;
@@ -2508,7 +2508,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                ) > 0usize {
                 BrotliAllocate(
                     m,
-                    num_bytes.wrapping_add(1usize).wrapping_mul(
+                    num_bytes.wrapping_add(1).wrapping_mul(
                         core::mem::size_of::<ZopfliNode>()
                     )
                 ) as (*mut ZopfliNode)
@@ -2532,7 +2532,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
         {
             BrotliInitZopfliNodes(
                 nodes,
-                num_bytes.wrapping_add(1usize)
+                num_bytes.wrapping_add(1)
             );
             if i == 0usize {
                 ZopfliCostModelSetFromLiteralCosts(
@@ -2588,7 +2588,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                 num_literals
             );
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     CleanupZopfliCostModel(m,&mut model as (*mut ZopfliCostModel));
     {

--- a/corrosion/backward_references_hq_safe.rs
+++ b/corrosion/backward_references_hq_safe.rs
@@ -128,7 +128,7 @@ pub fn BrotliInitZopfliNodes(
     i = 0usize;
     while i < length {
         array[(i as usize) ]= stub;
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -220,7 +220,7 @@ fn ZopfliNodeLengthCode(
     mut xself : & ZopfliNode
 ) -> u32 {
     let modifier : u32 = (*xself).length >> 25i32;
-    ZopfliNodeCopyLength(xself).wrapping_add(9u32).wrapping_sub(
+    ZopfliNodeCopyLength(xself).wrapping_add(9).wrapping_sub(
         modifier
     )
 }
@@ -242,7 +242,7 @@ fn ZopfliNodeDistanceCode(
             1u32
         )
     } else {
-        short_code.wrapping_sub(1u32)
+        short_code.wrapping_sub(1)
     }
 }
 
@@ -252,7 +252,7 @@ fn Log2FloorNonZero(mut n : usize) -> u32 {
               n = n >> 1i32;
               n
           } != 0 {
-        result = result.wrapping_add(1 as u32);
+        result = result.wrapping_add(1);
     }
     result
 }
@@ -274,16 +274,16 @@ fn PrefixEncodeCopyDistance(
             = (1 << postfix_bits.wrapping_add(
                                       2u32 as usize
                                   )).wrapping_add(
-                  distance_code.wrapping_sub(16usize).wrapping_sub(
+                  distance_code.wrapping_sub(16).wrapping_sub(
                       num_direct_codes
                   )
               );
         let mut bucket
             : usize
-            = Log2FloorNonZero(dist).wrapping_sub(1u32) as usize;
+            = Log2FloorNonZero(dist).wrapping_sub(1) as usize;
         let mut postfix_mask
             : usize
-            = (1u32 << postfix_bits).wrapping_sub(1u32) as usize;
+            = (1u32 << postfix_bits).wrapping_sub(1) as usize;
         let mut postfix : usize = dist & postfix_mask;
         let mut prefix : usize = dist >> bucket & 1;
         let mut offset
@@ -314,18 +314,18 @@ fn GetInsertLengthCode(
         let mut nbits
             : u32
             = Log2FloorNonZero(
-                  insertlen.wrapping_sub(2usize)
+                  insertlen.wrapping_sub(2)
               ).wrapping_sub(
                   1u32
               );
         ((nbits << 1i32) as usize).wrapping_add(
-            insertlen.wrapping_sub(2usize) >> nbits
+            insertlen.wrapping_sub(2) >> nbits
         ).wrapping_add(
             2usize
         ) as u16
     } else if insertlen < 2114usize {
         Log2FloorNonZero(
-            insertlen.wrapping_sub(66usize)
+            insertlen.wrapping_sub(66)
         ).wrapping_add(
             10u32
         ) as u16
@@ -340,23 +340,23 @@ fn GetInsertLengthCode(
 
 fn GetCopyLengthCode(mut copylen : usize) -> u16 {
     if copylen < 10usize {
-        copylen.wrapping_sub(2usize) as u16
+        copylen.wrapping_sub(2) as u16
     } else if copylen < 134usize {
         let mut nbits
             : u32
             = Log2FloorNonZero(
-                  copylen.wrapping_sub(6usize)
+                  copylen.wrapping_sub(6)
               ).wrapping_sub(
                   1u32
               );
         ((nbits << 1i32) as usize).wrapping_add(
-            copylen.wrapping_sub(6usize) >> nbits
+            copylen.wrapping_sub(6) >> nbits
         ).wrapping_add(
             4usize
         ) as u16
     } else if copylen < 2118usize {
         Log2FloorNonZero(
-            copylen.wrapping_sub(70usize)
+            copylen.wrapping_sub(70)
         ).wrapping_add(
             12u32
         ) as u16
@@ -440,7 +440,7 @@ pub fn BrotliZopfliCreateCommands(
     mut num_literals : &mut [usize
 ]) {
     let mut pos : usize = 0usize;
-    let mut offset : u32 = (nodes[(0)]).u.next;
+    let mut offset : u32 = (nodes[0]).u.next;
     let mut i : usize;
     let mut gap : usize = 0usize;
     i = 0usize;
@@ -506,7 +506,7 @@ pub fn BrotliZopfliCreateCommands(
             *num_literals = (*num_literals).wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     *last_insert_len = (*last_insert_len).wrapping_add(
                            num_bytes.wrapping_sub(pos)
@@ -583,7 +583,7 @@ fn InitZopfliCostModel(
                                 ) > 0usize {
                                  BrotliAllocate(
                                      m,
-                                     num_bytes.wrapping_add(2usize).wrapping_mul(
+                                     num_bytes.wrapping_add(2).wrapping_mul(
                                          core::mem::size_of::<f32>()
                                      )
                                  ) 
@@ -646,7 +646,7 @@ fn ZopfliCostModelSetFromLiteralCosts(
                                                   i.wrapping_add(1) as usize
                                               ) ]- literal_costs[(i as usize)]);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < 704usize {
@@ -657,7 +657,7 @@ fn ZopfliCostModelSetFromLiteralCosts(
                                                  ) as usize
                                              ) as (f32);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     i = 0usize;
     while i < (*xself).distance_histogram_size as usize {
@@ -668,7 +668,7 @@ fn ZopfliCostModelSetFromLiteralCosts(
                                                   ) as usize
                                               ) as (f32);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     (*xself).min_cost_cmd_ = FastLog2(11) as (f32);
 }
@@ -691,7 +691,7 @@ fn FindMatchLengthWithLimit(
         : usize
         = (limit >> 3i32).wrapping_add(1);
     while {
-              limit2 = limit2.wrapping_sub(1 as usize);
+              limit2 = limit2.wrapping_sub(1);
               limit2
           } != 0 {
         if BrotliUnalignedRead64(
@@ -699,8 +699,8 @@ fn FindMatchLengthWithLimit(
            ) == BrotliUnalignedRead64(
                     s1[(matched as usize) ..]
                 ) {
-            s2 = s2[(8usize)..];
-            matched = matched.wrapping_add(8usize);
+            s2 = s2[8..];
+            matched = matched.wrapping_add(8);
         } else {
             let mut x
                 : usize
@@ -716,12 +716,12 @@ fn FindMatchLengthWithLimit(
     }
     limit = (limit & 7usize).wrapping_add(1);
     while {
-              limit = limit.wrapping_sub(1 as usize);
+              limit = limit.wrapping_sub(1);
               limit
           } != 0 {
         if s1[(matched as usize) ]as i32 == *s2 as i32 {
             s2 = s2[(1 as usize)..];
-            matched = matched.wrapping_add(1 as usize);
+            matched = matched.wrapping_add(1);
         } else {
             return matched;
         }
@@ -893,7 +893,7 @@ fn StoreAndFindMatchesH10(
                 }
             }
         }
-        depth_remaining = depth_remaining.wrapping_sub(1 as usize);
+        depth_remaining = depth_remaining.wrapping_sub(1);
     }
     matches
 }
@@ -1016,7 +1016,7 @@ fn FindAllMatchesH10(
             }
             break;
         }
-        i = i.wrapping_sub(1 as usize);
+        i = i.wrapping_sub(1);
     }
     if best_len < max_length {
         matches = StoreAndFindMatchesH10(
@@ -1035,7 +1035,7 @@ fn FindAllMatchesH10(
         {
             dict_matches[(i as usize) ]= kInvalidMatch;
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     {
         let mut minlen
@@ -1081,7 +1081,7 @@ fn FindAllMatchesH10(
                         }
                     }
                 }
-                l = l.wrapping_add(1 as usize);
+                l = l.wrapping_add(1);
             }
         }
     }
@@ -1217,7 +1217,7 @@ fn StartPosQueuePush(
         : usize
         = !{
                let _old = (*xself).idx_;
-               (*xself).idx_ = (*xself).idx_.wrapping_add(1 as usize);
+               (*xself).idx_ = (*xself).idx_.wrapping_add(1);
                _old
            } & 7usize;
     let mut len
@@ -1248,9 +1248,9 @@ fn StartPosQueuePush(
                      (offset.wrapping_add(1) & 7usize) as usize
                  ) ]= __brotli_swap_tmp;
             }
-            offset = offset.wrapping_add(1 as usize);
+            offset = offset.wrapping_add(1);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -1327,11 +1327,11 @@ fn ComputeMinimumCopyLength(
     while pos.wrapping_add(len) <= num_bytes && ((nodes[(
                                                        pos.wrapping_add(len) as usize
                                                    )]).u.cost <= min_cost) {
-        len = len.wrapping_add(1 as usize);
+        len = len.wrapping_add(1);
         if len == next_len_offset {
             min_cost = min_cost + 1.0f32;
             next_len_offset = next_len_offset.wrapping_add(next_len_bucket);
-            next_len_bucket = next_len_bucket.wrapping_mul(2usize);
+            next_len_bucket = next_len_bucket.wrapping_mul(2);
         }
     }
     len
@@ -1558,13 +1558,13 @@ fn UpdateNodes(
                                         }
                                         best_len = l;
                                     }
-                                    l = l.wrapping_add(1 as usize);
+                                    l = l.wrapping_add(1);
                                 }
                             }
                         }
                         break;
                     }
-                    j = j.wrapping_add(1 as usize);
+                    j = j.wrapping_add(1);
                 }
                 if k >= 2usize {
                     break 'continue28;
@@ -1585,7 +1585,7 @@ fn UpdateNodes(
                                   };
                             let mut dist_code
                                 : usize
-                                = dist.wrapping_add(16usize).wrapping_sub(
+                                = dist.wrapping_add(16).wrapping_sub(
                                       1
                                   );
                             let mut dist_symbol : u16;
@@ -1648,16 +1648,16 @@ fn UpdateNodes(
                                         result = brotli_max_size_t(result,len);
                                     }
                                 }
-                                len = len.wrapping_add(1 as usize);
+                                len = len.wrapping_add(1);
                             }
                         }
-                        j = j.wrapping_add(1 as usize);
+                        j = j.wrapping_add(1);
                     }
                 }
             }
             break;
         }
-        k = k.wrapping_add(1 as usize);
+        k = k.wrapping_add(1);
     }
     result
 }
@@ -1671,7 +1671,7 @@ fn StoreH10(
     let mut xself : *mut H10 = SelfH10(handle);
     let max_backward
         : usize
-        = (*xself).window_mask_.wrapping_sub(16usize).wrapping_add(
+        = (*xself).window_mask_.wrapping_sub(16).wrapping_add(
               1
           );
     StoreAndFindMatchesH10(
@@ -1695,22 +1695,22 @@ fn StoreRangeH10(
 ) {
     let mut i : usize = ix_start;
     let mut j : usize = ix_start;
-    if ix_start.wrapping_add(63usize) <= ix_end {
-        i = ix_end.wrapping_sub(63usize);
+    if ix_start.wrapping_add(63) <= ix_end {
+        i = ix_end.wrapping_sub(63);
     }
-    if ix_start.wrapping_add(512usize) <= i {
+    if ix_start.wrapping_add(512) <= i {
         while j < i {
             {
                 StoreH10(handle,data,mask,j);
             }
-            j = j.wrapping_add(8usize);
+            j = j.wrapping_add(8);
         }
     }
     while i < ix_end {
         {
             StoreH10(handle,data,mask,i);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -1750,7 +1750,7 @@ fn ComputeShortestPathFromNodes(
             )]).dcode_insert_length & 0x7ffffffu32 == 0u32 && ((nodes[(
                                                                                       index as usize
                                                                                   )]).length == 1u32) {
-        index = index.wrapping_sub(1 as usize);
+        index = index.wrapping_sub(1);
     }
     (nodes[(index as usize)]).u.next = !(0u32);
     while index != 0usize {
@@ -1763,7 +1763,7 @@ fn ComputeShortestPathFromNodes(
               ) as usize;
         index = index.wrapping_sub(len);
         (nodes[(index as usize)]).u.next = len as u32;
-        num_commands = num_commands.wrapping_add(1 as usize);
+        num_commands = num_commands.wrapping_add(1);
     }
     num_commands
 }
@@ -1799,8 +1799,8 @@ pub fn BrotliZopfliComputeShortestPath(
     let mut i : usize;
     let mut gap : usize = 0usize;
     let mut lz_matches_offset : usize = 0usize;
-    (nodes[(0)]).length = 0u32;
-    (nodes[(0)]).u.cost = 0 as f32;
+    (nodes[0]).length = 0u32;
+    (nodes[0]).u.cost = 0 as f32;
     InitZopfliCostModel(
         m,
         &mut model ,
@@ -1897,9 +1897,9 @@ pub fn BrotliZopfliComputeShortestPath(
                     pos.wrapping_add(1),
                     brotli_min_size_t(pos.wrapping_add(skip),store_end)
                 );
-                skip = skip.wrapping_sub(1 as usize);
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as usize);
+                    i = i.wrapping_add(1);
                     if i.wrapping_add(HashTypeLengthH10()).wrapping_sub(
                            1
                        ) >= num_bytes {
@@ -1915,11 +1915,11 @@ pub fn BrotliZopfliComputeShortestPath(
                         &mut queue ,
                         nodes
                     );
-                    skip = skip.wrapping_sub(1 as usize);
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     CleanupZopfliCostModel(m,&mut model );
     ComputeShortestPathFromNodes(num_bytes,nodes)
@@ -2019,7 +2019,7 @@ fn SetCost(
         {
             sum = sum.wrapping_add(histogram[(i as usize) ]as usize);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     log2sum = FastLog2(sum) as (f32);
     missing_symbol_sum = sum;
@@ -2028,10 +2028,10 @@ fn SetCost(
         while i < histogram_size {
             {
                 if histogram[(i as usize) ]== 0u32 {
-                    missing_symbol_sum = missing_symbol_sum.wrapping_add(1 as usize);
+                    missing_symbol_sum = missing_symbol_sum.wrapping_add(1);
                 }
             }
-            i = i.wrapping_add(1 as usize);
+            i = i.wrapping_add(1);
         }
     }
     missing_symbol_cost = FastLog2(
@@ -2056,7 +2056,7 @@ fn SetCost(
             }
             break;
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
 }
 
@@ -2140,11 +2140,11 @@ fn ZopfliCostModelSetFromCommands(
                                 )];
                     *_lhs = (*_lhs).wrapping_add(_rhs as u32);
                 }
-                j = j.wrapping_add(1 as usize);
+                j = j.wrapping_add(1);
             }
             pos = pos.wrapping_add(inslength.wrapping_add(copylength));
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     SetCost(
         histogram_literal ,
@@ -2171,7 +2171,7 @@ fn ZopfliCostModelSetFromCommands(
                                min_cost_cmd,
                                cost_cmd[(i as usize)]);
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     (*xself).min_cost_cmd_ = min_cost_cmd;
     {
@@ -2196,7 +2196,7 @@ fn ZopfliCostModelSetFromCommands(
                                                       i.wrapping_add(1) as usize
                                                   ) ]- literal_costs[(i as usize)]);
             }
-            i = i.wrapping_add(1 as usize);
+            i = i.wrapping_add(1);
         }
     }
 }
@@ -2219,11 +2219,11 @@ fn ZopfliIterate(
     let mut queue : StartPosQueue;
     let mut cur_match_pos : usize = 0usize;
     let mut i : usize;
-    (nodes[(0)]).length = 0u32;
-    (nodes[(0)]).u.cost = 0 as f32;
+    (nodes[0]).length = 0u32;
+    (nodes[0]).u.cost = 0 as f32;
     InitStartPosQueue(&mut queue );
     i = 0usize;
-    while i.wrapping_add(3usize) < num_bytes {
+    while i.wrapping_add(3) < num_bytes {
         {
             let mut skip
                 : usize
@@ -2269,10 +2269,10 @@ fn ZopfliIterate(
                        );
             }
             if skip > 1 {
-                skip = skip.wrapping_sub(1 as usize);
+                skip = skip.wrapping_sub(1);
                 while skip != 0 {
-                    i = i.wrapping_add(1 as usize);
-                    if i.wrapping_add(3usize) >= num_bytes {
+                    i = i.wrapping_add(1);
+                    if i.wrapping_add(3) >= num_bytes {
                         break;
                     }
                     EvaluateNode(
@@ -2288,11 +2288,11 @@ fn ZopfliIterate(
                     cur_match_pos = cur_match_pos.wrapping_add(
                                         num_matches[(i as usize) ]as usize
                                     );
-                    skip = skip.wrapping_sub(1 as usize);
+                    skip = skip.wrapping_sub(1);
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     ComputeShortestPathFromNodes(num_bytes,nodes)
 }
@@ -2386,7 +2386,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                     let mut _new_size
                         : usize
                         = if matches_size == 0usize {
-                              cur_match_pos.wrapping_add(128usize).wrapping_add(
+                              cur_match_pos.wrapping_add(128).wrapping_add(
                                   shadow_matches
                               )
                           } else {
@@ -2398,7 +2398,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                                       ).wrapping_add(
                                           shadow_matches
                                       ) {
-                        _new_size = _new_size.wrapping_mul(2usize);
+                        _new_size = _new_size.wrapping_mul(2);
                     }
                     new_array = if _new_size > 0usize {
                                     BrotliAllocate(
@@ -2444,7 +2444,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
             j = cur_match_pos;
             while j.wrapping_add(1) < cur_match_end {
                 { }
-                j = j.wrapping_add(1 as usize);
+                j = j.wrapping_add(1);
             }
             num_matches[(i as usize) ]= num_found_matches as u32;
             if num_found_matches > 0usize {
@@ -2460,7 +2460,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                     matches[(
                          {
                              let _old = cur_match_pos;
-                             cur_match_pos = cur_match_pos.wrapping_add(1 as usize);
+                             cur_match_pos = cur_match_pos.wrapping_add(1);
                              _old
                          } as usize
                      ) ]= matches[(
@@ -2487,7 +2487,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                 }
             }
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     orig_num_literals = *num_literals;
     orig_last_insert_len = *last_insert_len;
@@ -2582,7 +2582,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                 num_literals
             );
         }
-        i = i.wrapping_add(1 as usize);
+        i = i.wrapping_add(1);
     }
     CleanupZopfliCostModel(m,&mut model );
     {

--- a/src/enc/backward_references/benchmark.rs
+++ b/src/enc/backward_references/benchmark.rs
@@ -44,7 +44,7 @@ fn make_generic_hasher() -> AdvHasher<H5Sub, StandardAlloc> {
             hash_shift_: 32i32 - params_hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
             block_bits_: params_hasher.block_bits as i32,
-            block_mask_: block_size.wrapping_sub(1u64) as u32,
+            block_mask_: block_size.wrapping_sub(1) as u32,
         },
     }
 }

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -272,7 +272,7 @@ where
     }
     #[inline(always)]
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
-        let max_backward: usize = self.window_mask_.wrapping_sub(16usize).wrapping_add(1);
+        let max_backward: usize = self.window_mask_.wrapping_sub(16).wrapping_add(1);
         StoreAndFindMatchesH10(
             self,
             data,
@@ -287,15 +287,15 @@ where
     fn StoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
         let mut i: usize = ix_start;
         let mut j: usize = ix_start;
-        if ix_start.wrapping_add(63usize) <= ix_end {
-            i = ix_end.wrapping_sub(63usize);
+        if ix_start.wrapping_add(63) <= ix_end {
+            i = ix_end.wrapping_sub(63);
         }
-        if ix_start.wrapping_add(512usize) <= i {
+        if ix_start.wrapping_add(512) <= i {
             while j < i {
                 {
                     self.Store(data, mask, j);
                 }
-                j = j.wrapping_add(8usize);
+                j = j.wrapping_add(8);
             }
         }
         while i < ix_end {

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -80,7 +80,7 @@ fn ZopfliNodeCopyDistance(xself: &ZopfliNode) -> u32 {
 fn ZopfliNodeLengthCode(xself: &ZopfliNode) -> u32 {
     let modifier: u32 = xself.length >> 25i32;
     ZopfliNodeCopyLength(xself)
-        .wrapping_add(9u32)
+        .wrapping_add(9)
         .wrapping_sub(modifier)
 }
 
@@ -94,10 +94,10 @@ fn ZopfliNodeDistanceCode(xself: &ZopfliNode) -> u32 {
     let short_code: u32 = xself.dcode_insert_length >> 27i32;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(xself)
-            .wrapping_add(16u32)
-            .wrapping_sub(1u32)
+            .wrapping_add(16)
+            .wrapping_sub(1)
     } else {
-        short_code.wrapping_sub(1u32)
+        short_code.wrapping_sub(1)
     }
 }
 
@@ -113,7 +113,7 @@ pub fn BrotliZopfliCreateCommands(
     num_literals: &mut usize,
 ) {
     let mut pos: usize = 0usize;
-    let mut offset: u32 = match (nodes[(0)]).u {
+    let mut offset: u32 = match (nodes[0]).u {
         Union1::next(off) => off,
         _ => 0,
     };
@@ -154,10 +154,10 @@ pub fn BrotliZopfliCreateCommands(
                     dist_code,
                 );
                 if is_dictionary == 0 && (dist_code > 0usize) {
-                    dist_cache[(3usize)] = dist_cache[(2usize)];
-                    dist_cache[(2usize)] = dist_cache[(1usize)];
-                    dist_cache[(1usize)] = dist_cache[(0)];
-                    dist_cache[(0)] = distance as i32;
+                    dist_cache[3] = dist_cache[2];
+                    dist_cache[2] = dist_cache[1];
+                    dist_cache[1] = dist_cache[0];
+                    dist_cache[0] = distance as i32;
                 }
             }
             *num_literals = (*num_literals).wrapping_add(insert_length);
@@ -228,8 +228,8 @@ fn InitZopfliCostModel<AllocF: alloc::Allocator<floatX>>(
         num_bytes_: num_bytes,
         cost_cmd_: [0.0; 704],
         min_cost_cmd_: 0.0,
-        literal_costs_: if num_bytes.wrapping_add(2usize) > 0usize {
-            m.alloc_cell(num_bytes.wrapping_add(2usize))
+        literal_costs_: if num_bytes.wrapping_add(2) > 0usize {
+            m.alloc_cell(num_bytes.wrapping_add(2))
         } else {
             AllocF::AllocatedMemory::default()
         },
@@ -258,18 +258,17 @@ fn ZopfliCostModelSetFromLiteralCosts<AllocF: Allocator<floatX>>(
         num_bytes,
         ringbuffer_mask,
         ringbuffer,
-        &mut literal_costs[1usize..],
+        &mut literal_costs[1..],
     );
-    literal_costs[(0)] = 0.0 as (floatX);
+    literal_costs[0] = 0.0 as (floatX);
     i = 0usize;
     while i < num_bytes {
         {
-            literal_carry =
-                literal_carry as floatX + literal_costs[i.wrapping_add(1usize)] as floatX;
-            literal_costs[i.wrapping_add(1usize)] =
+            literal_carry = literal_carry as floatX + literal_costs[i.wrapping_add(1)] as floatX;
+            literal_costs[i.wrapping_add(1)] =
                 (literal_costs[i] as floatX + literal_carry) as floatX;
             literal_carry -=
-                (literal_costs[i.wrapping_add(1usize)] as floatX - literal_costs[i] as floatX);
+                (literal_costs[i.wrapping_add(1)] as floatX - literal_costs[i] as floatX);
         }
         i = i.wrapping_add(1);
     }
@@ -392,7 +391,7 @@ where
     if cur_ix < short_match_max_backward {
         stop = 0usize;
     }
-    i = cur_ix.wrapping_sub(1usize);
+    i = cur_ix.wrapping_sub(1);
     'break14: while i > stop && (best_len <= 2usize) {
         'continue15: loop {
             {
@@ -403,8 +402,8 @@ where
                 }
                 prev_ix &= ring_buffer_mask;
                 if data[cur_ix_masked] as i32 != data[prev_ix] as i32
-                    || data[cur_ix_masked.wrapping_add(1usize)] as i32
-                        != data[prev_ix.wrapping_add(1usize)] as i32
+                    || data[cur_ix_masked.wrapping_add(1)] as i32
+                        != data[prev_ix.wrapping_add(1)] as i32
                 {
                     break 'continue15;
                 }
@@ -450,7 +449,7 @@ where
         i = i.wrapping_add(1);
     }
     {
-        let minlen: usize = brotli_max_size_t(4usize, best_len.wrapping_add(1usize));
+        let minlen: usize = brotli_max_size_t(4usize, best_len.wrapping_add(1));
         if dictionary.is_some()
             && BrotliFindAllStaticDictionaryMatches(
                 dictionary.unwrap(),
@@ -471,7 +470,7 @@ where
                         let distance: usize = max_backward
                             .wrapping_add(gap)
                             .wrapping_add((dict_id >> 5i32) as usize)
-                            .wrapping_add(1usize);
+                            .wrapping_add(1);
                         if distance <= params.dist.max_distance {
                             InitDictionaryBackwardMatch(
                                 &mut BackwardMatchMut(&mut matches[matches_offset]),
@@ -589,12 +588,10 @@ fn StartPosQueuePush(xself: &mut StartPosQueue, posdata: &PosData) {
     i = 1usize;
     while i < len {
         {
-            if (q[(offset & 7usize)]).costdiff
-                > (q[(offset.wrapping_add(1usize) & 7usize)]).costdiff
-            {
+            if (q[(offset & 7usize)]).costdiff > (q[(offset.wrapping_add(1) & 7usize)]).costdiff {
                 let mut __brotli_swap_tmp: PosData = q[(offset & 7usize)];
-                q[(offset & 7usize)] = q[(offset.wrapping_add(1usize) & 7usize)];
-                q[(offset.wrapping_add(1usize) & 7usize)] = __brotli_swap_tmp;
+                q[(offset & 7usize)] = q[(offset.wrapping_add(1) & 7usize)];
+                q[(offset.wrapping_add(1) & 7usize)] = __brotli_swap_tmp;
             }
             offset = offset.wrapping_add(1);
         }
@@ -673,7 +670,7 @@ fn ComputeMinimumCopyLength(
         if len == next_len_offset {
             min_cost += 1.0 as floatX;
             next_len_offset = next_len_offset.wrapping_add(next_len_bucket);
-            next_len_bucket = next_len_bucket.wrapping_mul(2usize);
+            next_len_bucket = next_len_bucket.wrapping_mul(2);
         }
     }
     len
@@ -785,7 +782,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                 let base_cost: floatX = start_costdiff
                     + GetInsertExtra(inscode) as (floatX)
                     + ZopfliCostModelGetLiteralCosts(model, 0usize, pos);
-                let mut best_len: usize = min_len.wrapping_sub(1usize);
+                let mut best_len: usize = min_len.wrapping_sub(1);
                 let mut j: usize = 0usize;
                 'break29: while j < 16usize && (best_len < max_len) {
                     'continue30: loop {
@@ -833,7 +830,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 let dist_cost: floatX =
                                     base_cost + ZopfliCostModelGetDistanceCost(model, j);
                                 let mut l: usize;
-                                l = best_len.wrapping_add(1usize);
+                                l = best_len.wrapping_add(1);
                                 while l <= len {
                                     {
                                         let copycode: u16 = GetCopyLengthCode(l);
@@ -861,7 +858,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                                 l,
                                                 l,
                                                 backward,
-                                                j.wrapping_add(1usize),
+                                                j.wrapping_add(1),
                                                 cost,
                                             );
                                             result = brotli_max_size_t(result, l);
@@ -892,7 +889,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                                 } else {
                                     0i32
                                 };
-                            let dist_code: usize = dist.wrapping_add(16usize).wrapping_sub(1usize);
+                            let dist_code: usize = dist.wrapping_add(16).wrapping_sub(1);
                             let mut dist_symbol: u16 = 0;
                             let mut distextra: u32 = 0;
 
@@ -1018,15 +1015,15 @@ where
         position
             .wrapping_add(num_bytes)
             .wrapping_sub(StoreLookaheadH10())
-            .wrapping_add(1usize)
+            .wrapping_add(1)
     } else {
         position
     };
     let mut i: usize;
     let gap: usize = 0usize;
     let lz_matches_offset: usize = 0usize;
-    (nodes[(0)]).length = 0u32;
-    (nodes[(0)]).u = Union1::cost(0.0);
+    (nodes[0]).length = 0u32;
+    (nodes[0]).u = Union1::cost(0.0);
     model = InitZopfliCostModel(m, &params.dist, num_bytes);
     if !(0i32 == 0) {
         return 0usize;
@@ -1034,7 +1031,7 @@ where
     ZopfliCostModelSetFromLiteralCosts(&mut model, position, ringbuffer, ringbuffer_mask);
     queue = InitStartPosQueue();
     i = 0usize;
-    while i.wrapping_add(handle.HashTypeLength()).wrapping_sub(1usize) < num_bytes {
+    while i.wrapping_add(handle.HashTypeLength()).wrapping_sub(1) < num_bytes {
         {
             let pos: usize = position.wrapping_add(i);
             let max_distance: usize = brotli_min_size_t(pos, max_backward_limit);
@@ -1052,10 +1049,10 @@ where
                 &mut matches[lz_matches_offset..],
             );
             if num_matches > 0usize
-                && (BackwardMatchLength(&BackwardMatch(matches[num_matches.wrapping_sub(1usize)]))
+                && (BackwardMatchLength(&BackwardMatch(matches[num_matches.wrapping_sub(1)]))
                     > max_zopfli_len)
             {
-                matches[(0)] = matches[num_matches.wrapping_sub(1usize)];
+                matches[0] = matches[num_matches.wrapping_sub(1)];
                 num_matches = 1usize;
             }
             skip = UpdateNodes(
@@ -1077,21 +1074,21 @@ where
                 skip = 0usize;
             }
             if num_matches == 1usize
-                && (BackwardMatchLength(&BackwardMatch(matches[(0)])) > max_zopfli_len)
+                && (BackwardMatchLength(&BackwardMatch(matches[0])) > max_zopfli_len)
             {
-                skip = brotli_max_size_t(BackwardMatchLength(&BackwardMatch(matches[(0)])), skip);
+                skip = brotli_max_size_t(BackwardMatchLength(&BackwardMatch(matches[0])), skip);
             }
             if skip > 1usize {
                 handle.StoreRange(
                     ringbuffer,
                     ringbuffer_mask,
-                    pos.wrapping_add(1usize),
+                    pos.wrapping_add(1),
                     brotli_min_size_t(pos.wrapping_add(skip), store_end),
                 );
                 skip = skip.wrapping_sub(1);
                 while skip != 0 {
                     i = i.wrapping_add(1);
-                    if i.wrapping_add(handle.HashTypeLength()).wrapping_sub(1usize) >= num_bytes {
+                    if i.wrapping_add(handle.HashTypeLength()).wrapping_sub(1) >= num_bytes {
                         break;
                     }
                     EvaluateNode(
@@ -1137,9 +1134,9 @@ pub fn BrotliCreateZopfliBackwardReferences<
 ) where
     Buckets: PartialEq<Buckets>,
 {
-    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16usize);
+    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16);
     let mut nodes: <Alloc as Allocator<ZopfliNode>>::AllocatedMemory;
-    nodes = if num_bytes.wrapping_add(1usize) > 0usize {
+    nodes = if num_bytes.wrapping_add(1) > 0usize {
         <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
     } else {
         <Alloc as Allocator<ZopfliNode>>::AllocatedMemory::default()
@@ -1147,7 +1144,7 @@ pub fn BrotliCreateZopfliBackwardReferences<
     if !(0i32 == 0) {
         return;
     }
-    BrotliInitZopfliNodes(nodes.slice_mut(), num_bytes.wrapping_add(1usize));
+    BrotliInitZopfliNodes(nodes.slice_mut(), num_bytes.wrapping_add(1));
     *num_commands = (*num_commands).wrapping_add(BrotliZopfliComputeShortestPath(
         alloc,
         dictionary,
@@ -1314,17 +1311,17 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
         let literal_costs: &mut [floatX] = xself.literal_costs_.slice_mut();
         let mut literal_carry: floatX = 0.0;
         let num_bytes: usize = xself.num_bytes_;
-        literal_costs[(0)] = 0.0 as (floatX);
+        literal_costs[0] = 0.0 as (floatX);
         i = 0usize;
         while i < num_bytes {
             {
                 literal_carry += cost_literal
                     [(ringbuffer[(position.wrapping_add(i) & ringbuffer_mask)] as usize)]
                     as floatX;
-                literal_costs[i.wrapping_add(1usize)] =
+                literal_costs[i.wrapping_add(1)] =
                     (literal_costs[i] as floatX + literal_carry) as floatX;
                 literal_carry -=
-                    (literal_costs[i.wrapping_add(1usize)] as floatX - literal_costs[i] as floatX);
+                    (literal_costs[i.wrapping_add(1)] as floatX - literal_costs[i] as floatX);
             }
             i = i.wrapping_add(1);
         }
@@ -1349,11 +1346,11 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
     let mut queue: StartPosQueue;
     let mut cur_match_pos: usize = 0usize;
     let mut i: usize;
-    (nodes[(0)]).length = 0u32;
-    (nodes[(0)]).u = Union1::cost(0.0);
+    (nodes[0]).length = 0u32;
+    (nodes[0]).u = Union1::cost(0.0);
     queue = InitStartPosQueue();
     i = 0usize;
-    while i.wrapping_add(3usize) < num_bytes {
+    while i.wrapping_add(3) < num_bytes {
         {
             let mut skip: usize = UpdateNodes(
                 num_bytes,
@@ -1375,14 +1372,11 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
             }
             cur_match_pos = cur_match_pos.wrapping_add(num_matches[i] as usize);
             if num_matches[i] == 1u32
-                && (BackwardMatchLength(&BackwardMatch(
-                    matches[cur_match_pos.wrapping_sub(1usize)],
-                )) > max_zopfli_len)
+                && (BackwardMatchLength(&BackwardMatch(matches[cur_match_pos.wrapping_sub(1)]))
+                    > max_zopfli_len)
             {
                 skip = brotli_max_size_t(
-                    BackwardMatchLength(&BackwardMatch(
-                        matches[cur_match_pos.wrapping_sub(1usize)],
-                    )),
+                    BackwardMatchLength(&BackwardMatch(matches[cur_match_pos.wrapping_sub(1)])),
                     skip,
                 );
             }
@@ -1390,7 +1384,7 @@ fn ZopfliIterate<AllocF: Allocator<floatX>>(
                 skip = skip.wrapping_sub(1);
                 while skip != 0 {
                     i = i.wrapping_add(1);
-                    if i.wrapping_add(3usize) >= num_bytes {
+                    if i.wrapping_add(3) >= num_bytes {
                         break;
                     }
                     EvaluateNode(
@@ -1434,7 +1428,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
 ) where
     Buckets: PartialEq<Buckets>,
 {
-    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16usize);
+    let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16);
     let mut num_matches: <Alloc as Allocator<u32>>::AllocatedMemory = if num_bytes > 0usize {
         <Alloc as Allocator<u32>>::alloc_cell(alloc, num_bytes)
     } else {
@@ -1445,7 +1439,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
         position
             .wrapping_add(num_bytes)
             .wrapping_sub(StoreLookaheadH10())
-            .wrapping_add(1usize)
+            .wrapping_add(1)
     } else {
         position
     };
@@ -1464,7 +1458,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     let gap: usize = 0usize;
     let shadow_matches: usize = 0usize;
     i = 0usize;
-    while i.wrapping_add(hasher.HashTypeLength()).wrapping_sub(1usize) < num_bytes {
+    while i.wrapping_add(hasher.HashTypeLength()).wrapping_sub(1) < num_bytes {
         {
             let pos: usize = position.wrapping_add(i);
             let max_distance: usize = brotli_min_size_t(pos, max_backward_limit);
@@ -1472,25 +1466,15 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
 
             let mut j: usize;
             {
-                if matches_size
-                    < cur_match_pos
-                        .wrapping_add(128usize)
-                        .wrapping_add(shadow_matches)
-                {
+                if matches_size < cur_match_pos.wrapping_add(128).wrapping_add(shadow_matches) {
                     let mut new_size: usize = if matches_size == 0usize {
-                        cur_match_pos
-                            .wrapping_add(128usize)
-                            .wrapping_add(shadow_matches)
+                        cur_match_pos.wrapping_add(128).wrapping_add(shadow_matches)
                     } else {
                         matches_size
                     };
                     let mut new_array: <Alloc as Allocator<u64>>::AllocatedMemory;
-                    while new_size
-                        < cur_match_pos
-                            .wrapping_add(128usize)
-                            .wrapping_add(shadow_matches)
-                    {
-                        new_size = new_size.wrapping_mul(2usize);
+                    while new_size < cur_match_pos.wrapping_add(128).wrapping_add(shadow_matches) {
+                        new_size = new_size.wrapping_mul(2);
                     }
                     new_array = if new_size > 0usize {
                         <Alloc as Allocator<u64>>::alloc_cell(alloc, new_size)
@@ -1532,18 +1516,18 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
             );
             let cur_match_end: usize = cur_match_pos.wrapping_add(num_found_matches);
             j = cur_match_pos;
-            while j.wrapping_add(1usize) < cur_match_end {
+            while j.wrapping_add(1) < cur_match_end {
                 {}
                 j = j.wrapping_add(1);
             }
             num_matches.slice_mut()[i] = num_found_matches as u32;
             if num_found_matches > 0usize {
                 let match_len: usize = BackwardMatchLength(&BackwardMatch(
-                    matches.slice()[(cur_match_end.wrapping_sub(1usize) as usize)],
+                    matches.slice()[(cur_match_end.wrapping_sub(1) as usize)],
                 ));
                 if match_len > 325usize {
-                    let skip: usize = match_len.wrapping_sub(1usize);
-                    let tmp = matches.slice()[(cur_match_end.wrapping_sub(1usize) as usize)];
+                    let skip: usize = match_len.wrapping_sub(1);
+                    let tmp = matches.slice()[(cur_match_end.wrapping_sub(1) as usize)];
                     matches.slice_mut()[{
                         let _old = cur_match_pos;
                         cur_match_pos = cur_match_pos.wrapping_add(1);
@@ -1553,7 +1537,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                     hasher.StoreRange(
                         ringbuffer,
                         ringbuffer_mask,
-                        pos.wrapping_add(1usize),
+                        pos.wrapping_add(1),
                         brotli_min_size_t(pos.wrapping_add(match_len), store_end),
                     );
                     for item in num_matches
@@ -1585,7 +1569,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
         *i = *j;
     }
     let orig_num_commands: usize = *num_commands;
-    nodes = if num_bytes.wrapping_add(1usize) > 0usize {
+    nodes = if num_bytes.wrapping_add(1) > 0usize {
         <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
     } else {
         <Alloc as Allocator<ZopfliNode>>::AllocatedMemory::default()
@@ -1600,7 +1584,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     i = 0usize;
     while i < 2usize {
         {
-            BrotliInitZopfliNodes(nodes.slice_mut(), num_bytes.wrapping_add(1usize));
+            BrotliInitZopfliNodes(nodes.slice_mut(), num_bytes.wrapping_add(1));
             if i == 0usize {
                 ZopfliCostModelSetFromLiteralCosts(
                     &mut model,

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -366,7 +366,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
         let mut compare_char: i32 = data[cur_ix_masked.wrapping_add(best_len_in)] as i32;
         let mut best_score: u64 = out.score;
         let mut best_len: usize = best_len_in;
-        let cached_backward: usize = distance_cache[(0)] as usize;
+        let cached_backward: usize = distance_cache[0] as usize;
         let mut prev_ix: usize = cur_ix.wrapping_sub(cached_backward);
         let mut is_match_found: i32 = 0i32;
         out.len_x_code = 0usize;
@@ -615,21 +615,21 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> PartialEq<H9<Alloc>> 
 
 fn adv_prepare_distance_cache(distance_cache: &mut [i32], num_distances: i32) {
     if num_distances > 4i32 {
-        let last_distance: i32 = distance_cache[(0)];
-        distance_cache[(4usize)] = last_distance - 1i32;
-        distance_cache[(5usize)] = last_distance + 1i32;
-        distance_cache[(6usize)] = last_distance - 2i32;
-        distance_cache[(7usize)] = last_distance + 2i32;
-        distance_cache[(8usize)] = last_distance - 3i32;
-        distance_cache[(9usize)] = last_distance + 3i32;
+        let last_distance: i32 = distance_cache[0];
+        distance_cache[4] = last_distance - 1i32;
+        distance_cache[5] = last_distance + 1i32;
+        distance_cache[6] = last_distance - 2i32;
+        distance_cache[7] = last_distance + 2i32;
+        distance_cache[8] = last_distance - 3i32;
+        distance_cache[9] = last_distance + 3i32;
         if num_distances > 10i32 {
-            let next_last_distance: i32 = distance_cache[(1)];
-            distance_cache[(10usize)] = next_last_distance - 1i32;
-            distance_cache[(11)] = next_last_distance + 1i32;
-            distance_cache[(12usize)] = next_last_distance - 2i32;
-            distance_cache[(13usize)] = next_last_distance + 2i32;
-            distance_cache[(14usize)] = next_last_distance - 3i32;
-            distance_cache[(15usize)] = next_last_distance + 3i32;
+            let next_last_distance: i32 = distance_cache[1];
+            distance_cache[10] = next_last_distance - 1i32;
+            distance_cache[11] = next_last_distance + 1i32;
+            distance_cache[12] = next_last_distance - 2i32;
+            distance_cache[13] = next_last_distance + 2i32;
+            distance_cache[14] = next_last_distance - 3i32;
+            distance_cache[15] = next_last_distance + 3i32;
         }
     }
 }
@@ -1863,7 +1863,7 @@ fn BackwardReferenceScoreUsingLastDistance(copy_length: usize, h9_opts: H9Opts) 
     ((h9_opts.literal_byte_score as u64) >> 2)
         .wrapping_mul(copy_length as u64)
         .wrapping_add((30u64 * 8u64).wrapping_mul(::core::mem::size_of::<u64>() as u64))
-        .wrapping_add(15u64)
+        .wrapping_add(15)
 }
 
 fn BackwardReferenceScore(
@@ -2394,7 +2394,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
     let mut apply_random_heuristics: usize = position.wrapping_add(random_heuristics_window_size);
     let kMinScore: u64 = (30u64 * 8)
         .wrapping_mul(::core::mem::size_of::<u64>() as u64)
-        .wrapping_add(100u64);
+        .wrapping_add(100);
     hasher.PrepareDistanceCache(dist_cache);
     while position.wrapping_add(hasher.HashTypeLength()) < pos_end {
         let mut max_length: usize = pos_end.wrapping_sub(position);
@@ -2483,10 +2483,10 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                 let distance_code: usize =
                     ComputeDistanceCode(sr.distance, max_distance, dist_cache);
                 if sr.distance <= max_distance && (distance_code > 0usize) {
-                    dist_cache[(3usize)] = dist_cache[(2usize)];
-                    dist_cache[(2usize)] = dist_cache[(1)];
-                    dist_cache[(1)] = dist_cache[(0)];
-                    dist_cache[(0)] = sr.distance as i32;
+                    dist_cache[3] = dist_cache[2];
+                    dist_cache[2] = dist_cache[1];
+                    dist_cache[1] = dist_cache[0];
+                    dist_cache[0] = sr.distance as i32;
                     hasher.PrepareDistanceCache(dist_cache);
                 }
                 new_commands_count += 1;
@@ -2509,7 +2509,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
             hasher.StoreRange(
                 ringbuffer,
                 ringbuffer_mask,
-                position.wrapping_add(2usize),
+                position.wrapping_add(2),
                 brotli_min_size_t(position.wrapping_add(sr.len), store_end),
             );
             position = position.wrapping_add(sr.len);
@@ -2520,7 +2520,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
             if position > apply_random_heuristics {
                 let kMargin: usize =
                     brotli_max_size_t(hasher.StoreLookahead().wrapping_sub(1), 4usize);
-                if position.wrapping_add(16usize) >= pos_end.wrapping_sub(kMargin) {
+                if position.wrapping_add(16) >= pos_end.wrapping_sub(kMargin) {
                     insert_length = insert_length.wrapping_add(pos_end - position);
                     position = pos_end;
                 } else if position
@@ -2528,12 +2528,12 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                         .wrapping_add((4usize).wrapping_mul(random_heuristics_window_size))
                 {
                     hasher.Store4Vec4(ringbuffer, ringbuffer_mask, position);
-                    insert_length = insert_length.wrapping_add(16usize);
-                    position = position.wrapping_add(16usize);
+                    insert_length = insert_length.wrapping_add(16);
+                    position = position.wrapping_add(16);
                 } else {
                     hasher.StoreEvenVec4(ringbuffer, ringbuffer_mask, position);
-                    insert_length = insert_length.wrapping_add(8usize);
-                    position = position.wrapping_add(8usize);
+                    insert_length = insert_length.wrapping_add(8);
+                    position = position.wrapping_add(8);
                 }
             }
         }

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -40,7 +40,7 @@ fn test_bulk_store_range() {
             hash_shift_: 32i32 - params_hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
             block_bits_: params_hasher.block_bits,
-            block_mask_: block_size.wrapping_sub(1u64) as u32,
+            block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
     buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
@@ -142,7 +142,7 @@ fn test_bulk_store_range_off_spec() {
             hash_shift_: 32i32 - params_hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
             block_bits_: params_hasher.block_bits,
-            block_mask_: block_size.wrapping_sub(1u64) as u32,
+            block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
     buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
@@ -230,7 +230,7 @@ fn test_bulk_store_range_pow2() {
             hash_shift_: 32i32 - params_hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
             block_bits_: params_hasher.block_bits,
-            block_mask_: block_size.wrapping_sub(1u64) as u32,
+            block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
     buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -281,7 +281,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     if count == 3i32 {
         let histo0: u32 = (*histogram).slice()[s[0]];
         let histo1: u32 = (*histogram).slice()[s[1]];
-        let histo2: u32 = (*histogram).slice()[s[2usize]];
+        let histo2: u32 = (*histogram).slice()[s[2]];
         let histomax: u32 = brotli_max_uint32_t(histo0, brotli_max_uint32_t(histo1, histo2));
         return kThreeSymbolHistogramCost
             + (2u32).wrapping_mul(histo0.wrapping_add(histo1).wrapping_add(histo2))
@@ -314,7 +314,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
             }
             i = i.wrapping_add(1);
         }
-        let h23: u32 = histo[2usize].wrapping_add(histo[3usize]);
+        let h23: u32 = histo[2].wrapping_add(histo[3]);
         let histomax: u32 = brotli_max_uint32_t(h23, histo[0]);
         return kFourSymbolHistogramCost
             + (3u32).wrapping_mul(h23) as super::util::floatX

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -169,7 +169,7 @@ fn CopyLiteralsToByteArray(
 }
 
 fn MyRand(seed: &mut u32) -> u32 {
-    *seed = (*seed).wrapping_mul(16807u32);
+    *seed = (*seed).wrapping_mul(16807);
     if *seed == 0u32 {
         *seed = 1u32;
     }
@@ -297,7 +297,7 @@ where
         return 0;
     }
     let data_size: usize = histograms[0].slice().len();
-    let bitmaplen: usize = num_histograms.wrapping_add(7usize) >> 3i32;
+    let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3i32;
     let mut num_blocks: usize = 1;
     let mut i: usize;
     let mut j: usize;
@@ -533,8 +533,8 @@ fn ClusterBlocks<
     let mut histogram_symbols = <Alloc as Allocator<u32>>::alloc_cell(alloc, num_blocks);
     let mut block_lengths = <Alloc as Allocator<u32>>::alloc_cell(alloc, num_blocks);
     let expected_num_clusters: usize = (16usize)
-        .wrapping_mul(num_blocks.wrapping_add(64usize).wrapping_sub(1))
-        .wrapping_div(64usize);
+        .wrapping_mul(num_blocks.wrapping_add(64).wrapping_sub(1))
+        .wrapping_div(64);
     let mut all_histograms_size: usize = 0usize;
     let mut all_histograms_capacity: usize = expected_num_clusters;
     let mut all_histograms =
@@ -637,7 +637,7 @@ fn ClusterBlocks<
                         all_histograms_capacity
                     };
                     while _new_size < all_histograms_size.wrapping_add(num_new_clusters) {
-                        _new_size = _new_size.wrapping_mul(2usize);
+                        _new_size = _new_size.wrapping_mul(2);
                     }
                     let mut new_array =
                         <Alloc as Allocator<HistogramType>>::alloc_cell(alloc, _new_size);
@@ -658,7 +658,7 @@ fn ClusterBlocks<
                         cluster_size_capacity
                     };
                     while _new_size < cluster_size_size.wrapping_add(num_new_clusters) {
-                        _new_size = _new_size.wrapping_mul(2usize);
+                        _new_size = _new_size.wrapping_mul(2);
                     }
                     let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
                     new_array.slice_mut()[..cluster_size_capacity]
@@ -699,12 +699,12 @@ fn ClusterBlocks<
             0i32;
             0i32;
         }
-        i = i.wrapping_add(64usize);
+        i = i.wrapping_add(64);
     }
     <Alloc as Allocator<HistogramType>>::free_cell(alloc, core::mem::take(&mut histograms));
     max_num_pairs = brotli_min_size_t(
         (64usize).wrapping_mul(num_clusters),
-        num_clusters.wrapping_div(2usize).wrapping_mul(num_clusters),
+        num_clusters.wrapping_div(2).wrapping_mul(num_clusters),
     );
     if pairs_capacity < max_num_pairs.wrapping_add(1) {
         let new_cell =
@@ -768,7 +768,7 @@ fn ClusterBlocks<
                     j = j.wrapping_add(1);
                 }
                 best_out = if i == 0usize {
-                    histogram_symbols.slice()[(0)]
+                    histogram_symbols.slice()[0]
                 } else {
                     histogram_symbols.slice()[i.wrapping_sub(1)]
                 };
@@ -814,7 +814,7 @@ fn ClusterBlocks<
                 (*split).types_alloc_size()
             };
             while _new_size < num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..(*split).types_alloc_size()]
@@ -833,7 +833,7 @@ fn ClusterBlocks<
                 (*split).lengths_alloc_size()
             };
             while _new_size < num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..(*split).lengths_alloc_size()]
@@ -915,7 +915,7 @@ fn SplitByteVector<
                 };
 
                 while _new_size < split.num_blocks.wrapping_add(1) {
-                    _new_size = _new_size.wrapping_mul(2usize);
+                    _new_size = _new_size.wrapping_mul(2);
                 }
                 let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
                 new_array.slice_mut()[..(*split).types_alloc_size()]
@@ -934,7 +934,7 @@ fn SplitByteVector<
                     (*split).lengths_alloc_size()
                 };
                 while _new_size < split.num_blocks.wrapping_add(1) {
-                    _new_size = _new_size.wrapping_mul(2usize);
+                    _new_size = _new_size.wrapping_mul(2);
                 }
                 let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
                 new_array.slice_mut()[..(*split).lengths_alloc_size()]
@@ -970,7 +970,7 @@ fn SplitByteVector<
     {
         let mut block_ids = <Alloc as Allocator<u8>>::alloc_cell(alloc, length);
         let mut num_blocks: usize = 0usize;
-        let bitmaplen: usize = num_histograms.wrapping_add(7usize) >> 3i32;
+        let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3i32;
         let mut insert_cost = <Alloc as Allocator<super::util::floatX>>::alloc_cell(
             alloc,
             data_size.wrapping_mul(num_histograms),

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -847,7 +847,7 @@ fn BrotliStoreHuffmanTreeOfHuffmanTreeToBitMask(
         && (code_length_bitdepth[(kStorageOrder[1] as usize)] as i32 == 0i32)
     {
         skip_some = 2;
-        if code_length_bitdepth[(kStorageOrder[2usize] as usize)] as i32 == 0i32 {
+        if code_length_bitdepth[(kStorageOrder[2] as usize)] as i32 == 0i32 {
             skip_some = 3;
         }
     }
@@ -1086,9 +1086,9 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                     let mut k: i32;
                     SortHuffmanTreeItems(tree.slice_mut(), n as usize, SimpleSortHuffmanTree {});
                     let sentinel: HuffmanTree = NewHuffmanTree(!(0u32), -1i16, -1i16);
-                    tree.slice_mut()[(node_index.wrapping_add(1u32) as usize)] = sentinel;
+                    tree.slice_mut()[(node_index.wrapping_add(1) as usize)] = sentinel;
                     tree.slice_mut()[(node_index as usize)] = sentinel;
-                    node_index = node_index.wrapping_add(2u32);
+                    node_index = node_index.wrapping_add(2);
                     k = n - 1i32;
                     while k > 0i32 {
                         {
@@ -1115,12 +1115,12 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                             let sum_total = (tree.slice()[(left as usize)])
                                 .total_count_
                                 .wrapping_add((tree.slice()[(right as usize)]).total_count_);
-                            let tree_ind = (node_index.wrapping_sub(1u32) as usize);
+                            let tree_ind = (node_index.wrapping_sub(1) as usize);
                             (tree.slice_mut()[tree_ind]).total_count_ = sum_total;
                             (tree.slice_mut()[tree_ind]).index_left_ = left as i16;
                             (tree.slice_mut()[tree_ind]).index_right_or_value_ = right as i16;
                             tree.slice_mut()[(node_index as usize)] = sentinel;
-                            node_index = node_index.wrapping_add(1u32);
+                            node_index = node_index.wrapping_add(1);
                         }
                         k -= 1;
                     }
@@ -1131,7 +1131,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                     }
                 }
             }
-            count_limit = count_limit.wrapping_mul(2u32);
+            count_limit = count_limit.wrapping_mul(2);
         }
         {
             m.free_cell(core::mem::take(&mut tree));
@@ -1166,12 +1166,12 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
         } else if count == 3 {
             BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
             BrotliWriteBits(max_bits as u8, symbols[1], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[2usize], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[2], storage_ix, storage);
         } else {
             BrotliWriteBits(max_bits as u8, symbols[0], storage_ix, storage);
             BrotliWriteBits(max_bits as u8, symbols[1], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[2usize], storage_ix, storage);
-            BrotliWriteBits(max_bits as u8, symbols[3usize], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[2], storage_ix, storage);
+            BrotliWriteBits(max_bits as u8, symbols[3], storage_ix, storage);
             BrotliWriteBits(
                 1,
                 if depth[(symbols[0] as usize)] as i32 == 1i32 {
@@ -1385,20 +1385,20 @@ fn BrotliEncodeMlen(length: u32, bits: &mut u64, numbits: &mut u32, nibblesbits:
     let lg: u32 = (if length == 1u32 {
         1u32
     } else {
-        Log2FloorNonZero(length.wrapping_sub(1u32) as (u64)).wrapping_add(1u32)
+        Log2FloorNonZero(length.wrapping_sub(1) as (u64)).wrapping_add(1)
     });
     let mnibbles: u32 = (if lg < 16u32 {
         16u32
     } else {
-        lg.wrapping_add(3u32)
+        lg.wrapping_add(3)
     })
-    .wrapping_div(4u32);
+    .wrapping_div(4);
     assert!(length > 0);
     assert!(length <= (1 << 24));
     assert!(lg <= 24);
-    *nibblesbits = mnibbles.wrapping_sub(4u32);
-    *numbits = mnibbles.wrapping_mul(4u32);
-    *bits = length.wrapping_sub(1u32) as u64;
+    *nibblesbits = mnibbles.wrapping_sub(4);
+    *numbits = mnibbles.wrapping_mul(4);
+    *bits = length.wrapping_sub(1) as u64;
 }
 
 fn StoreCompressedMetaBlockHeader(
@@ -1469,7 +1469,7 @@ fn NextBlockTypeCode(calculator: &mut BlockTypeCodeCalculator, type_: u8) -> usi
     } else if type_ as usize == calculator.second_last_type {
         0u32
     } else {
-        (type_ as u32).wrapping_add(2u32)
+        (type_ as u32).wrapping_add(2)
     }) as usize;
     calculator.second_last_type = calculator.last_type;
     calculator.last_type = type_ as usize;
@@ -1489,7 +1489,7 @@ fn BlockLengthPrefixCode(len: u32) -> u32 {
         0i32
     }) as u32;
     while code < (26i32 - 1i32) as u32
-        && (len >= kBlockLengthPrefixCode[code.wrapping_add(1u32) as usize].offset)
+        && (len >= kBlockLengthPrefixCode[code.wrapping_add(1) as usize].offset)
     {
         code = code.wrapping_add(1);
     }
@@ -1537,35 +1537,20 @@ fn StoreSimpleHuffmanTree(
         }
     }
     if num_symbols == 2usize {
-        BrotliWriteBits(max_bits as u8, symbols[(0)] as u64, storage_ix, storage);
-        BrotliWriteBits(max_bits as u8, symbols[(1)] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
     } else if num_symbols == 3usize {
-        BrotliWriteBits(max_bits as u8, symbols[(0)] as u64, storage_ix, storage);
-        BrotliWriteBits(max_bits as u8, symbols[(1)] as u64, storage_ix, storage);
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(2usize)] as u64,
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[2] as u64, storage_ix, storage);
     } else {
-        BrotliWriteBits(max_bits as u8, symbols[(0)] as u64, storage_ix, storage);
-        BrotliWriteBits(max_bits as u8, symbols[(1)] as u64, storage_ix, storage);
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(2usize)] as u64,
-            storage_ix,
-            storage,
-        );
-        BrotliWriteBits(
-            max_bits as u8,
-            symbols[(3usize)] as u64,
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(max_bits as u8, symbols[0] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[1] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[2] as u64, storage_ix, storage);
+        BrotliWriteBits(max_bits as u8, symbols[3] as u64, storage_ix, storage);
         BrotliWriteBits(
             1,
-            if depths[symbols[(0)]] as i32 == 1i32 {
+            if depths[symbols[0]] as i32 == 1i32 {
                 1i32
             } else {
                 0i32
@@ -1704,8 +1689,8 @@ fn BuildAndStoreBlockSplitCode(
     if num_types > 1 {
         BuildAndStoreHuffmanTree(
             &mut type_histo[0..],
-            num_types.wrapping_add(2usize),
-            num_types.wrapping_add(2usize),
+            num_types.wrapping_add(2),
+            num_types.wrapping_add(2),
             tree,
             &mut code.type_depths[0..],
             &mut code.type_bits[0..],
@@ -1722,7 +1707,7 @@ fn BuildAndStoreBlockSplitCode(
             storage_ix,
             storage,
         );
-        StoreBlockSwitch(code, lengths[(0)], types[(0)], 1i32, storage_ix, storage);
+        StoreBlockSwitch(code, lengths[0], types[0], 1i32, storage_ix, storage);
     }
 }
 
@@ -1754,7 +1739,7 @@ fn StoreTrivialContextMap(
     StoreVarLenUint8(num_types.wrapping_sub(1) as u64, storage_ix, storage);
     if num_types > 1 {
         let repeat_code: usize = context_bits.wrapping_sub(1u32 as usize);
-        let repeat_bits: usize = (1u32 << repeat_code).wrapping_sub(1u32) as usize;
+        let repeat_bits: usize = (1u32 << repeat_code).wrapping_sub(1) as usize;
         let alphabet_size: usize = num_types.wrapping_add(repeat_code);
         let mut histogram: [u32; 272] = [0; 272];
         let mut depths: [u8; 272] = [0; 272];
@@ -1827,7 +1812,7 @@ fn MoveToFront(v: &mut [u8], index: usize) {
         }
         i = i.wrapping_sub(1);
     }
-    v[(0)] = value;
+    v[0] = value;
 }
 
 fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
@@ -1837,7 +1822,7 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
     if v_size == 0usize {
         return;
     }
-    max_value = v_in[(0)];
+    max_value = v_in[0];
     i = 1;
     while i < v_size {
         {
@@ -1856,7 +1841,7 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
         i = i.wrapping_add(1);
     }
     {
-        let mtf_size: usize = max_value.wrapping_add(1u32) as usize;
+        let mtf_size: usize = max_value.wrapping_add(1) as usize;
         i = 0usize;
         while i < v_size {
             {
@@ -1947,9 +1932,9 @@ fn RunLengthCodeZeros(
                         }
                     }
                 } else {
-                    let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1u32);
+                    let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1);
                     v[*out_size] = max_prefix.wrapping_add(extra_bits << 9i32);
-                    reps = reps.wrapping_sub((2u32 << max_prefix).wrapping_sub(1u32));
+                    reps = reps.wrapping_sub((2u32 << max_prefix).wrapping_sub(1));
                     *out_size = (*out_size).wrapping_add(1);
                 }
             }
@@ -2009,7 +1994,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
         if use_rle != 0 {
             BrotliWriteBits(
                 4,
-                max_run_length_prefix.wrapping_sub(1u32) as (u64),
+                max_run_length_prefix.wrapping_sub(1) as (u64),
                 storage_ix,
                 storage,
             );
@@ -2473,7 +2458,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as usize);
             if CommandCopyLen(&cmd) != 0 {
-                prev_byte2 = input[(pos.wrapping_sub(2usize) & mask)];
+                prev_byte2 = input[(pos.wrapping_sub(2) & mask)];
                 prev_byte = input[(pos.wrapping_sub(1) & mask)];
                 if cmd.cmd_prefix_ as i32 >= 128i32 {
                     let dist_code: usize = cmd.dist_prefix_ as usize & 0x3ff;

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -99,7 +99,7 @@ fn BrotliCompareAndPushToQueue<
             let threshold: super::util::floatX = if *num_pairs == 0usize {
                 1e38 as super::util::floatX
             } else {
-                brotli_max_double(0.0 as super::util::floatX, (pairs[0usize]).cost_diff)
+                brotli_max_double(0.0 as super::util::floatX, (pairs[0]).cost_diff)
             };
 
             let mut combo: HistogramType = out[idx1 as usize].clone();
@@ -112,13 +112,13 @@ fn BrotliCompareAndPushToQueue<
         }
         if is_good_pair != 0 {
             p.cost_diff += p.cost_combo;
-            if *num_pairs > 0usize && HistogramPairIsLess(&pairs[0usize], &p) {
+            if *num_pairs > 0usize && HistogramPairIsLess(&pairs[0], &p) {
                 /* Replace the top of the queue if needed. */
                 if *num_pairs < max_num_pairs {
-                    pairs[*num_pairs] = pairs[0usize];
+                    pairs[*num_pairs] = pairs[0];
                     *num_pairs = (*num_pairs).wrapping_add(1);
                 }
-                pairs[0usize] = p;
+                pairs[0] = p;
             } else if *num_pairs < max_num_pairs {
                 pairs[*num_pairs] = p;
                 *num_pairs = (*num_pairs).wrapping_add(1);
@@ -174,7 +174,7 @@ pub fn BrotliHistogramCombine<
     }
     while num_clusters > min_cluster_size {
         let mut i: usize;
-        if (pairs[(0)]).cost_diff >= cost_diff_threshold {
+        if (pairs[0]).cost_diff >= cost_diff_threshold {
             cost_diff_threshold = 1e38 as super::util::floatX;
             min_cluster_size = max_clusters;
             {
@@ -184,10 +184,10 @@ pub fn BrotliHistogramCombine<
             }
         }
         /* Take the best pair from the top of heap. */
-        let best_idx1: u32 = (pairs[(0)]).idx1;
-        let best_idx2: u32 = (pairs[(0)]).idx2;
+        let best_idx1: u32 = (pairs[0]).idx1;
+        let best_idx2: u32 = (pairs[0]).idx2;
         HistogramSelfAddHistogram(out, (best_idx1 as usize), (best_idx2 as usize));
-        (out[(best_idx1 as usize)]).set_bit_cost((pairs[(0)]).cost_combo);
+        (out[(best_idx1 as usize)]).set_bit_cost((pairs[0]).cost_combo);
         {
             let _rhs = cluster_size[(best_idx2 as usize)];
             let _lhs = &mut cluster_size[(best_idx1 as usize)];
@@ -233,10 +233,10 @@ pub fn BrotliHistogramCombine<
                                 break 'continue12;
                             }
                         }
-                        if HistogramPairIsLess(&pairs[(0)], &p) {
+                        if HistogramPairIsLess(&pairs[0], &p) {
                             /* Replace the top of the queue if needed. */
-                            let front: HistogramPair = pairs[(0)];
-                            pairs[(0)] = p;
+                            let front: HistogramPair = pairs[0];
+                            pairs[0] = p;
                             pairs[copy_to_idx] = front;
                         } else {
                             pairs[copy_to_idx] = p;
@@ -309,7 +309,7 @@ pub fn BrotliHistogramRemap<
     while i < in_size {
         {
             let mut best_out: u32 = if i == 0usize {
-                symbols[(0)]
+                symbols[0]
             } else {
                 symbols[i.wrapping_sub(1)]
             };
@@ -463,7 +463,7 @@ pub fn BrotliClusterHistograms<
     let max_input_histograms: usize = 64usize;
     let pairs_capacity: usize = max_input_histograms
         .wrapping_mul(max_input_histograms)
-        .wrapping_div(2usize);
+        .wrapping_div(2);
     let mut pairs =
         <Alloc as Allocator<HistogramPair>>::alloc_cell(alloc, pairs_capacity.wrapping_add(1));
     let mut i: usize;
@@ -516,7 +516,7 @@ pub fn BrotliClusterHistograms<
     {
         let max_num_pairs: usize = brotli_min_size_t(
             (64usize).wrapping_mul(num_clusters),
-            num_clusters.wrapping_div(2usize).wrapping_mul(num_clusters),
+            num_clusters.wrapping_div(2).wrapping_mul(num_clusters),
         );
         {
             if pairs_capacity < max_num_pairs.wrapping_add(1) {
@@ -527,7 +527,7 @@ pub fn BrotliClusterHistograms<
                 };
                 let mut new_array: <Alloc as Allocator<HistogramPair>>::AllocatedMemory;
                 while _new_size < max_num_pairs.wrapping_add(1) {
-                    _new_size = _new_size.wrapping_mul(2usize);
+                    _new_size = _new_size.wrapping_mul(2);
                 }
                 new_array = if _new_size != 0 {
                     <Alloc as Allocator<HistogramPair>>::alloc_cell(alloc, _new_size)

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -37,24 +37,24 @@ pub fn CommandDistanceContext(xself: &Command) -> u32 {
 #[inline(always)]
 pub fn ComputeDistanceCode(distance: usize, max_distance: usize, dist_cache: &[i32]) -> usize {
     if distance <= max_distance {
-        let distance_plus_3: usize = distance.wrapping_add(3usize);
-        let offset0: usize = distance_plus_3.wrapping_sub(dist_cache[(0)] as usize);
-        let offset1: usize = distance_plus_3.wrapping_sub(dist_cache[(1)] as usize);
-        if distance == dist_cache[(0)] as usize {
+        let distance_plus_3: usize = distance.wrapping_add(3);
+        let offset0: usize = distance_plus_3.wrapping_sub(dist_cache[0] as usize);
+        let offset1: usize = distance_plus_3.wrapping_sub(dist_cache[1] as usize);
+        if distance == dist_cache[0] as usize {
             return 0usize;
-        } else if distance == dist_cache[(1)] as usize {
+        } else if distance == dist_cache[1] as usize {
             return 1;
         } else if offset0 < 7usize {
             return (0x9750468i32 >> (4usize).wrapping_mul(offset0) & 0xfi32) as usize;
         } else if offset1 < 7usize {
             return (0xfdb1acei32 >> (4usize).wrapping_mul(offset1) & 0xfi32) as usize;
-        } else if distance == dist_cache[(2usize)] as usize {
+        } else if distance == dist_cache[2] as usize {
             return 2usize;
-        } else if distance == dist_cache[(3usize)] as usize {
+        } else if distance == dist_cache[3] as usize {
             return 3usize;
         }
     }
-    distance.wrapping_add(16usize).wrapping_sub(1)
+    distance.wrapping_add(16).wrapping_sub(1)
 }
 
 #[inline(always)]
@@ -62,12 +62,12 @@ pub fn GetInsertLengthCode(insertlen: usize) -> u16 {
     if insertlen < 6usize {
         insertlen as u16
     } else if insertlen < 130usize {
-        let nbits: u32 = Log2FloorNonZero(insertlen.wrapping_sub(2) as u64).wrapping_sub(1u32);
+        let nbits: u32 = Log2FloorNonZero(insertlen.wrapping_sub(2) as u64).wrapping_sub(1);
         ((nbits << 1i32) as usize)
-            .wrapping_add(insertlen.wrapping_sub(2usize) >> nbits)
-            .wrapping_add(2usize) as u16
+            .wrapping_add(insertlen.wrapping_sub(2) >> nbits)
+            .wrapping_add(2) as u16
     } else if insertlen < 2114usize {
-        Log2FloorNonZero(insertlen.wrapping_sub(66usize) as u64).wrapping_add(10u32) as u16
+        Log2FloorNonZero(insertlen.wrapping_sub(66) as u64).wrapping_add(10) as u16
     } else if insertlen < 6210usize {
         21u32 as u16
     } else if insertlen < 22594usize {
@@ -80,14 +80,14 @@ pub fn GetInsertLengthCode(insertlen: usize) -> u16 {
 #[inline(always)]
 pub fn GetCopyLengthCode(copylen: usize) -> u16 {
     if copylen < 10usize {
-        copylen.wrapping_sub(2usize) as u16
+        copylen.wrapping_sub(2) as u16
     } else if copylen < 134usize {
-        let nbits: u32 = Log2FloorNonZero(copylen.wrapping_sub(6usize) as u64).wrapping_sub(1u32);
+        let nbits: u32 = Log2FloorNonZero(copylen.wrapping_sub(6) as u64).wrapping_sub(1);
         ((nbits << 1i32) as usize)
-            .wrapping_add(copylen.wrapping_sub(6usize) >> nbits)
-            .wrapping_add(4usize) as u16
+            .wrapping_add(copylen.wrapping_sub(6) >> nbits)
+            .wrapping_add(4) as u16
     } else if copylen < 2118usize {
-        Log2FloorNonZero(copylen.wrapping_sub(70usize) as u64).wrapping_add(12u32) as u16
+        Log2FloorNonZero(copylen.wrapping_sub(70) as u64).wrapping_add(12) as u16
     } else {
         23u32 as u16
     }
@@ -132,8 +132,8 @@ pub fn PrefixEncodeCopyDistance(
                 .wrapping_sub(BROTLI_NUM_DISTANCE_SHORT_CODES as u64)
                 .wrapping_sub(num_direct_codes as u64),
         );
-        let bucket: u64 = Log2FloorNonZero(dist).wrapping_sub(1u32) as (u64);
-        let postfix_mask: u64 = (1u32 << postfix_bits).wrapping_sub(1u32) as (u64);
+        let bucket: u64 = Log2FloorNonZero(dist).wrapping_sub(1) as (u64);
+        let postfix_mask: u64 = (1u32 << postfix_bits).wrapping_sub(1) as (u64);
         let postfix: u64 = dist & postfix_mask;
         let prefix: u64 = (dist >> bucket) & 1;
         let offset: u64 = (2u64).wrapping_add(prefix) << bucket;

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -38,7 +38,7 @@ fn Hash(p: &[u8], shift: usize) -> u32 {
 }
 fn IsMatch(p1: &[u8], p2: &[u8]) -> i32 {
     if !!(BROTLI_UNALIGNED_LOAD32(p1) == BROTLI_UNALIGNED_LOAD32(p2)
-        && (p1[(4usize)] as i32 == p2[(4usize)] as i32))
+        && (p1[4] as i32 == p2[4] as i32))
     {
         1i32
     } else {
@@ -95,7 +95,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         }
         histogram_total = input_size
             .wrapping_add(kSampleRate)
-            .wrapping_sub(1usize)
+            .wrapping_sub(1)
             .wrapping_div(kSampleRate);
         i = 0usize;
         while i < 256usize {
@@ -135,7 +135,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
             i = i.wrapping_add(1);
         }
         literal_ratio
-            .wrapping_mul(125usize)
+            .wrapping_mul(125)
             .wrapping_div(histogram_total)
     }
 }
@@ -155,7 +155,7 @@ fn EmitInsertLen(
     storage: &mut [u8],
 ) {
     if insertlen < 6usize {
-        let code: usize = insertlen.wrapping_add(40usize);
+        let code: usize = insertlen.wrapping_add(40);
         BrotliWriteBits(
             depth[code] as usize,
             bits[code] as (u64),
@@ -168,12 +168,12 @@ fn EmitInsertLen(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if insertlen < 130usize {
-        let tail: usize = insertlen.wrapping_sub(2usize);
-        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1u32);
+        let tail: usize = insertlen.wrapping_sub(2);
+        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
         let inscode: usize = ((nbits << 1i32) as usize)
             .wrapping_add(prefix)
-            .wrapping_add(42usize);
+            .wrapping_add(42);
         BrotliWriteBits(
             depth[(inscode as usize)] as usize,
             bits[(inscode as usize)] as (u64),
@@ -192,9 +192,9 @@ fn EmitInsertLen(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if insertlen < 2114usize {
-        let tail: usize = insertlen.wrapping_sub(66usize);
+        let tail: usize = insertlen.wrapping_sub(66);
         let nbits: u32 = Log2FloorNonZero(tail as u64);
-        let code: usize = nbits.wrapping_add(50u32) as usize;
+        let code: usize = nbits.wrapping_add(50) as usize;
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -213,21 +213,16 @@ fn EmitInsertLen(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else {
-        BrotliWriteBits(
-            depth[(61usize)] as usize,
-            bits[(61usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[61] as usize, bits[61] as (u64), storage_ix, storage);
         BrotliWriteBits(
             12usize,
-            (insertlen as u64).wrapping_sub(2114u64),
+            (insertlen as u64).wrapping_sub(2114),
             storage_ix,
             storage,
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(61usize)];
+            let _lhs = &mut histo[61];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     }
@@ -235,7 +230,7 @@ fn EmitInsertLen(
 
 fn ShouldUseUncompressedMode(delta: isize, insertlen: usize, literal_ratio: usize) -> i32 {
     let compressed: usize = delta as usize;
-    if compressed.wrapping_mul(50usize) > insertlen {
+    if compressed.wrapping_mul(50) > insertlen {
         0i32
     } else if !!(literal_ratio > 980usize) {
         1i32
@@ -245,7 +240,7 @@ fn ShouldUseUncompressedMode(delta: isize, insertlen: usize, literal_ratio: usiz
 }
 fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mut [u8]) {
     let bitpos: usize = new_storage_ix & 7usize;
-    let mask: usize = (1u32 << bitpos).wrapping_sub(1u32) as usize;
+    let mask: usize = (1u32 << bitpos).wrapping_sub(1) as usize;
     {
         let _rhs = mask as u8;
         let _lhs = &mut storage[(new_storage_ix >> 3i32)];
@@ -278,12 +273,7 @@ fn EmitLongInsertLen(
     storage: &mut [u8],
 ) {
     if insertlen < 22594usize {
-        BrotliWriteBits(
-            depth[(62usize)] as usize,
-            bits[(62usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[62] as usize, bits[62] as (u64), storage_ix, storage);
         BrotliWriteBits(
             14usize,
             (insertlen as u64).wrapping_sub(6210),
@@ -292,16 +282,11 @@ fn EmitLongInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(62usize)];
+            let _lhs = &mut histo[62];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else {
-        BrotliWriteBits(
-            depth[(63usize)] as usize,
-            bits[(63usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[63] as usize, bits[63] as (u64), storage_ix, storage);
         BrotliWriteBits(
             24usize,
             (insertlen as u64).wrapping_sub(22594),
@@ -310,7 +295,7 @@ fn EmitLongInsertLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(63usize)];
+            let _lhs = &mut histo[63];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     }
@@ -348,13 +333,13 @@ fn EmitDistance(
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
-    let d: u64 = distance.wrapping_add(3usize) as u64;
-    let nbits: u32 = Log2FloorNonZero(d).wrapping_sub(1u32);
+    let d: u64 = distance.wrapping_add(3) as u64;
+    let nbits: u32 = Log2FloorNonZero(d).wrapping_sub(1);
     let prefix: u64 = d >> nbits & 1;
     let offset: u64 = (2u64).wrapping_add(prefix) << nbits;
-    let distcode: u64 = ((2u32).wrapping_mul(nbits.wrapping_sub(1u32)) as (u64))
+    let distcode: u64 = ((2u32).wrapping_mul(nbits.wrapping_sub(1)) as (u64))
         .wrapping_add(prefix)
-        .wrapping_add(80u64);
+        .wrapping_add(80);
     BrotliWriteBits(
         depth[(distcode as usize)] as usize,
         bits[(distcode as usize)] as (u64),
@@ -379,23 +364,23 @@ fn EmitCopyLenLastDistance(
 ) {
     if copylen < 12usize {
         BrotliWriteBits(
-            depth[copylen.wrapping_sub(4usize)] as usize,
-            bits[copylen.wrapping_sub(4usize)] as (u64),
+            depth[copylen.wrapping_sub(4)] as usize,
+            bits[copylen.wrapping_sub(4)] as (u64),
             storage_ix,
             storage,
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[copylen.wrapping_sub(4usize)];
+            let _lhs = &mut histo[copylen.wrapping_sub(4)];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if copylen < 72usize {
-        let tail: usize = copylen.wrapping_sub(8usize);
-        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1u32);
+        let tail: usize = copylen.wrapping_sub(8);
+        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
         let code: usize = ((nbits << 1i32) as usize)
             .wrapping_add(prefix)
-            .wrapping_add(4usize);
+            .wrapping_add(4);
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -414,8 +399,8 @@ fn EmitCopyLenLastDistance(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if copylen < 136usize {
-        let tail: usize = copylen.wrapping_sub(8usize);
-        let code: usize = (tail >> 5i32).wrapping_add(30usize);
+        let tail: usize = copylen.wrapping_sub(8);
+        let code: usize = (tail >> 5i32).wrapping_add(30);
         BrotliWriteBits(
             depth[code] as usize,
             bits[code] as (u64),
@@ -423,12 +408,7 @@ fn EmitCopyLenLastDistance(
             storage,
         );
         BrotliWriteBits(5usize, tail as u64 & 31, storage_ix, storage);
-        BrotliWriteBits(
-            depth[(64usize)] as usize,
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
             let _rhs = 1;
             let _lhs = &mut histo[code];
@@ -436,13 +416,13 @@ fn EmitCopyLenLastDistance(
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if copylen < 2120usize {
-        let tail: usize = copylen.wrapping_sub(72usize);
+        let tail: usize = copylen.wrapping_sub(72);
         let nbits: u32 = Log2FloorNonZero(tail as u64);
-        let code: usize = nbits.wrapping_add(28u32) as usize;
+        let code: usize = nbits.wrapping_add(28) as usize;
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -455,12 +435,7 @@ fn EmitCopyLenLastDistance(
             storage_ix,
             storage,
         );
-        BrotliWriteBits(
-            depth[(64usize)] as usize,
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
             let _rhs = 1;
             let _lhs = &mut histo[(code as usize)];
@@ -468,36 +443,26 @@ fn EmitCopyLenLastDistance(
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else {
-        BrotliWriteBits(
-            depth[(39usize)] as usize,
-            bits[(39usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[39] as usize, bits[39] as (u64), storage_ix, storage);
         BrotliWriteBits(
             24usize,
-            copylen.wrapping_sub(2120usize) as u64,
+            copylen.wrapping_sub(2120) as u64,
             storage_ix,
             storage,
         );
-        BrotliWriteBits(
-            depth[(64usize)] as usize,
-            bits[(64usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(39usize)];
+            let _lhs = &mut histo[39];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(64usize)];
+            let _lhs = &mut histo[64];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     }
@@ -520,23 +485,23 @@ fn EmitCopyLen(
 ) {
     if copylen < 10usize {
         BrotliWriteBits(
-            depth[copylen.wrapping_add(14usize)] as usize,
-            bits[copylen.wrapping_add(14usize)] as (u64),
+            depth[copylen.wrapping_add(14)] as usize,
+            bits[copylen.wrapping_add(14)] as (u64),
             storage_ix,
             storage,
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[copylen.wrapping_add(14usize)];
+            let _lhs = &mut histo[copylen.wrapping_add(14)];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if copylen < 134usize {
-        let tail: usize = copylen.wrapping_sub(6usize);
-        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1u32);
+        let tail: usize = copylen.wrapping_sub(6);
+        let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
         let code: usize = ((nbits << 1i32) as usize)
             .wrapping_add(prefix)
-            .wrapping_add(20usize);
+            .wrapping_add(20);
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -555,9 +520,9 @@ fn EmitCopyLen(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else if copylen < 2118usize {
-        let tail: usize = copylen.wrapping_sub(70usize);
+        let tail: usize = copylen.wrapping_sub(70);
         let nbits: u32 = Log2FloorNonZero(tail as u64);
-        let code: usize = nbits.wrapping_add(28u32) as usize;
+        let code: usize = nbits.wrapping_add(28) as usize;
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -576,12 +541,7 @@ fn EmitCopyLen(
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     } else {
-        BrotliWriteBits(
-            depth[(39usize)] as usize,
-            bits[(39usize)] as (u64),
-            storage_ix,
-            storage,
-        );
+        BrotliWriteBits(depth[39] as usize, bits[39] as (u64), storage_ix, storage);
         BrotliWriteBits(
             24usize,
             (copylen as u64).wrapping_sub(2118),
@@ -590,7 +550,7 @@ fn EmitCopyLen(
         );
         {
             let _rhs = 1;
-            let _lhs = &mut histo[(39usize)];
+            let _lhs = &mut histo[39];
             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
         }
     }
@@ -612,7 +572,7 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> i32 {
     {
         let total: usize = len
             .wrapping_add(kSampleRate)
-            .wrapping_sub(1usize)
+            .wrapping_sub(1)
             .wrapping_div(kSampleRate);
         let mut r: super::util::floatX = (FastLog2(total as u64) + 0.5 as super::util::floatX)
             * total as (super::util::floatX)
@@ -640,10 +600,10 @@ fn UpdateBits(mut n_bits: usize, mut bits: u32, mut pos: usize, array: &mut [u8]
         let n_changed_bits: usize =
             brotli_min_size_t(n_bits, (8usize).wrapping_sub(n_unchanged_bits));
         let total_bits: usize = n_unchanged_bits.wrapping_add(n_changed_bits);
-        let mask: u32 = !(1u32 << total_bits).wrapping_sub(1u32)
-            | (1u32 << n_unchanged_bits).wrapping_sub(1u32);
+        let mask: u32 =
+            !(1u32 << total_bits).wrapping_sub(1) | (1u32 << n_unchanged_bits).wrapping_sub(1);
         let unchanged_bits: u32 = array[byte_pos] as u32 & mask;
-        let changed_bits: u32 = bits & (1u32 << n_changed_bits).wrapping_sub(1u32);
+        let changed_bits: u32 = bits & (1u32 << n_changed_bits).wrapping_sub(1);
         array[byte_pos] = (changed_bits << n_unchanged_bits | unchanged_bits) as u8;
         n_bits = n_bits.wrapping_sub(n_changed_bits);
         bits >>= n_changed_bits;
@@ -664,11 +624,11 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
-        &histogram[64usize..],
+        &histogram[64..],
         64usize,
         14i32,
         &mut tree[..],
-        &mut depth[64usize..],
+        &mut depth[64..],
     );
     /* We have to jump through a few hoops here in order to compute
     the command bits because the symbols are in a different order than in
@@ -688,7 +648,7 @@ fn BuildAndStoreCommandPrefixCode(
     memcpy(bits, (40usize), &cmd_bits[..], 24usize, 8usize);
     memcpy(bits, (48usize), &cmd_bits[..], 40usize, 8usize);
     memcpy(bits, (56usize), &cmd_bits[..], 56usize, 8usize);
-    BrotliConvertBitDepthsToSymbols(&mut depth[64usize..], 64usize, &mut bits[64usize..]);
+    BrotliConvertBitDepthsToSymbols(&mut depth[64..], 64usize, &mut bits[64..]);
     {
         let mut i: usize;
         for item in cmd_depth[..64].iter_mut() {
@@ -720,7 +680,7 @@ fn BuildAndStoreCommandPrefixCode(
         );
     }
     BrotliStoreHuffmanTree(
-        &mut depth[64usize..],
+        &mut depth[64..],
         64usize,
         &mut tree[..],
         storage_ix,
@@ -754,7 +714,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
     let mut metablock_start = 0usize;
     let mut block_size = brotli_min_size_t(input_size, kFirstBlockSize);
     let mut total_block_size = block_size;
-    let mut mlen_storage_ix = (*storage_ix).wrapping_add(3usize);
+    let mut mlen_storage_ix = (*storage_ix).wrapping_add(3);
     let mut lit_depth = [0u8; 256];
     let mut lit_bits = [0u16; 256];
     let mut literal_ratio: usize;
@@ -774,9 +734,9 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
     );
     {
         let mut i = 0usize;
-        while i.wrapping_add(7usize) < *cmd_code_numbits {
+        while i.wrapping_add(7) < *cmd_code_numbits {
             BrotliWriteBits(8usize, cmd_code[i >> 3] as u64, storage_ix, storage);
-            i = i.wrapping_add(8usize);
+            i = i.wrapping_add(8);
         }
     }
     BrotliWriteBits(
@@ -801,7 +761,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                 let ip_limit: usize = input_index.wrapping_add(len_limit);
                 let mut next_hash = Hash(
                     &input_ptr[{
-                        ip_index = ip_index.wrapping_add(1usize);
+                        ip_index = ip_index.wrapping_add(1);
                         ip_index
                     }..],
                     shift,
@@ -817,7 +777,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                                     let hash = next_hash;
                                     let bytes_between_hash_lookups: u32 = {
                                         let _old = skip;
-                                        skip = skip.wrapping_add(1u32);
+                                        skip = skip.wrapping_add(1);
                                         _old
                                     } >> 5i32;
                                     ip_index = next_ip;
@@ -845,7 +805,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             }
                         }
                         if !(ip_index.wrapping_sub(candidate)
-                            > (1usize << 18i32).wrapping_sub(16usize) as isize as usize
+                            > (1usize << 18i32).wrapping_sub(16) as isize as usize
                             && (code_block_selection as i32
                                 == CodeBlockState::EMIT_COMMANDS as i32))
                         {
@@ -860,7 +820,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                         let matched = (5usize).wrapping_add(FindMatchLengthWithLimit(
                             &input_ptr[candidate + 5..],
                             &input_ptr[ip_index + 5..],
-                            ip_end.wrapping_sub(ip_index).wrapping_sub(5usize),
+                            ip_end.wrapping_sub(ip_index).wrapping_sub(5),
                         ));
                         let distance = base.wrapping_sub(candidate) as i32;
                         let insert = base.wrapping_sub(next_emit);
@@ -883,7 +843,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             EmitUncompressedMetaBlock(
                                 &input_ptr[metablock_start..],
                                 base.wrapping_sub(metablock_start),
-                                mlen_storage_ix.wrapping_sub(3usize),
+                                mlen_storage_ix.wrapping_sub(3),
                                 storage_ix,
                                 storage,
                             );
@@ -953,13 +913,13 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             let mut prev_hash: u32 = HashBytesAtOffset(input_bytes, 0i32, shift);
                             let cur_hash: u32 = HashBytesAtOffset(input_bytes, 3i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(3usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(3) as i32;
                             prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(2usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(2) as i32;
                             prev_hash = HashBytesAtOffset(input_bytes, 2i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(1usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(1) as i32;
                             candidate = base_ip.wrapping_add(table[cur_hash as usize] as usize);
                             table[cur_hash as usize] = ip_index.wrapping_sub(base_ip) as i32;
                         }
@@ -969,11 +929,9 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                         let matched: usize = (5usize).wrapping_add(FindMatchLengthWithLimit(
                             &input_ptr[candidate + 5..],
                             &input_ptr[ip_index + 5..],
-                            ip_end.wrapping_sub(ip_index).wrapping_sub(5usize),
+                            ip_end.wrapping_sub(ip_index).wrapping_sub(5),
                         ));
-                        if ip_index.wrapping_sub(candidate)
-                            > (1usize << 18i32).wrapping_sub(16usize)
-                        {
+                        if ip_index.wrapping_sub(candidate) > (1usize << 18i32).wrapping_sub(16) {
                             break;
                         }
                         ip_index = ip_index.wrapping_add(matched);
@@ -1006,13 +964,13 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             let mut prev_hash: u32 = HashBytesAtOffset(input_bytes, 0i32, shift);
                             let cur_hash: u32 = HashBytesAtOffset(input_bytes, 3i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(3usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(3) as i32;
                             prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(2usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(2) as i32;
                             prev_hash = HashBytesAtOffset(input_bytes, 2i32, shift);
                             table[prev_hash as usize] =
-                                ip_index.wrapping_sub(base_ip).wrapping_sub(1usize) as i32;
+                                ip_index.wrapping_sub(base_ip).wrapping_sub(1) as i32;
                             candidate = base_ip.wrapping_add(table[cur_hash as usize] as usize);
                             table[cur_hash as usize] = ip_index.wrapping_sub(base_ip) as i32;
                         }
@@ -1023,7 +981,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                     if code_block_selection as i32 == CodeBlockState::EMIT_COMMANDS as i32 {
                         next_hash = Hash(
                             &input_ptr[{
-                                ip_index = ip_index.wrapping_add(1usize);
+                                ip_index = ip_index.wrapping_add(1);
                                 ip_index
                             }..],
                             shift,
@@ -1045,7 +1003,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                 total_block_size = total_block_size.wrapping_add(block_size);
                 UpdateBits(
                     20usize,
-                    total_block_size.wrapping_sub(1usize) as u32,
+                    total_block_size.wrapping_sub(1) as u32,
                     mlen_storage_ix,
                     storage,
                 );
@@ -1080,7 +1038,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                     EmitUncompressedMetaBlock(
                         &input_ptr[metablock_start..],
                         ip_end.wrapping_sub(metablock_start),
-                        mlen_storage_ix.wrapping_sub(3usize),
+                        mlen_storage_ix.wrapping_sub(3),
                         storage_ix,
                         storage,
                     );
@@ -1111,7 +1069,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                 metablock_start = input_index;
                 block_size = brotli_min_size_t(input_size, kFirstBlockSize);
                 total_block_size = block_size;
-                mlen_storage_ix = (*storage_ix).wrapping_add(3usize);
+                mlen_storage_ix = (*storage_ix).wrapping_add(3);
                 BrotliStoreMetaBlockHeader(block_size, 0i32, storage_ix, storage);
                 BrotliWriteBits(13usize, 0, storage_ix, storage);
                 literal_ratio = BuildAndStoreLiteralPrefixCode(

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -20,26 +20,26 @@ fn EmitInsertLen(insertlen: u32, commands: &mut &mut [u32]) -> usize {
     if insertlen < 6u32 {
         (*commands)[0] = insertlen;
     } else if insertlen < 130u32 {
-        let tail: u32 = insertlen.wrapping_sub(2u32);
-        let nbits: u32 = Log2FloorNonZero(tail as (u64)).wrapping_sub(1u32);
+        let tail: u32 = insertlen.wrapping_sub(2);
+        let nbits: u32 = Log2FloorNonZero(tail as (u64)).wrapping_sub(1);
         let prefix: u32 = tail >> nbits;
-        let inscode: u32 = (nbits << 1i32).wrapping_add(prefix).wrapping_add(2u32);
+        let inscode: u32 = (nbits << 1i32).wrapping_add(prefix).wrapping_add(2);
         let extra: u32 = tail.wrapping_sub(prefix << nbits);
         (*commands)[0] = inscode | extra << 8i32;
     } else if insertlen < 2114u32 {
-        let tail: u32 = insertlen.wrapping_sub(66u32);
+        let tail: u32 = insertlen.wrapping_sub(66);
         let nbits: u32 = Log2FloorNonZero(tail as (u64));
-        let code: u32 = nbits.wrapping_add(10u32);
+        let code: u32 = nbits.wrapping_add(10);
         let extra: u32 = tail.wrapping_sub(1u32 << nbits);
         (*commands)[0] = code | extra << 8i32;
     } else if insertlen < 6210u32 {
-        let extra: u32 = insertlen.wrapping_sub(2114u32);
+        let extra: u32 = insertlen.wrapping_sub(2114);
         (*commands)[0] = 21u32 | extra << 8i32;
     } else if insertlen < 22594u32 {
-        let extra: u32 = insertlen.wrapping_sub(6210u32);
+        let extra: u32 = insertlen.wrapping_sub(6210);
         (*commands)[0] = 22u32 | extra << 8i32;
     } else {
-        let extra: u32 = insertlen.wrapping_sub(22594u32);
+        let extra: u32 = insertlen.wrapping_sub(22594);
         (*commands)[0] = 23u32 | extra << 8i32;
     }
     let remainder = core::mem::take(commands);
@@ -48,14 +48,14 @@ fn EmitInsertLen(insertlen: u32, commands: &mut &mut [u32]) -> usize {
 }
 
 fn EmitDistance(distance: u32, commands: &mut &mut [u32]) -> usize {
-    let d: u32 = distance.wrapping_add(3u32);
-    let nbits: u32 = Log2FloorNonZero(d as (u64)).wrapping_sub(1u32);
+    let d: u32 = distance.wrapping_add(3);
+    let nbits: u32 = Log2FloorNonZero(d as (u64)).wrapping_sub(1);
     let prefix: u32 = d >> nbits & 1u32;
     let offset: u32 = (2u32).wrapping_add(prefix) << nbits;
     let distcode: u32 = (2u32)
-        .wrapping_mul(nbits.wrapping_sub(1u32))
+        .wrapping_mul(nbits.wrapping_sub(1))
         .wrapping_add(prefix)
-        .wrapping_add(80u32);
+        .wrapping_add(80);
     let extra: u32 = d.wrapping_sub(offset);
     (*commands)[0] = distcode | extra << 8i32;
     let remainder = core::mem::take(commands);
@@ -65,23 +65,23 @@ fn EmitDistance(distance: u32, commands: &mut &mut [u32]) -> usize {
 
 fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
     if copylen < 12usize {
-        (*commands)[0] = copylen.wrapping_add(20usize) as u32;
+        (*commands)[0] = copylen.wrapping_add(20) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         1
     } else if copylen < 72usize {
-        let tail: usize = copylen.wrapping_sub(8usize);
-        let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1u32) as usize;
+        let tail: usize = copylen.wrapping_sub(8);
+        let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1) as usize;
         let prefix: usize = tail >> nbits;
-        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(28usize);
+        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(28);
         let extra: usize = tail.wrapping_sub(prefix << nbits);
         (*commands)[0] = (code | extra << 8i32) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         1
     } else if copylen < 136usize {
-        let tail: usize = copylen.wrapping_sub(8usize);
-        let code: usize = (tail >> 5i32).wrapping_add(54usize);
+        let tail: usize = copylen.wrapping_sub(8);
+        let code: usize = (tail >> 5i32).wrapping_add(54);
         let extra: usize = tail & 31usize;
         (*commands)[0] = (code | extra << 8i32) as u32;
         let remainder = core::mem::take(commands);
@@ -91,9 +91,9 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
         let _ = core::mem::replace(commands, &mut remainder2[1..]);
         2
     } else if copylen < 2120usize {
-        let tail: usize = copylen.wrapping_sub(72usize);
+        let tail: usize = copylen.wrapping_sub(72);
         let nbits: usize = Log2FloorNonZero(tail as u64) as usize;
-        let code: usize = nbits.wrapping_add(52usize);
+        let code: usize = nbits.wrapping_add(52);
         let extra: usize = tail.wrapping_sub(1usize << nbits);
         (*commands)[0] = (code | extra << 8i32) as u32;
         let remainder = core::mem::take(commands);
@@ -103,7 +103,7 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
         let _ = core::mem::replace(commands, &mut remainder2[1..]);
         2
     } else {
-        let extra: usize = copylen.wrapping_sub(2120usize);
+        let extra: usize = copylen.wrapping_sub(2120);
         (*commands)[0] = (63usize | extra << 8i32) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
@@ -124,22 +124,22 @@ fn HashBytesAtOffset(v: u64, offset: i32, shift: usize, length: usize) -> u32 {
 
 fn EmitCopyLen(copylen: usize, commands: &mut &mut [u32]) -> usize {
     if copylen < 10usize {
-        (*commands)[0] = copylen.wrapping_add(38usize) as u32;
+        (*commands)[0] = copylen.wrapping_add(38) as u32;
     } else if copylen < 134usize {
-        let tail: usize = copylen.wrapping_sub(6usize);
-        let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1u32) as usize;
+        let tail: usize = copylen.wrapping_sub(6);
+        let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1) as usize;
         let prefix: usize = tail >> nbits;
-        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(44usize);
+        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(44);
         let extra: usize = tail.wrapping_sub(prefix << nbits);
         (*commands)[0] = (code | extra << 8i32) as u32;
     } else if copylen < 2118usize {
-        let tail: usize = copylen.wrapping_sub(70usize);
+        let tail: usize = copylen.wrapping_sub(70);
         let nbits: usize = Log2FloorNonZero(tail as u64) as usize;
-        let code: usize = nbits.wrapping_add(52usize);
+        let code: usize = nbits.wrapping_add(52);
         let extra: usize = tail.wrapping_sub(1usize << nbits);
         (*commands)[0] = (code | extra << 8i32) as u32;
     } else {
-        let extra: usize = copylen.wrapping_sub(2118usize);
+        let extra: usize = copylen.wrapping_sub(2118);
         (*commands)[0] = (63usize | extra << 8i32) as u32;
     }
     let remainder = core::mem::take(commands);
@@ -157,8 +157,7 @@ fn IsMatch(p1: &[u8], p2: &[u8], length: usize) -> i32 {
         if length == 4 {
             return 1;
         }
-        return ((p1[(4usize)] as i32 == p2[(4usize)] as i32)
-            && (p1[(5usize)] as i32 == p2[(5usize)] as i32)) as i32;
+        return ((p1[4] as i32 == p2[4] as i32) && (p1[5] as i32 == p2[5] as i32)) as i32;
     }
     0
 }
@@ -250,7 +249,7 @@ fn CreateCommands(
                     }
                 }
                 if !(ip_index.wrapping_sub(candidate)
-                    > (1usize << 18i32).wrapping_sub(16usize) as isize as usize
+                    > (1usize << 18i32).wrapping_sub(16) as isize as usize
                     && (goto_emit_remainder == 0))
                 {
                     break;
@@ -305,35 +304,35 @@ fn CreateCommands(
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 3)..]);
                         cur_hash = HashBytesAtOffset(input_bytes, 3i32, shift, min_match);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1) as i32;
                     } else {
                         assert!(ip_index >= 5);
                         // could this be off the end FIXME
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 5)..]);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(5usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(5) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(4usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(4) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 2i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3) as i32;
                         assert!(ip_index >= 2);
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 2)..]);
                         cur_hash = HashBytesAtOffset(input_bytes, 2i32, shift, min_match);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1) as i32;
                     }
                     candidate = table[(cur_hash as usize)] as usize;
                     table[(cur_hash as usize)] = ip_index as i32;
                 }
             }
             while ip_index.wrapping_sub(candidate)
-                <= (1usize << 18i32).wrapping_sub(16usize) as isize as usize
+                <= (1usize << 18i32).wrapping_sub(16) as isize as usize
                 && (IsMatch(&base_ip[ip_index..], &base_ip[candidate..], min_match) != 0)
             {
                 let base_index: usize = ip_index;
@@ -366,26 +365,26 @@ fn CreateCommands(
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 3)..]);
                         cur_hash = HashBytesAtOffset(input_bytes, 3i32, shift, min_match);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 2i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1) as i32;
                     } else {
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 5)..]);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(5usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(5) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(4usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(4) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 2i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(3) as i32;
                         assert!(ip_index >= 2);
                         input_bytes = BROTLI_UNALIGNED_LOAD64(&base_ip[(ip_index - 2)..]);
                         cur_hash = HashBytesAtOffset(input_bytes, 2i32, shift, min_match);
                         prev_hash = HashBytesAtOffset(input_bytes, 0i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(2) as i32;
                         prev_hash = HashBytesAtOffset(input_bytes, 1i32, shift, min_match);
-                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1usize) as i32;
+                        table[(prev_hash as usize)] = ip_index.wrapping_sub(1) as i32;
                     }
                     candidate = table[(cur_hash as usize)] as usize;
                     table[(cur_hash as usize)] = ip_index as i32;
@@ -432,7 +431,7 @@ fn ShouldCompress(input: &[u8], input_size: usize, num_literals: usize) -> i32 {
                 let _lhs = &mut literal_histo[input[i] as usize];
                 *_lhs = (*_lhs).wrapping_add(_rhs as u32);
             }
-            i = i.wrapping_add(43usize);
+            i = i.wrapping_add(43);
         }
         if !!(BitsEntropy(&mut literal_histo[..], 256usize) < max_total_bit_cost) {
             1i32
@@ -494,11 +493,11 @@ fn BuildAndStoreCommandPrefixCode(
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);
     BrotliCreateHuffmanTree(
-        &histogram[64usize..],
+        &histogram[64..],
         64usize,
         14i32,
         &mut tree[..],
-        &mut depth[64usize..],
+        &mut depth[64..],
     );
     /* We have to jump through a few hoops here in order to compute
     the command bits because the symbols are in a different order than in
@@ -518,7 +517,7 @@ fn BuildAndStoreCommandPrefixCode(
     memcpy(bits, (24usize), &cmd_bits[..], 0, 48usize);
     memcpy(bits, (48usize), &cmd_bits[..], 32usize, 8usize);
     memcpy(bits, (56usize), &cmd_bits[..], 48usize, 8usize);
-    BrotliConvertBitDepthsToSymbols(&mut depth[64usize..], 64usize, &mut bits[64usize..]);
+    BrotliConvertBitDepthsToSymbols(&mut depth[64..], 64usize, &mut bits[64..]);
     {
         let mut i: usize;
         for item in cmd_depth[..64].iter_mut() {
@@ -550,7 +549,7 @@ fn BuildAndStoreCommandPrefixCode(
         );
     }
     BrotliStoreHuffmanTree(
-        &mut depth[64usize..],
+        &mut depth[64..],
         64usize,
         &mut tree[..],
         storage_ix,
@@ -623,22 +622,22 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
     }
     {
         let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[1usize];
+        let _lhs = &mut cmd_histo[1];
         *_lhs = (*_lhs).wrapping_add(_rhs as u32);
     }
     {
         let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[2usize];
+        let _lhs = &mut cmd_histo[2];
         *_lhs = (*_lhs).wrapping_add(_rhs as u32);
     }
     {
         let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[64usize];
+        let _lhs = &mut cmd_histo[64];
         *_lhs = (*_lhs).wrapping_add(_rhs as u32);
     }
     {
         let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[84usize];
+        let _lhs = &mut cmd_histo[84];
         *_lhs = (*_lhs).wrapping_add(_rhs as u32);
     }
     BuildAndStoreCommandPrefixCode(
@@ -795,7 +794,7 @@ compress_specialization!(17, BrotliCompressFragmentTwoPassImpl17);
 
 fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mut [u8]) {
     let bitpos: usize = new_storage_ix & 7usize;
-    let mask: usize = (1u32 << bitpos).wrapping_sub(1u32) as usize;
+    let mask: usize = (1u32 << bitpos).wrapping_sub(1) as usize;
     {
         let _rhs = mask as u8;
         let _lhs = &mut storage[(new_storage_ix >> 3i32)];

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -661,7 +661,7 @@ fn RingBufferSetup<AllocU8: alloc::Allocator<u8>>(
     let window_bits: i32 = ComputeRbBits(params);
     let tail_bits: i32 = params.lgblock;
     rb.size_ = 1u32 << window_bits;
-    rb.mask_ = (1u32 << window_bits).wrapping_sub(1u32);
+    rb.mask_ = (1u32 << window_bits).wrapping_sub(1);
     rb.tail_size_ = 1u32 << tail_bits;
     rb.total_size_ = rb.size_.wrapping_add(rb.tail_size_);
 }
@@ -787,7 +787,7 @@ fn RingBufferInitBuffer<AllocU8: alloc::Allocator<u8>>(
     let _ = core::mem::replace(&mut rb.data_mo, new_data);
     rb.cur_size_ = buflen;
     rb.buffer_index = 2usize;
-    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2usize))] = 0;
+    rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(2))] = 0;
     rb.data_mo.slice_mut()[(rb.buffer_index.wrapping_sub(1))] = 0;
     i = 0usize;
     while i < kSlackForEightByteHashingEverywhere {
@@ -836,7 +836,7 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
         rb.data_mo.slice_mut()[rb
             .buffer_index
             .wrapping_add(rb.size_ as usize)
-            .wrapping_sub(2usize)] = 0u8;
+            .wrapping_sub(2)] = 0u8;
         rb.data_mo.slice_mut()[rb
             .buffer_index
             .wrapping_add(rb.size_ as usize)
@@ -865,8 +865,8 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
     let data_2 = rb.data_mo.slice()[rb
         .buffer_index
         .wrapping_add(rb.size_ as usize)
-        .wrapping_sub(2usize)];
-    rb.data_mo.slice_mut()[rb.buffer_index.wrapping_sub(2usize)] = data_2;
+        .wrapping_sub(2)];
+    rb.data_mo.slice_mut()[rb.buffer_index.wrapping_sub(2)] = data_2;
     let data_1 = rb.data_mo.slice()[rb
         .buffer_index
         .wrapping_add(rb.size_ as usize)
@@ -874,7 +874,7 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
     rb.data_mo.slice_mut()[rb.buffer_index.wrapping_sub(1)] = data_1;
     rb.pos_ = rb.pos_.wrapping_add(n as u32);
     if rb.pos_ > 1u32 << 30i32 {
-        rb.pos_ = rb.pos_ & (1u32 << 30i32).wrapping_sub(1u32) | 1u32 << 30i32;
+        rb.pos_ = rb.pos_ & (1u32 << 30i32).wrapping_sub(1) | 1u32 << 30i32;
     }
 }
 
@@ -1105,7 +1105,7 @@ fn InitializeH5<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
             hash_shift_: 32i32 - params.hasher.bucket_bits,
             bucket_size_: bucket_size as u32,
             block_bits_: params.hasher.block_bits,
-            block_mask_: block_size.wrapping_sub(1u64) as u32,
+            block_mask_: block_size.wrapping_sub(1) as u32,
         },
     })
 }
@@ -1280,7 +1280,7 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
     } else {
         true
     };
-    let max_dict_size: usize = (1usize << s.params.lgwin).wrapping_sub(16usize);
+    let max_dict_size: usize = (1usize << s.params.lgwin).wrapping_sub(16);
     s.hasher_ = opt_hasher;
     let mut dict_size: usize = size;
     if EnsureInitialized(s) == 0 {
@@ -1303,7 +1303,7 @@ pub fn BrotliEncoderSetCustomDictionaryWithOptionalPrecomputedHasher<Alloc: Brot
         s.prev_byte_ = dict[dict_size.wrapping_sub(1)];
     }
     if dict_size > 1 {
-        s.prev_byte2_ = dict[dict_size.wrapping_sub(2usize)];
+        s.prev_byte2_ = dict[dict_size.wrapping_sub(2)];
     }
     let m16 = &mut s.m8;
     if cfg!(debug_assertions) || !has_optional_hasher {
@@ -1376,7 +1376,7 @@ fn ShouldCompress(
     num_literals: usize,
     num_commands: usize,
 ) -> i32 {
-    if num_commands < (bytes >> 8i32).wrapping_add(2usize)
+    if num_commands < (bytes >> 8i32).wrapping_add(2)
         && num_literals as (super::util::floatX)
             > 0.99 as super::util::floatX * bytes as (super::util::floatX)
     {
@@ -1466,7 +1466,7 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
     let mut result: usize = 0usize;
     let mut offset: usize = 0usize;
     if input_size == 0usize {
-        output[(0)] = 6u8;
+        output[0] = 6u8;
         return 1;
     }
     output[{
@@ -1495,7 +1495,7 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
             } as u32;
         }
         let bits: u32 = nibbles << 1i32
-            | chunk_size.wrapping_sub(1u32) << 3i32
+            | chunk_size.wrapping_sub(1) << 3i32
             | 1u32 << (19u32).wrapping_add((4u32).wrapping_mul(nibbles));
         output[{
             let _old = result;
@@ -1641,23 +1641,23 @@ fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<A
     s.last_bytes_bits_ = 0;
     seal |= 0x6u32 << seal_bits;
 
-    seal_bits = seal_bits.wrapping_add(6usize);
+    seal_bits = seal_bits.wrapping_add(6);
     if !IsNextOutNull(&s.next_out_) {
         destination = &mut GetNextOut!(*s)[s.available_out_..];
     } else {
         destination = &mut s.tiny_buf_[..];
         s.next_out_ = NextOut::TinyBuf(0);
     }
-    destination[(0)] = seal as u8;
+    destination[0] = seal as u8;
     if seal_bits > 8usize {
-        destination[(1)] = (seal >> 8i32) as u8;
+        destination[1] = (seal >> 8i32) as u8;
     }
     if seal_bits > 16usize {
-        destination[(2usize)] = (seal >> 16i32) as u8;
+        destination[2] = (seal >> 16i32) as u8;
     }
     s.available_out_ = s
         .available_out_
-        .wrapping_add(seal_bits.wrapping_add(7usize) >> 3i32);
+        .wrapping_add(seal_bits.wrapping_add(7) >> 3i32);
 }
 fn InjectFlushOrPushOutput<Alloc: BrotliAlloc>(
     s: &mut BrotliEncoderStateStruct<Alloc>,
@@ -1719,8 +1719,8 @@ fn WrapPosition(position: u64) -> u32 {
     let mut result: u32 = position as u32;
     let gb: u64 = position >> 30i32;
     if gb > 2 {
-        result = result & (1u32 << 30i32).wrapping_sub(1u32)
-            | ((gb.wrapping_sub(1) & 1) as u32).wrapping_add(1u32) << 30i32;
+        result = result & (1u32 << 30i32).wrapping_sub(1)
+            | ((gb.wrapping_sub(1) & 1) as u32).wrapping_add(1) << 30i32;
     }
     result
 }
@@ -1847,21 +1847,21 @@ fn ChooseContextMap(
         {
             {
                 let _rhs = bigram_histo[i];
-                let _lhs = &mut monogram_histo[i.wrapping_rem(3usize)];
+                let _lhs = &mut monogram_histo[i.wrapping_rem(3)];
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
             {
                 let _rhs = bigram_histo[i];
-                let _lhs = &mut two_prefix_histo[i.wrapping_rem(6usize)];
+                let _lhs = &mut two_prefix_histo[i.wrapping_rem(6)];
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
         }
         i = i.wrapping_add(1);
     }
     entropy[1] = ShannonEntropy(&monogram_histo[..], 3usize, &mut dummy);
-    entropy[2usize] = ShannonEntropy(&two_prefix_histo[..], 3usize, &mut dummy)
-        + ShannonEntropy(&two_prefix_histo[3usize..], 3usize, &mut dummy);
-    entropy[3usize] = 0i32 as (super::util::floatX);
+    entropy[2] = ShannonEntropy(&two_prefix_histo[..], 3usize, &mut dummy)
+        + ShannonEntropy(&two_prefix_histo[3..], 3usize, &mut dummy);
+    entropy[3] = 0i32 as (super::util::floatX);
     i = 0usize;
     while i < 3usize {
         {
@@ -1870,14 +1870,14 @@ fn ChooseContextMap(
                 3usize,
                 &mut dummy,
             );
-            let _lhs = &mut entropy[3usize];
+            let _lhs = &mut entropy[3];
             *_lhs += _rhs;
         }
         i = i.wrapping_add(1);
     }
     let total: usize = monogram_histo[0]
         .wrapping_add(monogram_histo[1])
-        .wrapping_add(monogram_histo[2usize]) as usize;
+        .wrapping_add(monogram_histo[2]) as usize;
     0i32;
     entropy[0] = 1.0 as super::util::floatX / total as (super::util::floatX);
     {
@@ -1887,22 +1887,22 @@ fn ChooseContextMap(
     }
     {
         let _rhs = entropy[0];
-        let _lhs = &mut entropy[2usize];
+        let _lhs = &mut entropy[2];
         *_lhs *= _rhs;
     }
     {
         let _rhs = entropy[0];
-        let _lhs = &mut entropy[3usize];
+        let _lhs = &mut entropy[3];
         *_lhs *= _rhs;
     }
     if quality < 7i32 {
-        entropy[3usize] = entropy[1] * 10i32 as (super::util::floatX);
+        entropy[3] = entropy[1] * 10i32 as (super::util::floatX);
     }
-    if entropy[1] - entropy[2usize] < 0.2 as super::util::floatX
-        && (entropy[1] - entropy[3usize] < 0.2 as super::util::floatX)
+    if entropy[1] - entropy[2] < 0.2 as super::util::floatX
+        && (entropy[1] - entropy[3] < 0.2 as super::util::floatX)
     {
         *num_literal_contexts = 1;
-    } else if entropy[2usize] - entropy[3usize] < 0.02 as super::util::floatX {
+    } else if entropy[2] - entropy[3] < 0.02 as super::util::floatX {
         *num_literal_contexts = 2usize;
         *literal_context_map = &kStaticContextMapSimpleUTF8[..];
     } else {
@@ -2028,10 +2028,10 @@ fn DecideOverLiteralContextModeling(
         let end_pos: usize = start_pos.wrapping_add(length);
         let mut bigram_prefix_histo: [u32; 9] =
             [0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32, 0u32];
-        while start_pos.wrapping_add(64usize) <= end_pos {
+        while start_pos.wrapping_add(64) <= end_pos {
             {
                 static lut: [i32; 4] = [0i32, 0i32, 1i32, 2i32];
-                let stride_end_pos: usize = start_pos.wrapping_add(64usize);
+                let stride_end_pos: usize = start_pos.wrapping_add(64);
                 let mut prev: i32 = lut[(input[(start_pos & mask)] as i32 >> 6i32) as usize] * 3i32;
                 let mut pos: usize;
                 pos = start_pos.wrapping_add(1);
@@ -2049,7 +2049,7 @@ fn DecideOverLiteralContextModeling(
                     pos = pos.wrapping_add(1);
                 }
             }
-            start_pos = start_pos.wrapping_add(4096usize);
+            start_pos = start_pos.wrapping_add(4096);
         }
         ChooseContextMap(
             quality,
@@ -2505,10 +2505,10 @@ where
     {
         let mut newsize: usize = s
             .num_commands_
-            .wrapping_add(bytes.wrapping_div(2u32) as usize)
+            .wrapping_add(bytes.wrapping_div(2) as usize)
             .wrapping_add(1);
         if newsize > s.cmd_alloc_size_ {
-            newsize = newsize.wrapping_add(bytes.wrapping_div(4u32).wrapping_add(16u32) as usize);
+            newsize = newsize.wrapping_add(bytes.wrapping_div(4).wrapping_add(16) as usize);
             s.cmd_alloc_size_ = newsize;
             let mut new_commands = <Alloc as Allocator<Command>>::alloc_cell(&mut s.m8, newsize);
             if !s.commands_.slice().is_empty() {
@@ -2595,8 +2595,8 @@ where
     }
     {
         let max_length: usize = MaxMetablockSize(&mut s.params);
-        let max_literals: usize = max_length.wrapping_div(8usize);
-        let max_commands: usize = max_length.wrapping_div(8usize);
+        let max_literals: usize = max_length.wrapping_div(8);
+        let max_commands: usize = max_length.wrapping_div(8);
         let processed_bytes: usize = s.input_pos_.wrapping_sub(s.last_flush_pos_) as usize;
         let next_input_fits_metablock: i32 =
             if !!(processed_bytes.wrapping_add(InputBlockSize(s)) <= max_length) {
@@ -2644,8 +2644,8 @@ where
     {
         let metablock_size: u32 = s.input_pos_.wrapping_sub(s.last_flush_pos_) as u32;
         //let mut storage_ix: usize = (*s).last_bytes_bits_ as usize;
-        //(*s).storage_.slice_mut()[(0)] = (*s).last_bytes_ as u8;
-        //(*s).storage_.slice_mut()[(1)] = ((*s).last_bytes_ >> 8) as u8;
+        //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
+        //(*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
 
         WriteMetaBlockInternal(
             &mut s.m8,
@@ -2681,7 +2681,7 @@ where
         }
         let data = &s.ringbuffer_.data_mo.slice()[s.ringbuffer_.buffer_index..];
         if s.last_flush_pos_ > 0 {
-            s.prev_byte_ = data[(((s.last_flush_pos_ as u32).wrapping_sub(1u32) & mask) as usize)];
+            s.prev_byte_ = data[(((s.last_flush_pos_ as u32).wrapping_sub(1) & mask) as usize)];
         }
         if s.last_flush_pos_ > 1 {
             s.prev_byte2_ = data[((s.last_flush_pos_.wrapping_sub(2) as u32 & mask) as usize)];
@@ -2701,8 +2701,8 @@ fn WriteMetadataHeader<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Allo
     let header = GetNextOut!(*s);
     let mut storage_ix: usize;
     storage_ix = s.last_bytes_bits_ as usize;
-    header[(0)] = s.last_bytes_ as u8;
-    header[(1)] = (s.last_bytes_ >> 8) as u8;
+    header[0] = s.last_bytes_ as u8;
+    header[1] = (s.last_bytes_ >> 8) as u8;
     s.last_bytes_ = 0;
     s.last_bytes_bits_ = 0;
     BrotliWriteBits(1, 0, &mut storage_ix, header);
@@ -2714,9 +2714,9 @@ fn WriteMetadataHeader<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Allo
         let nbits: u32 = if block_size == 1 {
             0u32
         } else {
-            Log2FloorNonZero((block_size as u32).wrapping_sub(1u32) as (u64)).wrapping_add(1u32)
+            Log2FloorNonZero((block_size as u32).wrapping_sub(1) as (u64)).wrapping_add(1)
         };
-        let nbytes: u32 = nbits.wrapping_add(7u32).wrapping_div(8u32);
+        let nbytes: u32 = nbits.wrapping_add(7).wrapping_div(8);
         BrotliWriteBits(2usize, nbytes as (u64), &mut storage_ix, header);
         BrotliWriteBits(
             (8u32).wrapping_mul(nbytes) as usize,
@@ -2921,7 +2921,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             let force_flush: i32 = (*available_in == block_size
                 && (op as i32 == BrotliEncoderOperation::BROTLI_OPERATION_FLUSH as i32))
                 as i32;
-            let max_out_size: usize = (2usize).wrapping_mul(block_size).wrapping_add(503usize);
+            let max_out_size: usize = (2usize).wrapping_mul(block_size).wrapping_add(503);
             let mut inplace: i32 = 1i32;
             let storage: &mut [u8];
             let mut storage_ix: usize = s.last_bytes_bits_ as usize;
@@ -2942,8 +2942,8 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 GetBrotliStorage(s, max_out_size);
                 storage = s.storage_.slice_mut();
             }
-            storage[(0)] = s.last_bytes_ as u8;
-            storage[(1)] = (s.last_bytes_ >> 8) as u8;
+            storage[0] = s.last_bytes_ as u8;
+            storage[1] = (s.last_bytes_ >> 8) as u8;
             let table: &mut [i32] = GetHashTable!(s, s.params.quality, block_size, &mut table_size);
             if s.params.quality == 0i32 {
                 BrotliCompressFragmentFast(

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -188,7 +188,7 @@ pub fn BrotliCreateHuffmanTree(
                 }
             }
             if n == 1 {
-                depth[((tree[(0)]).index_right_or_value_ as usize)] = 1u8;
+                depth[((tree[0]).index_right_or_value_ as usize)] = 1u8;
                 {
                     {
                         break 'break1;
@@ -242,7 +242,7 @@ pub fn BrotliCreateHuffmanTree(
                 }
             }
         }
-        count_limit = count_limit.wrapping_mul(2u32);
+        count_limit = count_limit.wrapping_mul(2);
     }
 }
 pub fn BrotliOptimizeHuffmanCountsForRle(
@@ -317,7 +317,7 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
         *rle_item = 0;
     }
     {
-        let mut symbol: u32 = counts[(0)];
+        let mut symbol: u32 = counts[0];
         let mut step: usize = 0usize;
         i = 0usize;
         while i <= length {
@@ -346,13 +346,9 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     }
     stride = 0usize;
     limit = (256u32)
-        .wrapping_mul(
-            (counts[(0)])
-                .wrapping_add(counts[(1)])
-                .wrapping_add(counts[(2usize)]),
-        )
-        .wrapping_div(3u32)
-        .wrapping_add(420u32) as usize;
+        .wrapping_mul((counts[0]).wrapping_add(counts[1]).wrapping_add(counts[2]))
+        .wrapping_div(3)
+        .wrapping_add(420) as usize;
     sum = 0usize;
     i = 0usize;
     while i <= length {
@@ -368,7 +364,7 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 if stride >= 4usize || stride >= 3usize && (sum == 0usize) {
                     let mut k: usize;
                     let mut count: usize = sum
-                        .wrapping_add(stride.wrapping_div(2usize))
+                        .wrapping_add(stride.wrapping_div(2))
                         .wrapping_div(stride);
                     if count == 0usize {
                         count = 1;
@@ -386,15 +382,15 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 }
                 stride = 0usize;
                 sum = 0usize;
-                if i < length.wrapping_sub(2usize) {
+                if i < length.wrapping_sub(2) {
                     limit = (256u32)
                         .wrapping_mul(
                             (counts[i])
                                 .wrapping_add(counts[i.wrapping_add(1)])
-                                .wrapping_add(counts[i.wrapping_add(2usize)]),
+                                .wrapping_add(counts[i.wrapping_add(2)]),
                         )
-                        .wrapping_div(3u32)
-                        .wrapping_add(420u32) as usize;
+                        .wrapping_div(3)
+                        .wrapping_add(420) as usize;
                 } else if i < length {
                     limit = (256u32).wrapping_mul(counts[i]) as usize;
                 } else {
@@ -407,11 +403,11 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
                 if stride >= 4usize {
                     limit = (256usize)
                         .wrapping_mul(sum)
-                        .wrapping_add(stride.wrapping_div(2usize))
+                        .wrapping_add(stride.wrapping_div(2))
                         .wrapping_div(stride);
                 }
                 if stride == 4usize {
-                    limit = limit.wrapping_add(120usize);
+                    limit = limit.wrapping_add(120);
                 }
             }
         }
@@ -452,12 +448,12 @@ pub fn DecideOverRleUse(
         }
         i = i.wrapping_add(reps);
     }
-    *use_rle_for_non_zero = if !!(total_reps_non_zero > count_reps_non_zero.wrapping_mul(2usize)) {
+    *use_rle_for_non_zero = if !!(total_reps_non_zero > count_reps_non_zero.wrapping_mul(2)) {
         1i32
     } else {
         0i32
     };
-    *use_rle_for_zero = if !!(total_reps_zero > count_reps_zero.wrapping_mul(2usize)) {
+    *use_rle_for_zero = if !!(total_reps_zero > count_reps_zero.wrapping_mul(2)) {
         1i32
     } else {
         0i32
@@ -507,7 +503,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
         }
     } else {
         let start: usize = *tree_size;
-        repetitions = repetitions.wrapping_sub(3usize);
+        repetitions = repetitions.wrapping_sub(3);
         while 1i32 != 0 {
             tree[*tree_size] = 16u8;
             extra_bits_data[*tree_size] = (repetitions & 0x3usize) as u8;
@@ -550,7 +546,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
         }
     } else {
         let start: usize = *tree_size;
-        repetitions = repetitions.wrapping_sub(3usize);
+        repetitions = repetitions.wrapping_sub(3);
         while 1i32 != 0 {
             tree[*tree_size] = 17u8;
             extra_bits_data[*tree_size] = (repetitions & 0x7usize) as u8;
@@ -646,7 +642,7 @@ fn BrotliReverseBits(num_bits: usize, mut bits: u16) -> u16 {
             bits = (bits as i32 >> 4i32) as u16;
             retval |= kLut[(bits as i32 & 0xfi32) as usize];
         }
-        i = i.wrapping_add(4usize);
+        i = i.wrapping_add(4);
     }
     retval >>= (0usize.wrapping_sub(num_bits) & 0x3usize);
     retval as u16

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -538,7 +538,7 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
             }
             pos = pos.wrapping_add(CommandCopyLen(cmd) as usize);
             if CommandCopyLen(cmd) != 0 {
-                prev_byte2 = ringbuffer[(pos.wrapping_sub(2usize) & mask)];
+                prev_byte2 = ringbuffer[(pos.wrapping_sub(2) & mask)];
                 prev_byte = ringbuffer[(pos.wrapping_sub(1) & mask)];
                 if cmd.cmd_prefix_ as i32 >= 128i32 {
                     BlockSplitIteratorNext(&mut dist_it);

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -42,10 +42,10 @@ fn DecideMultiByteStatsLevel(pos: usize, len: usize, mask: usize, data: &[u8]) -
         }
         i = i.wrapping_add(1);
     }
-    if counts[2usize] < 500usize {
+    if counts[2] < 500usize {
         max_utf8 = 1;
     }
-    if counts[1].wrapping_add(counts[2usize]) < 25usize {
+    if counts[1].wrapping_add(counts[2]) < 25usize {
         max_utf8 = 0usize;
     }
     max_utf8
@@ -100,13 +100,13 @@ fn EstimateBitCostsForLiteralsUTF8(
                         .wrapping_sub(1)
                         & mask)] as i32
                 }) as usize;
-                let last_c: usize = (if i < window_half.wrapping_add(2usize) {
+                let last_c: usize = (if i < window_half.wrapping_add(2) {
                     0i32
                 } else {
                     data[(pos
                         .wrapping_add(i)
                         .wrapping_sub(window_half)
-                        .wrapping_sub(2usize)
+                        .wrapping_sub(2)
                         & mask)] as i32
                 }) as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
@@ -131,7 +131,7 @@ fn EstimateBitCostsForLiteralsUTF8(
                 let last_c: usize = data[(pos
                     .wrapping_add(i)
                     .wrapping_add(window_half)
-                    .wrapping_sub(2usize)
+                    .wrapping_sub(2)
                     & mask)] as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
                 {
@@ -155,7 +155,7 @@ fn EstimateBitCostsForLiteralsUTF8(
                 let last_c: usize = (if i < 2usize {
                     0i32
                 } else {
-                    data[(pos.wrapping_add(i).wrapping_sub(2usize) & mask)] as i32
+                    data[(pos.wrapping_add(i).wrapping_sub(2) & mask)] as i32
                 }) as usize;
                 let utf8_pos: usize = UTF8Position(last_c, c, max_utf8);
                 let masked_pos: usize = pos.wrapping_add(i) & mask;

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -430,7 +430,7 @@ fn InitBlockSplitter<
             };
             let mut new_array: <Alloc as Allocator<u8>>::AllocatedMemory;
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             if (!split.types.slice().is_empty()) {
@@ -451,7 +451,7 @@ fn InitBlockSplitter<
                 split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             new_array.slice_mut()[..split.lengths.slice().len()]
@@ -515,7 +515,7 @@ fn InitContextBlockSplitter<
                 split.types.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u8>>::alloc_cell(alloc, _new_size);
             if (!split.types.slice().is_empty()) {
@@ -536,7 +536,7 @@ fn InitContextBlockSplitter<
                 split.lengths.slice().len()
             };
             while _new_size < max_num_blocks {
-                _new_size = _new_size.wrapping_mul(2usize);
+                _new_size = _new_size.wrapping_mul(2);
             }
             let mut new_array = <Alloc as Allocator<u32>>::alloc_cell(alloc, _new_size);
             if (!split.lengths.slice().is_empty()) {
@@ -571,10 +571,10 @@ fn BlockSplitterFinishBlock<
 ) {
     xself.block_size_ = brotli_max_size_t(xself.block_size_, xself.min_block_size_);
     if xself.num_blocks_ == 0usize {
-        split.lengths.slice_mut()[(0)] = xself.block_size_ as u32;
-        split.types.slice_mut()[(0)] = 0u8;
-        xself.last_entropy_[(0)] = BitsEntropy((histograms[(0)]).slice(), xself.alphabet_size_);
-        xself.last_entropy_[(1)] = xself.last_entropy_[(0)];
+        split.lengths.slice_mut()[0] = xself.block_size_ as u32;
+        split.types.slice_mut()[0] = 0u8;
+        xself.last_entropy_[0] = BitsEntropy((histograms[0]).slice(), xself.alphabet_size_);
+        xself.last_entropy_[1] = xself.last_entropy_[0];
         xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
         split.num_types = split.num_types.wrapping_add(1);
         xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1);
@@ -615,8 +615,8 @@ fn BlockSplitterFinishBlock<
             split.types.slice_mut()[xself.num_blocks_] = split.num_types as u8;
             xself.last_histogram_ix_[1] = xself.last_histogram_ix_[0];
             xself.last_histogram_ix_[0] = split.num_types as u8 as usize;
-            xself.last_entropy_[(1)] = xself.last_entropy_[(0)];
-            xself.last_entropy_[(0)] = entropy;
+            xself.last_entropy_[1] = xself.last_entropy_[0];
+            xself.last_entropy_[0] = entropy;
             xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
             split.num_types = split.num_types.wrapping_add(1);
             xself.curr_histogram_ix_ = xself.curr_histogram_ix_.wrapping_add(1);
@@ -629,13 +629,13 @@ fn BlockSplitterFinishBlock<
         } else if diff[1] < diff[0] - 20.0 as super::util::floatX {
             split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
             split.types.slice_mut()[xself.num_blocks_] =
-                split.types.slice()[xself.num_blocks_.wrapping_sub(2usize)]; //FIXME: investigate copy?
+                split.types.slice()[xself.num_blocks_.wrapping_sub(2)]; //FIXME: investigate copy?
             {
                 xself.last_histogram_ix_.swap(0, 1);
             }
             histograms[xself.last_histogram_ix_[0]] = combined_histo[1].clone();
-            xself.last_entropy_[(1)] = xself.last_entropy_[(0)];
-            xself.last_entropy_[(0)] = combined_entropy[1];
+            xself.last_entropy_[1] = xself.last_entropy_[0];
+            xself.last_entropy_[0] = combined_entropy[1];
             xself.num_blocks_ = xself.num_blocks_.wrapping_add(1);
             xself.block_size_ = 0usize;
             HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
@@ -648,9 +648,9 @@ fn BlockSplitterFinishBlock<
                 *_lhs = (*_lhs).wrapping_add(_rhs);
             }
             histograms[xself.last_histogram_ix_[0]] = combined_histo[0].clone();
-            xself.last_entropy_[(0)] = combined_entropy[0];
+            xself.last_entropy_[0] = combined_entropy[0];
             if split.num_types == 1 {
-                xself.last_entropy_[(1)] = xself.last_entropy_[(0)];
+                xself.last_entropy_[1] = xself.last_entropy_[0];
             }
             xself.block_size_ = 0usize;
             HistogramClear(&mut histograms[xself.curr_histogram_ix_]);
@@ -688,8 +688,8 @@ fn ContextBlockSplitterFinishBlock<
     }
     if xself.num_blocks_ == 0usize {
         let mut i: usize;
-        split.lengths.slice_mut()[(0)] = xself.block_size_ as u32;
-        split.types.slice_mut()[(0)] = 0u8;
+        split.lengths.slice_mut()[0] = xself.block_size_ as u32;
+        split.types.slice_mut()[0] = 0u8;
         i = 0usize;
         while i < num_contexts {
             {
@@ -773,7 +773,7 @@ fn ContextBlockSplitterFinishBlock<
             xself.target_block_size_ = xself.min_block_size_;
         } else if diff[1] < diff[0] - 20.0 as super::util::floatX {
             split.lengths.slice_mut()[xself.num_blocks_] = xself.block_size_ as u32;
-            let nbm2 = split.types.slice()[xself.num_blocks_.wrapping_sub(2usize)];
+            let nbm2 = split.types.slice()[xself.num_blocks_.wrapping_sub(2)];
             split.types.slice_mut()[xself.num_blocks_] = nbm2;
 
             {
@@ -1030,7 +1030,7 @@ pub fn BrotliBuildMetaBlockGreedyInternal<
             }
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as usize);
             if CommandCopyLen(&cmd) != 0 {
-                prev_byte2 = ringbuffer[(pos.wrapping_sub(2usize) & mask)];
+                prev_byte2 = ringbuffer[(pos.wrapping_sub(2) & mask)];
                 prev_byte = ringbuffer[(pos.wrapping_sub(1) & mask)];
                 if cmd.cmd_prefix_ as i32 >= 128i32 {
                     BlockSplitterAddSymbol(

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -81,7 +81,7 @@ macro_rules! sub_match {
             $s1_as_64 = BROTLI_UNALIGNED_LOAD64(&$s1_lo[(index << 3)..((index + 1) << 3)]);
             $s2_as_64 = BROTLI_UNALIGNED_LOAD64(&$s2_lo[(index << 3)..((index + 1) << 3)]);
             if $s2_as_64 == $s1_as_64 {
-                $matched = $matched.wrapping_add(8usize) as u32 as usize;
+                $matched = $matched.wrapping_add(8) as u32 as usize;
             } else {
                 $matched = $matched
                     .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3i32) as usize)
@@ -100,7 +100,7 @@ macro_rules! sub_match8 {
         $s2_as_64 = BROTLI_UNALIGNED_LOAD64($s2);
         $s2 = $s2.split_at(8).1;
         if $s2_as_64 == $s1_as_64 {
-            $matched = $matched.wrapping_add(8usize) as u32 as usize;
+            $matched = $matched.wrapping_add(8) as u32 as usize;
         } else {
             $matched = $matched
                 .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3i32) as usize)
@@ -248,7 +248,7 @@ mod test {
         let mut a = [91u8; 600000];
         let mut b = [0u8; 600000];
         for i in 1..a.len() {
-            a[i] = (a[i - 1] % 19u8).wrapping_add(17u8);
+            a[i] = (a[i - 1] % 19u8).wrapping_add(17);
         }
         construct_situation(&a[..], &mut b[..], a.len(), 0);
         assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 0);
@@ -354,14 +354,14 @@ pub fn IsMatch(dictionary: &BrotliDictionary, w: DictWord, data: &[u8], max_leng
                 0i32
             }
         } else if w.transform() as i32 == 10i32 {
-            if !!(dict[(0)] as i32 >= b'a' as i32
-                && (dict[(0)] as i32 <= b'z' as i32)
-                && (dict[(0)] as i32 ^ 32i32 == data[(0)] as i32)
+            if !!(dict[0] as i32 >= b'a' as i32
+                && (dict[0] as i32 <= b'z' as i32)
+                && (dict[0] as i32 ^ 32i32 == data[0] as i32)
                 && (FindMatchLengthWithLimit(
                     dict.split_at(1).1,
                     data.split_at(1).1,
-                    (w.len() as u32).wrapping_sub(1u32) as usize,
-                ) == (w.len() as u32).wrapping_sub(1u32) as usize))
+                    (w.len() as u32).wrapping_sub(1) as usize,
+                ) == (w.len() as u32).wrapping_sub(1) as usize))
             {
                 1i32
             } else {
@@ -471,24 +471,24 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     AddMatch(id, l, l, matches);
                     has_found_match = 1i32;
                 }
-                if matchlen >= l.wrapping_sub(1usize) {
+                if matchlen >= l.wrapping_sub(1) {
                     //eprint!("Bdding match {} {} {}\n", w.len(), w.transform(), w.idx());
                     AddMatch(
                         id.wrapping_add((12usize).wrapping_mul(n)),
-                        l.wrapping_sub(1usize),
+                        l.wrapping_sub(1),
                         l,
                         matches,
                     );
-                    if l.wrapping_add(2usize) < max_length
-                        && (data[(l.wrapping_sub(1usize) as usize)] as i32 == b'i' as i32)
+                    if l.wrapping_add(2) < max_length
+                        && (data[(l.wrapping_sub(1) as usize)] as i32 == b'i' as i32)
                         && (data[(l as usize)] as i32 == b'n' as i32)
-                        && (data[(l.wrapping_add(1usize) as usize)] as i32 == b'g' as i32)
-                        && (data[(l.wrapping_add(2usize) as usize)] as i32 == b' ' as i32)
+                        && (data[(l.wrapping_add(1) as usize)] as i32 == b'g' as i32)
+                        && (data[(l.wrapping_add(2) as usize)] as i32 == b' ' as i32)
                     {
                         //eprint!("Cdding match {} {} {}\n", w.len(), w.transform(), w.idx());
                         AddMatch(
                             id.wrapping_add((49usize).wrapping_mul(n)),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
@@ -497,9 +497,9 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 }
                 minlen = min_length;
                 if l > 9usize {
-                    minlen = brotli_max_size_t(minlen, l.wrapping_sub(9usize));
+                    minlen = brotli_max_size_t(minlen, l.wrapping_sub(9));
                 }
-                let maxlen: usize = brotli_min_size_t(matchlen, l.wrapping_sub(2usize));
+                let maxlen: usize = brotli_min_size_t(matchlen, l.wrapping_sub(2));
                 len = minlen;
                 while len <= maxlen {
                     {
@@ -517,455 +517,443 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     }
                     len = len.wrapping_add(1);
                 }
-                if matchlen < l || l.wrapping_add(6usize) >= max_length {
+                if matchlen < l || l.wrapping_add(6) >= max_length {
                     {
                         continue;
                     }
                 }
                 let s: &[u8] = data.split_at(l as usize).1;
-                if s[(0)] as i32 == b' ' as i32 {
+                if s[0] as i32 == b' ' as i32 {
                     //eprint!("Edding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
-                    AddMatch(id.wrapping_add(n), l.wrapping_add(1usize), l, matches);
-                    if s[(1usize)] as i32 == b'a' as i32 {
-                        if s[(2usize)] as i32 == b' ' as i32 {
+                    AddMatch(id.wrapping_add(n), l.wrapping_add(1), l, matches);
+                    if s[1] as i32 == b'a' as i32 {
+                        if s[2] as i32 == b' ' as i32 {
                             //eprint!("Fdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((28usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
-                        } else if s[(2usize)] as i32 == b's' as i32 {
-                            if s[(3usize)] as i32 == b' ' as i32 {
+                        } else if s[2] as i32 == b's' as i32 {
+                            if s[3] as i32 == b' ' as i32 {
                                 //eprint!("Gdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((46usize).wrapping_mul(n)),
-                                    l.wrapping_add(4usize),
+                                    l.wrapping_add(4),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b't' as i32 {
-                            if s[(3usize)] as i32 == b' ' as i32 {
+                        } else if s[2] as i32 == b't' as i32 {
+                            if s[3] as i32 == b' ' as i32 {
                                 //eprint!("Hdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((60usize).wrapping_mul(n)),
-                                    l.wrapping_add(4usize),
+                                    l.wrapping_add(4),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b'n' as i32
-                            && s[(3usize)] as i32 == b'd' as i32
-                            && (s[(4usize)] as i32 == b' ' as i32)
+                        } else if s[2] as i32 == b'n' as i32
+                            && s[3] as i32 == b'd' as i32
+                            && (s[4] as i32 == b' ' as i32)
                         {
                             //eprint!("Idding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((10usize).wrapping_mul(n)),
-                                l.wrapping_add(5usize),
+                                l.wrapping_add(5),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'b' as i32 {
-                        if s[(2usize)] as i32 == b'y' as i32 && (s[(3usize)] as i32 == b' ' as i32)
-                        {
+                    } else if s[1] as i32 == b'b' as i32 {
+                        if s[2] as i32 == b'y' as i32 && (s[3] as i32 == b' ' as i32) {
                             //eprint!("Jdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((38usize).wrapping_mul(n)),
-                                l.wrapping_add(4usize),
+                                l.wrapping_add(4),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'i' as i32 {
-                        if s[(2usize)] as i32 == b'n' as i32 {
-                            if s[(3usize)] as i32 == b' ' as i32 {
+                    } else if s[1] as i32 == b'i' as i32 {
+                        if s[2] as i32 == b'n' as i32 {
+                            if s[3] as i32 == b' ' as i32 {
                                 //eprint!("Kdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((16usize).wrapping_mul(n)),
-                                    l.wrapping_add(4usize),
+                                    l.wrapping_add(4),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b's' as i32
-                            && s[(3usize)] as i32 == b' ' as i32
-                        {
+                        } else if s[2] as i32 == b's' as i32 && s[3] as i32 == b' ' as i32 {
                             //eprint!("Ldding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((47usize).wrapping_mul(n)),
-                                l.wrapping_add(4usize),
+                                l.wrapping_add(4),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'f' as i32 {
-                        if s[(2usize)] as i32 == b'o' as i32 {
-                            if s[(3usize)] as i32 == b'r' as i32
-                                && (s[(4usize)] as i32 == b' ' as i32)
-                            {
+                    } else if s[1] as i32 == b'f' as i32 {
+                        if s[2] as i32 == b'o' as i32 {
+                            if s[3] as i32 == b'r' as i32 && (s[4] as i32 == b' ' as i32) {
                                 //eprint!("Mdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((25usize).wrapping_mul(n)),
-                                    l.wrapping_add(5usize),
+                                    l.wrapping_add(5),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b'r' as i32
-                            && s[(3usize)] as i32 == b'o' as i32
-                            && (s[(4usize)] as i32 == b'm' as i32)
-                            && (s[(5usize)] as i32 == b' ' as i32)
+                        } else if s[2] as i32 == b'r' as i32
+                            && s[3] as i32 == b'o' as i32
+                            && (s[4] as i32 == b'm' as i32)
+                            && (s[5] as i32 == b' ' as i32)
                         {
                             //eprint!("Ndding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((37usize).wrapping_mul(n)),
-                                l.wrapping_add(6usize),
+                                l.wrapping_add(6),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'o' as i32 {
-                        if s[(2usize)] as i32 == b'f' as i32 {
-                            if s[(3usize)] as i32 == b' ' as i32 {
+                    } else if s[1] as i32 == b'o' as i32 {
+                        if s[2] as i32 == b'f' as i32 {
+                            if s[3] as i32 == b' ' as i32 {
                                 //eprint!("Odding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((8usize).wrapping_mul(n)),
-                                    l.wrapping_add(4usize),
+                                    l.wrapping_add(4),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b'n' as i32
-                            && s[(3usize)] as i32 == b' ' as i32
-                        {
+                        } else if s[2] as i32 == b'n' as i32 && s[3] as i32 == b' ' as i32 {
                             //eprint!("Pdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((45usize).wrapping_mul(n)),
-                                l.wrapping_add(4usize),
+                                l.wrapping_add(4),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'n' as i32 {
-                        if s[(2usize)] as i32 == b'o' as i32
-                            && (s[(3usize)] as i32 == b't' as i32)
-                            && (s[(4usize)] as i32 == b' ' as i32)
+                    } else if s[1] as i32 == b'n' as i32 {
+                        if s[2] as i32 == b'o' as i32
+                            && (s[3] as i32 == b't' as i32)
+                            && (s[4] as i32 == b' ' as i32)
                         {
                             //eprint!("Qdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((80usize).wrapping_mul(n)),
-                                l.wrapping_add(5usize),
+                                l.wrapping_add(5),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b't' as i32 {
-                        if s[(2usize)] as i32 == b'h' as i32 {
-                            if s[(3usize)] as i32 == b'e' as i32 {
-                                if s[(4usize)] as i32 == b' ' as i32 {
+                    } else if s[1] as i32 == b't' as i32 {
+                        if s[2] as i32 == b'h' as i32 {
+                            if s[3] as i32 == b'e' as i32 {
+                                if s[4] as i32 == b' ' as i32 {
                                     //eprint!("Rdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                     AddMatch(
                                         id.wrapping_add((5usize).wrapping_mul(n)),
-                                        l.wrapping_add(5usize),
+                                        l.wrapping_add(5),
                                         l,
                                         matches,
                                     );
                                 }
-                            } else if s[(3usize)] as i32 == b'a' as i32
-                                && s[(4usize)] as i32 == b't' as i32
-                                && (s[(5usize)] as i32 == b' ' as i32)
+                            } else if s[3] as i32 == b'a' as i32
+                                && s[4] as i32 == b't' as i32
+                                && (s[5] as i32 == b' ' as i32)
                             {
                                 //eprint!("Sdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((29usize).wrapping_mul(n)),
-                                    l.wrapping_add(6usize),
+                                    l.wrapping_add(6),
                                     l,
                                     matches,
                                 );
                             }
-                        } else if s[(2usize)] as i32 == b'o' as i32
-                            && s[(3usize)] as i32 == b' ' as i32
-                        {
+                        } else if s[2] as i32 == b'o' as i32 && s[3] as i32 == b' ' as i32 {
                             //eprint!("Tdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((17usize).wrapping_mul(n)),
-                                l.wrapping_add(4usize),
+                                l.wrapping_add(4),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'w' as i32
-                        && s[(2usize)] as i32 == b'i' as i32
-                        && (s[(3usize)] as i32 == b't' as i32)
-                        && (s[(4usize)] as i32 == b'h' as i32)
-                        && (s[(5usize)] as i32 == b' ' as i32)
+                    } else if s[1] as i32 == b'w' as i32
+                        && s[2] as i32 == b'i' as i32
+                        && (s[3] as i32 == b't' as i32)
+                        && (s[4] as i32 == b'h' as i32)
+                        && (s[5] as i32 == b' ' as i32)
                     {
                         //eprint!("Udding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((35usize).wrapping_mul(n)),
-                            l.wrapping_add(6usize),
+                            l.wrapping_add(6),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'\"' as i32 {
+                } else if s[0] as i32 == b'\"' as i32 {
                     //eprint!("Vdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((19usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b'>' as i32 {
+                    if s[1] as i32 == b'>' as i32 {
                         //eprint!("Wdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((21usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'.' as i32 {
+                } else if s[0] as i32 == b'.' as i32 {
                     //eprint!("Xdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((20usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("Ydding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((31usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
-                        if s[(2usize)] as i32 == b'T' as i32 && (s[(3usize)] as i32 == b'h' as i32)
-                        {
-                            if s[(4usize)] as i32 == b'e' as i32 {
-                                if s[(5usize)] as i32 == b' ' as i32 {
+                        if s[2] as i32 == b'T' as i32 && (s[3] as i32 == b'h' as i32) {
+                            if s[4] as i32 == b'e' as i32 {
+                                if s[5] as i32 == b' ' as i32 {
                                     //eprint!("Zdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                     AddMatch(
                                         id.wrapping_add((43usize).wrapping_mul(n)),
-                                        l.wrapping_add(6usize),
+                                        l.wrapping_add(6),
                                         l,
                                         matches,
                                     );
                                 }
-                            } else if s[(4usize)] as i32 == b'i' as i32
-                                && s[(5usize)] as i32 == b's' as i32
-                                && (s[(6usize)] as i32 == b' ' as i32)
+                            } else if s[4] as i32 == b'i' as i32
+                                && s[5] as i32 == b's' as i32
+                                && (s[6] as i32 == b' ' as i32)
                             {
                                 //eprint!("AAdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                                 AddMatch(
                                     id.wrapping_add((75usize).wrapping_mul(n)),
-                                    l.wrapping_add(7usize),
+                                    l.wrapping_add(7),
                                     l,
                                     matches,
                                 );
                             }
                         }
                     }
-                } else if s[(0)] as i32 == b',' as i32 {
+                } else if s[0] as i32 == b',' as i32 {
                     //eprint!("ABdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((76usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("ACdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((14usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'\n' as i32 {
+                } else if s[0] as i32 == b'\n' as i32 {
                     //eprint!("ADdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((22usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b'\t' as i32 {
+                    if s[1] as i32 == b'\t' as i32 {
                         //eprint!("AEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((50usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b']' as i32 {
+                } else if s[0] as i32 == b']' as i32 {
                     //eprint!("AFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((24usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'\'' as i32 {
+                } else if s[0] as i32 == b'\'' as i32 {
                     //eprint!("AGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((36usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b':' as i32 {
+                } else if s[0] as i32 == b':' as i32 {
                     //eprint!("AHdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((51usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'(' as i32 {
+                } else if s[0] as i32 == b'(' as i32 {
                     //eprint!("AIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((57usize).wrapping_mul(n)),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'=' as i32 {
-                    if s[(1usize)] as i32 == b'\"' as i32 {
+                } else if s[0] as i32 == b'=' as i32 {
+                    if s[1] as i32 == b'\"' as i32 {
                         //eprint!("AJdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((70usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as i32 == b'\'' as i32 {
+                    } else if s[1] as i32 == b'\'' as i32 {
                         //eprint!("AKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((86usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'a' as i32 {
-                    if s[(1usize)] as i32 == b'l' as i32 && (s[(2usize)] as i32 == b' ' as i32) {
+                } else if s[0] as i32 == b'a' as i32 {
+                    if s[1] as i32 == b'l' as i32 && (s[2] as i32 == b' ' as i32) {
                         //eprint!("ALdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((84usize).wrapping_mul(n)),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'e' as i32 {
-                    if s[(1usize)] as i32 == b'd' as i32 {
-                        if s[(2usize)] as i32 == b' ' as i32 {
+                } else if s[0] as i32 == b'e' as i32 {
+                    if s[1] as i32 == b'd' as i32 {
+                        if s[2] as i32 == b' ' as i32 {
                             //eprint!("AMdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((53usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'r' as i32 {
-                        if s[(2usize)] as i32 == b' ' as i32 {
+                    } else if s[1] as i32 == b'r' as i32 {
+                        if s[2] as i32 == b' ' as i32 {
                             //eprint!("ANdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((82usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b's' as i32
-                        && s[(2usize)] as i32 == b't' as i32
-                        && (s[(3usize)] as i32 == b' ' as i32)
+                    } else if s[1] as i32 == b's' as i32
+                        && s[2] as i32 == b't' as i32
+                        && (s[3] as i32 == b' ' as i32)
                     {
                         //eprint!("AOdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((95usize).wrapping_mul(n)),
-                            l.wrapping_add(4usize),
+                            l.wrapping_add(4),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'f' as i32 {
-                    if s[(1usize)] as i32 == b'u' as i32
-                        && (s[(2usize)] as i32 == b'l' as i32)
-                        && (s[(3usize)] as i32 == b' ' as i32)
+                } else if s[0] as i32 == b'f' as i32 {
+                    if s[1] as i32 == b'u' as i32
+                        && (s[2] as i32 == b'l' as i32)
+                        && (s[3] as i32 == b' ' as i32)
                     {
                         //eprint!("APdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((90usize).wrapping_mul(n)),
-                            l.wrapping_add(4usize),
+                            l.wrapping_add(4),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'i' as i32 {
-                    if s[(1usize)] as i32 == b'v' as i32 {
-                        if s[(2usize)] as i32 == b'e' as i32 && (s[(3usize)] as i32 == b' ' as i32)
-                        {
+                } else if s[0] as i32 == b'i' as i32 {
+                    if s[1] as i32 == b'v' as i32 {
+                        if s[2] as i32 == b'e' as i32 && (s[3] as i32 == b' ' as i32) {
                             //eprint!("AQdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((92usize).wrapping_mul(n)),
-                                l.wrapping_add(4usize),
+                                l.wrapping_add(4),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'z' as i32
-                        && s[(2usize)] as i32 == b'e' as i32
-                        && (s[(3usize)] as i32 == b' ' as i32)
+                    } else if s[1] as i32 == b'z' as i32
+                        && s[2] as i32 == b'e' as i32
+                        && (s[3] as i32 == b' ' as i32)
                     {
                         //eprint!("ARdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((100usize).wrapping_mul(n)),
-                            l.wrapping_add(4usize),
+                            l.wrapping_add(4),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'l' as i32 {
-                    if s[(1usize)] as i32 == b'e' as i32 {
-                        if s[(2usize)] as i32 == b's' as i32
-                            && (s[(3usize)] as i32 == b's' as i32)
-                            && (s[(4usize)] as i32 == b' ' as i32)
+                } else if s[0] as i32 == b'l' as i32 {
+                    if s[1] as i32 == b'e' as i32 {
+                        if s[2] as i32 == b's' as i32
+                            && (s[3] as i32 == b's' as i32)
+                            && (s[4] as i32 == b' ' as i32)
                         {
                             //eprint!("ASdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                             AddMatch(
                                 id.wrapping_add((93usize).wrapping_mul(n)),
-                                l.wrapping_add(5usize),
+                                l.wrapping_add(5),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(1usize)] as i32 == b'y' as i32 && s[(2usize)] as i32 == b' ' as i32
-                    {
+                    } else if s[1] as i32 == b'y' as i32 && s[2] as i32 == b' ' as i32 {
                         //eprint!("ATdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                         AddMatch(
                             id.wrapping_add((61usize).wrapping_mul(n)),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'o' as i32
-                    && s[(1usize)] as i32 == b'u' as i32
-                    && (s[(2usize)] as i32 == b's' as i32)
-                    && (s[(3usize)] as i32 == b' ' as i32)
+                } else if s[0] as i32 == b'o' as i32
+                    && s[1] as i32 == b'u' as i32
+                    && (s[2] as i32 == b's' as i32)
+                    && (s[3] as i32 == b' ' as i32)
                 {
                     //eprint!("AUdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
                     AddMatch(
                         id.wrapping_add((106usize).wrapping_mul(n)),
-                        l.wrapping_add(4usize),
+                        l.wrapping_add(4),
                         l,
                         matches,
                     );
@@ -992,131 +980,131 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     matches,
                 );
                 has_found_match = 1i32;
-                if l.wrapping_add(1usize) >= max_length {
+                if l.wrapping_add(1) >= max_length {
                     {
                         continue;
                     }
                 }
                 let s: &[u8] = data.split_at(l as usize).1;
-                if s[(0)] as i32 == b' ' as i32 {
+                if s[0] as i32 == b' ' as i32 {
                     //eprint!("AWdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 68i32 } else { 4i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'\"' as i32 {
+                } else if s[0] as i32 == b'\"' as i32 {
                     //eprint!("AXdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 87i32 } else { 66i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b'>' as i32 {
+                    if s[1] as i32 == b'>' as i32 {
                         //eprint!("AYdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 97i32 } else { 69i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'.' as i32 {
+                } else if s[0] as i32 == b'.' as i32 {
                     //eprint!("AZdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 101i32 } else { 79i32 } as usize)
                                 .wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("BAdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 114i32 } else { 88i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b',' as i32 {
+                } else if s[0] as i32 == b',' as i32 {
                     //eprint!("BBdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 112i32 } else { 99i32 } as usize)
                                 .wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("BCdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 107i32 } else { 58i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'\'' as i32 {
+                } else if s[0] as i32 == b'\'' as i32 {
                     //eprint!("BDdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 94i32 } else { 74i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'(' as i32 {
+                } else if s[0] as i32 == b'(' as i32 {
                     //eprint!("BEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 113i32 } else { 78i32 } as usize)
                                 .wrapping_mul(n),
                         ),
-                        l.wrapping_add(1usize),
+                        l.wrapping_add(1),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'=' as i32 {
-                    if s[(1usize)] as i32 == b'\"' as i32 {
+                } else if s[0] as i32 == b'=' as i32 {
+                    if s[1] as i32 == b'\"' as i32 {
                         //eprint!("BFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 105i32 } else { 104i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as i32 == b'\'' as i32 {
+                    } else if s[1] as i32 == b'\'' as i32 {
                         //eprint!("BGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 116i32 } else { 108i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
@@ -1125,9 +1113,8 @@ pub fn BrotliFindAllStaticDictionaryMatches(
             }
         }
     }
-    if max_length >= 5usize && (data[(0)] as i32 == b' ' as i32 || data[(0)] as i32 == b'.' as i32)
-    {
-        let is_space: i32 = if !!(data[(0)] as i32 == b' ' as i32) {
+    if max_length >= 5usize && (data[0] as i32 == b' ' as i32 || data[0] as i32 == b'.' as i32) {
+        let is_space: i32 = if !!(data[0] as i32 == b' ' as i32) {
             1i32
         } else {
             0i32
@@ -1151,7 +1138,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     dictionary,
                     w,
                     data.split_at(1).1,
-                    max_length.wrapping_sub(1usize),
+                    max_length.wrapping_sub(1),
                 ) == 0
                 {
                     {
@@ -1163,86 +1150,86 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     id.wrapping_add(
                         (if is_space != 0 { 6i32 } else { 32i32 } as usize).wrapping_mul(n),
                     ),
-                    l.wrapping_add(1usize),
+                    l.wrapping_add(1),
                     l,
                     matches,
                 );
                 has_found_match = 1i32;
-                if l.wrapping_add(2usize) >= max_length {
+                if l.wrapping_add(2) >= max_length {
                     {
                         continue;
                     }
                 }
-                let s: &[u8] = data.split_at(l.wrapping_add(1usize) as usize).1;
-                if s[(0)] as i32 == b' ' as i32 {
+                let s: &[u8] = data.split_at(l.wrapping_add(1) as usize).1;
+                if s[0] as i32 == b' ' as i32 {
                     //eprint!("BIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_space != 0 { 2i32 } else { 77i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(2usize),
+                        l.wrapping_add(2),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b'(' as i32 {
+                } else if s[0] as i32 == b'(' as i32 {
                     //eprint!("BJdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_space != 0 { 89i32 } else { 67i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(2usize),
+                        l.wrapping_add(2),
                         l,
                         matches,
                     );
                 } else if is_space != 0 {
-                    if s[(0)] as i32 == b',' as i32 {
+                    if s[0] as i32 == b',' as i32 {
                         //eprint!("BKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((103usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
-                        if s[(1usize)] as i32 == b' ' as i32 {
+                        if s[1] as i32 == b' ' as i32 {
                             //eprint!("BLdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((33usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(0)] as i32 == b'.' as i32 {
+                    } else if s[0] as i32 == b'.' as i32 {
                         //eprint!("BMdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((71usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
-                        if s[(1usize)] as i32 == b' ' as i32 {
+                        if s[1] as i32 == b' ' as i32 {
                             //eprint!("BNdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((52usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
                         }
-                    } else if s[(0)] as i32 == b'=' as i32 {
-                        if s[(1usize)] as i32 == b'\"' as i32 {
+                    } else if s[0] as i32 == b'=' as i32 {
+                        if s[1] as i32 == b'\"' as i32 {
                             //eprint!("BOdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((81usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
-                        } else if s[(1usize)] as i32 == b'\'' as i32 {
+                        } else if s[1] as i32 == b'\'' as i32 {
                             //eprint!("BPdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((98usize).wrapping_mul(n)),
-                                l.wrapping_add(3usize),
+                                l.wrapping_add(3),
                                 l,
                                 matches,
                             );
@@ -1260,7 +1247,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     dictionary,
                     w,
                     data.split_at(1).1,
-                    max_length.wrapping_sub(1usize),
+                    max_length.wrapping_sub(1),
                 ) == 0
                 {
                     {
@@ -1272,92 +1259,92 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     id.wrapping_add(
                         (if is_all_caps != 0 { 85i32 } else { 30i32 } as usize).wrapping_mul(n),
                     ),
-                    l.wrapping_add(1usize),
+                    l.wrapping_add(1),
                     l,
                     matches,
                 );
                 has_found_match = 1i32;
-                if l.wrapping_add(2usize) >= max_length {
+                if l.wrapping_add(2) >= max_length {
                     {
                         continue;
                     }
                 }
                 let s: &[u8] = data.split_at(l.wrapping_add(1)).1;
-                if s[(0)] as i32 == b' ' as i32 {
+                if s[0] as i32 == b' ' as i32 {
                     //eprint!("CBdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 83i32 } else { 15i32 } as usize).wrapping_mul(n),
                         ),
-                        l.wrapping_add(2usize),
+                        l.wrapping_add(2),
                         l,
                         matches,
                     );
-                } else if s[(0)] as i32 == b',' as i32 {
+                } else if s[0] as i32 == b',' as i32 {
                     if is_all_caps == 0 {
                         //eprint!("CCdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((109usize).wrapping_mul(n)),
-                            l.wrapping_add(2usize),
+                            l.wrapping_add(2),
                             l,
                             matches,
                         );
                     }
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("CDdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 111i32 } else { 65i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'.' as i32 {
+                } else if s[0] as i32 == b'.' as i32 {
                     //eprint!("CEdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(
                             (if is_all_caps != 0 { 115i32 } else { 96i32 } as usize)
                                 .wrapping_mul(n),
                         ),
-                        l.wrapping_add(2usize),
+                        l.wrapping_add(2),
                         l,
                         matches,
                     );
-                    if s[(1usize)] as i32 == b' ' as i32 {
+                    if s[1] as i32 == b' ' as i32 {
                         //eprint!("CFdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 117i32 } else { 91i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
                     }
-                } else if s[(0)] as i32 == b'=' as i32 {
-                    if s[(1usize)] as i32 == b'\"' as i32 {
+                } else if s[0] as i32 == b'=' as i32 {
+                    if s[1] as i32 == b'\"' as i32 {
                         //eprint!("CGdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 110i32 } else { 118i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
-                    } else if s[(1usize)] as i32 == b'\'' as i32 {
+                    } else if s[1] as i32 == b'\'' as i32 {
                         //eprint!("CHdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add(
                                 (if is_all_caps != 0 { 119i32 } else { 120i32 } as usize)
                                     .wrapping_mul(n),
                             ),
-                            l.wrapping_add(3usize),
+                            l.wrapping_add(3),
                             l,
                             matches,
                         );
@@ -1367,11 +1354,11 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     if max_length >= 6usize
-        && (data[(1usize)] as i32 == b' ' as i32
-            && (data[(0)] as i32 == b'e' as i32
-                || data[(0)] as i32 == b's' as i32
-                || data[(0)] as i32 == b',' as i32)
-            || data[(0)] as i32 == 0xc2i32 && (data[(1usize)] as i32 == 0xa0i32))
+        && (data[1] as i32 == b' ' as i32
+            && (data[0] as i32 == b'e' as i32
+                || data[0] as i32 == b's' as i32
+                || data[0] as i32 == b',' as i32)
+            || data[0] as i32 == 0xc2i32 && (data[1] as i32 == 0xa0i32))
     {
         let mut offset: usize =
             kStaticDictionaryBuckets[Hash(data.split_at(2).1) as usize] as usize;
@@ -1392,24 +1379,24 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     dictionary,
                     w,
                     data.split_at(2).1,
-                    max_length.wrapping_sub(2usize),
+                    max_length.wrapping_sub(2),
                 ) != 0)
             {
-                if data[(0)] as i32 == 0xc2i32 {
+                if data[0] as i32 == 0xc2i32 {
                     //eprint!("CIdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add((102usize).wrapping_mul(n)),
-                        l.wrapping_add(2usize),
+                        l.wrapping_add(2),
                         l,
                         matches,
                     );
                     has_found_match = 1i32;
-                } else if l.wrapping_add(2usize) < max_length
-                    && (data[(l.wrapping_add(2usize) as usize)] as i32 == b' ' as i32)
+                } else if l.wrapping_add(2) < max_length
+                    && (data[(l.wrapping_add(2) as usize)] as i32 == b' ' as i32)
                 {
-                    let t: usize = (if data[(0)] as i32 == b'e' as i32 {
+                    let t: usize = (if data[0] as i32 == b'e' as i32 {
                         18i32
-                    } else if data[(0)] as i32 == b's' as i32 {
+                    } else if data[0] as i32 == b's' as i32 {
                         7i32
                     } else {
                         13i32
@@ -1417,7 +1404,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     //eprint!("CJdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                     AddMatch(
                         id.wrapping_add(t.wrapping_mul(n)),
-                        l.wrapping_add(3usize),
+                        l.wrapping_add(3),
                         l,
                         matches,
                     );
@@ -1427,16 +1414,16 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     if max_length >= 9usize
-        && (data[(0)] as i32 == b' ' as i32
-            && (data[(1usize)] as i32 == b't' as i32)
-            && (data[(2usize)] as i32 == b'h' as i32)
-            && (data[(3usize)] as i32 == b'e' as i32)
-            && (data[(4usize)] as i32 == b' ' as i32)
-            || data[(0)] as i32 == b'.' as i32
-                && (data[(1usize)] as i32 == b'c' as i32)
-                && (data[(2usize)] as i32 == b'o' as i32)
-                && (data[(3usize)] as i32 == b'm' as i32)
-                && (data[(4usize)] as i32 == b'/' as i32))
+        && (data[0] as i32 == b' ' as i32
+            && (data[1] as i32 == b't' as i32)
+            && (data[2] as i32 == b'h' as i32)
+            && (data[3] as i32 == b'e' as i32)
+            && (data[4] as i32 == b' ' as i32)
+            || data[0] as i32 == b'.' as i32
+                && (data[1] as i32 == b'c' as i32)
+                && (data[2] as i32 == b'o' as i32)
+                && (data[3] as i32 == b'm' as i32)
+                && (data[4] as i32 == b'/' as i32))
     {
         let mut offset: usize =
             kStaticDictionaryBuckets[Hash(data.split_at(5).1) as usize] as usize;
@@ -1457,50 +1444,50 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     dictionary,
                     w,
                     data.split_at(5).1,
-                    max_length.wrapping_sub(5usize),
+                    max_length.wrapping_sub(5),
                 ) != 0)
             {
                 //eprint!("CKdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                 AddMatch(
                     id.wrapping_add(
-                        (if data[(0)] as i32 == b' ' as i32 {
+                        (if data[0] as i32 == b' ' as i32 {
                             41i32
                         } else {
                             72i32
                         } as usize)
                             .wrapping_mul(n),
                     ),
-                    l.wrapping_add(5usize),
+                    l.wrapping_add(5),
                     l,
                     matches,
                 );
                 has_found_match = 1i32;
-                if l.wrapping_add(5usize) < max_length {
-                    let s: &[u8] = data.split_at(l.wrapping_add(5usize) as usize).1;
-                    if data[(0)] as i32 == b' ' as i32
-                        && l.wrapping_add(8usize) < max_length
-                        && (s[(0)] as i32 == b' ' as i32)
-                        && (s[(1usize)] as i32 == b'o' as i32)
-                        && (s[(2usize)] as i32 == b'f' as i32)
-                        && (s[(3usize)] as i32 == b' ' as i32)
+                if l.wrapping_add(5) < max_length {
+                    let s: &[u8] = data.split_at(l.wrapping_add(5) as usize).1;
+                    if data[0] as i32 == b' ' as i32
+                        && l.wrapping_add(8) < max_length
+                        && (s[0] as i32 == b' ' as i32)
+                        && (s[1] as i32 == b'o' as i32)
+                        && (s[2] as i32 == b'f' as i32)
+                        && (s[3] as i32 == b' ' as i32)
                     {
                         //eprint!("CLdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                         AddMatch(
                             id.wrapping_add((62usize).wrapping_mul(n)),
-                            l.wrapping_add(9usize),
+                            l.wrapping_add(9),
                             l,
                             matches,
                         );
-                        if l.wrapping_add(12usize) < max_length
-                            && (s[(4usize)] as i32 == b't' as i32)
-                            && (s[(5usize)] as i32 == b'h' as i32)
-                            && (s[(6usize)] as i32 == b'e' as i32)
-                            && (s[(7usize)] as i32 == b' ' as i32)
+                        if l.wrapping_add(12) < max_length
+                            && (s[4] as i32 == b't' as i32)
+                            && (s[5] as i32 == b'h' as i32)
+                            && (s[6] as i32 == b'e' as i32)
+                            && (s[7] as i32 == b' ' as i32)
                         {
                             //eprint!("BQdding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), 666);
                             AddMatch(
                                 id.wrapping_add((73usize).wrapping_mul(n)),
-                                l.wrapping_add(13usize),
+                                l.wrapping_add(13),
                                 l,
                                 matches,
                             );

--- a/src/enc/utf8_util.rs
+++ b/src/enc/utf8_util.rs
@@ -2,48 +2,48 @@
 static kMinUTF8Ratio: super::util::floatX = 0.75 as super::util::floatX;
 
 fn BrotliParseAsUTF8(symbol: &mut i32, input: &[u8], size: usize) -> usize {
-    if input[0usize] as i32 & 0x80i32 == 0i32 {
-        *symbol = input[0usize] as i32;
+    if input[0] as i32 & 0x80i32 == 0i32 {
+        *symbol = input[0] as i32;
         if *symbol > 0i32 {
             return 1usize;
         }
     }
     if size > 1u32 as usize
-        && (input[0usize] as i32 & 0xe0i32 == 0xc0i32)
-        && (input[1usize] as i32 & 0xc0i32 == 0x80i32)
+        && (input[0] as i32 & 0xe0i32 == 0xc0i32)
+        && (input[1] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0usize] as i32 & 0x1fi32) << 6i32 | input[1usize] as i32 & 0x3fi32;
+        *symbol = (input[0] as i32 & 0x1fi32) << 6i32 | input[1] as i32 & 0x3fi32;
         if *symbol > 0x7fi32 {
             return 2usize;
         }
     }
     if size > 2u32 as usize
-        && (input[0usize] as i32 & 0xf0i32 == 0xe0i32)
-        && (input[1usize] as i32 & 0xc0i32 == 0x80i32)
-        && (input[2usize] as i32 & 0xc0i32 == 0x80i32)
+        && (input[0] as i32 & 0xf0i32 == 0xe0i32)
+        && (input[1] as i32 & 0xc0i32 == 0x80i32)
+        && (input[2] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0usize] as i32 & 0xfi32) << 12i32
-            | (input[1usize] as i32 & 0x3fi32) << 6i32
-            | input[2usize] as i32 & 0x3fi32;
+        *symbol = (input[0] as i32 & 0xfi32) << 12i32
+            | (input[1] as i32 & 0x3fi32) << 6i32
+            | input[2] as i32 & 0x3fi32;
         if *symbol > 0x7ffi32 {
             return 3usize;
         }
     }
     if size > 3u32 as usize
-        && (input[0usize] as i32 & 0xf8i32 == 0xf0i32)
-        && (input[1usize] as i32 & 0xc0i32 == 0x80i32)
-        && (input[2usize] as i32 & 0xc0i32 == 0x80i32)
-        && (input[3usize] as i32 & 0xc0i32 == 0x80i32)
+        && (input[0] as i32 & 0xf8i32 == 0xf0i32)
+        && (input[1] as i32 & 0xc0i32 == 0x80i32)
+        && (input[2] as i32 & 0xc0i32 == 0x80i32)
+        && (input[3] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0usize] as i32 & 0x7i32) << 18i32
-            | (input[1usize] as i32 & 0x3fi32) << 12i32
-            | (input[2usize] as i32 & 0x3fi32) << 6i32
-            | input[3usize] as i32 & 0x3fi32;
+        *symbol = (input[0] as i32 & 0x7i32) << 18i32
+            | (input[1] as i32 & 0x3fi32) << 12i32
+            | (input[2] as i32 & 0x3fi32) << 6i32
+            | input[3] as i32 & 0x3fi32;
         if *symbol > 0xffffi32 && (*symbol <= 0x10ffffi32) {
             return 4usize;
         }
     }
-    *symbol = 0x110000i32 | input[0usize] as i32;
+    *symbol = 0x110000i32 | input[0] as i32;
     1usize
 }
 


### PR DESCRIPTION
Whenever calling a function on a value, e.g. `value.wrapping_sub(1usize)`, there is almost never a need for specifying constant type.  The theoretical exception is if calling `foo<T>(&self, value: T)`, but I don't think there is a case like this here.

Another common case is a constant with type as an indexer - also never needed unless there is some magical implementation of the indexer trait.

Executed replacements:

```rust
.foo(123_usize)    -> .foo(123)
.foo(123 as usize) -> .foo(123)
[123_usize]        -> [123]
[(123_usize)]      -> [123]
[(123)]            -> [123]
[123_usize..       -> [123..
[(123_usize)..     -> [123..
```

```regex
(\.[a-z_]+)\((\d+)_?[ui][a-z0-9]*\)    -> $1($2)
(\.[a-z_]+)\((\d+) as [ui][a-z0-9]*\)  -> $1($2)
\[(\d+)_?[ui][a-z0-9]*\]               -> [$1]
\[\((\d+)_?[ui][a-z0-9]*\)\]           -> [$1]
\[\((\d+)(_?[ui][a-z0-9]*)?\)\]        -> [$1]
\[(\d+)_?[ui][a-z0-9]*\.\.             -> [$1..
\[\((\d+)_?[ui][a-z0-9]*\)\.\.         -> [$1..
```

CI results in https://github.com/rust-brotli/rust-brotli/pull/41