### PR TITLE
chore: add nightly fmt command

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,6 +30,10 @@ fmt *ARGS:
     cargo fmt --all -- {{ ARGS }}
     cd c && cargo fmt --all -- {{ ARGS }}
 
+# Run Nightly cargo fmt, ordering imports by groups
+fmt2:
+    cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
+
 # Run cargo clippy
 clippy:
     cargo clippy -- -D warnings


### PR DESCRIPTION
This command is optional, and could be applied only once in a while. It shouldn't conflict with the regular stable `cargo fmt`, but it will keep the use statements more organized.