### PR TITLE
Simplify derefs `(*foo).bar()` into `foo.bar()`

### DIFF
--- a/corrosion/backward_references_hq.rs
+++ b/corrosion/backward_references_hq.rs
@@ -207,19 +207,19 @@ pub struct Command {
 unsafe extern fn ZopfliNodeCopyLength(
     mut self : *const ZopfliNode
 ) -> u32 {
-    (*self).length & 0x1ffffffu32
+    self.length & 0x1ffffffu32
 }
 
 unsafe extern fn ZopfliNodeCopyDistance(
     mut self : *const ZopfliNode
 ) -> u32 {
-    (*self).distance
+    self.distance
 }
 
 unsafe extern fn ZopfliNodeLengthCode(
     mut self : *const ZopfliNode
 ) -> u32 {
-    let modifier : u32 = (*self).length >> 25i32;
+    let modifier : u32 =  self.length >> 25i32;
     ZopfliNodeCopyLength(self).wrapping_add(9).wrapping_sub(
         modifier
     )
@@ -234,7 +234,7 @@ unsafe extern fn brotli_min_size_t(
 unsafe extern fn ZopfliNodeDistanceCode(
     mut self : *const ZopfliNode
 ) -> u32 {
-    let short_code : u32 = (*self).dcode_insert_length >> 27i32;
+    let short_code : u32 =  self.dcode_insert_length >> 27i32;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(self).wrapping_add(
             16u32
@@ -406,14 +406,14 @@ unsafe extern fn InitCommand(
     mut distance_code : usize
 ) {
     let mut delta : u32 = copylen_code_delta as i8 as u8 as u32;
-    (*self).insert_len_ = insertlen as u32;
-    (*self).copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
+    self.insert_len_ = insertlen as u32;
+    self.copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
     PrefixEncodeCopyDistance(
         distance_code,
-        (*dist).num_direct_distance_codes as usize,
-        (*dist).distance_postfix_bits as usize,
-        &mut (*self).dist_prefix_ as (*mut u16),
-        &mut (*self).dist_extra_ as (*mut u32)
+        dist.num_direct_distance_codes as usize,
+        dist.distance_postfix_bits as usize,
+        &mut  self.dist_prefix_ as (*mut u16),
+        &mut  self.dist_extra_ as (*mut u32)
     );
     GetLengthCode(
         insertlen,
@@ -423,7 +423,7 @@ unsafe extern fn InitCommand(
         } else {
             0i32
         },
-        &mut (*self).cmd_prefix_ as (*mut u16)
+        &mut  self.cmd_prefix_ as (*mut u16)
     );
 }
 
@@ -458,7 +458,7 @@ pub unsafe extern fn BrotliZopfliCreateCommands(
                 : usize
                 = ((*next).dcode_insert_length & 0x7ffffffu32) as usize;
             pos = pos.wrapping_add(insert_length);
-            offset = (*next).u.next;
+            offset =  next.u.next;
             if i == 0usize {
                 insert_length = insert_length.wrapping_add(*last_insert_len);
                 *last_insert_len = 0usize;
@@ -503,12 +503,12 @@ pub unsafe extern fn BrotliZopfliCreateCommands(
                     *dist_cache.offset(0) = distance as i32;
                 }
             }
-            *num_literals = (*num_literals).wrapping_add(insert_length);
+            *num_literals =  num_literals.wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
         i = i.wrapping_add(1);
     }
-    *last_insert_len = (*last_insert_len).wrapping_add(
+    *last_insert_len =  last_insert_len.wrapping_add(
                            num_bytes.wrapping_sub(pos)
                        );
 }
@@ -524,7 +524,7 @@ pub struct MemoryManager {
 unsafe extern fn MaxZopfliLen(
     mut params : *const BrotliEncoderParams
 ) -> usize {
-    (if (*params).quality <= 10i32 {
+    (if  params.quality <= 10i32 {
          150i32
      } else {
          325i32
@@ -573,12 +573,12 @@ unsafe extern fn InitZopfliCostModel(
     mut dist : *const BrotliDistanceParams,
     mut num_bytes : usize
 ) {
-    let mut distance_histogram_size : u32 = (*dist).alphabet_size;
+    let mut distance_histogram_size : u32 =  dist.alphabet_size;
     if distance_histogram_size > 544u32 {
         distance_histogram_size = 544u32;
     }
-    (*self).num_bytes_ = num_bytes;
-    (*self).literal_costs_ = if num_bytes.wrapping_add(
+    self.num_bytes_ = num_bytes;
+    self.literal_costs_ = if num_bytes.wrapping_add(
                                     2usize
                                 ) > 0usize {
                                  BrotliAllocate(
@@ -590,7 +590,7 @@ unsafe extern fn InitZopfliCostModel(
                              } else {
                                  0i32 as (*mut std::os::raw::c_void) as (*mut f32)
                              };
-    (*self).cost_dist_ = if (*dist).alphabet_size > 0u32 {
+    self.cost_dist_ = if  dist.alphabet_size > 0u32 {
                              BrotliAllocate(
                                  m,
                                  ((*dist).alphabet_size as usize).wrapping_mul(
@@ -600,7 +600,7 @@ unsafe extern fn InitZopfliCostModel(
                          } else {
                              0i32 as (*mut std::os::raw::c_void) as (*mut f32)
                          };
-    (*self).distance_histogram_size = distance_histogram_size;
+    self.distance_histogram_size = distance_histogram_size;
     if !(0i32 == 0) { }
 }
 
@@ -619,11 +619,11 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
     mut ringbuffer : *const u8,
     mut ringbuffer_mask : usize
 ) {
-    let mut literal_costs : *mut f32 = (*self).literal_costs_;
+    let mut literal_costs : *mut f32 =  self.literal_costs_;
     let mut literal_carry : f32 = 0.0f64 as (f32);
-    let mut cost_dist : *mut f32 = (*self).cost_dist_;
-    let mut cost_cmd : *mut f32 = (*self).cost_cmd_;
-    let mut num_bytes : usize = (*self).num_bytes_;
+    let mut cost_dist : *mut f32 =  self.cost_dist_;
+    let mut cost_cmd : *mut f32 =  self.cost_cmd_;
+    let mut num_bytes : usize =  self.num_bytes_;
     let mut i : usize;
     BrotliEstimateBitCostsForLiterals(
         position,
@@ -660,7 +660,7 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
         i = i.wrapping_add(1);
     }
     i = 0usize;
-    while i < (*self).distance_histogram_size as usize {
+    while i <  self.distance_histogram_size as usize {
         {
             *cost_dist.offset(i as isize) = FastLog2(
                                                   (20u32).wrapping_add(
@@ -670,11 +670,11 @@ unsafe extern fn ZopfliCostModelSetFromLiteralCosts(
         }
         i = i.wrapping_add(1);
     }
-    (*self).min_cost_cmd_ = FastLog2(11usize) as (f32);
+    self.min_cost_cmd_ = FastLog2(11usize) as (f32);
 }
 
 unsafe extern fn InitStartPosQueue(mut self : *mut StartPosQueue) {
-    (*self).idx_ = 0usize;
+    self.idx_ = 0usize;
 }
 
 unsafe extern fn BrotliUnalignedRead64(
@@ -732,8 +732,8 @@ unsafe extern fn FindMatchLengthWithLimit(
 unsafe extern fn InitBackwardMatch(
     mut self : *mut BackwardMatch, mut dist : usize, mut len : usize
 ) {
-    (*self).distance = dist as u32;
-    (*self).length_and_code = (len << 5i32) as u32;
+    self.distance = dist as u32;
+    self.length_and_code = (len << 5i32) as u32;
 }
 
 #[derive(Clone, Copy)]
@@ -768,14 +768,14 @@ unsafe extern fn ForestH10(mut self : *mut H10) -> *mut u32 {
 unsafe extern fn LeftChildIndexH10(
     mut self : *mut H10, pos : usize
 ) -> usize {
-    (2usize).wrapping_mul(pos & (*self).window_mask_)
+    (2usize).wrapping_mul(pos &  self.window_mask_)
 }
 
 unsafe extern fn RightChildIndexH10(
     mut self : *mut H10, pos : usize
 ) -> usize {
     (2usize).wrapping_mul(
-        pos & (*self).window_mask_
+        pos &  self.window_mask_
     ).wrapping_add(
         1usize
     )
@@ -822,8 +822,8 @@ unsafe extern fn StoreAndFindMatchesH10(
             let prev_ix_masked : usize = prev_ix & ring_buffer_mask;
             if backward == 0usize || backward > max_backward || depth_remaining == 0usize {
                 if should_reroot_tree != 0 {
-                    *forest.offset(node_left as isize) = (*self).invalid_pos_;
-                    *forest.offset(node_right as isize) = (*self).invalid_pos_;
+                    *forest.offset(node_left as isize) =  self.invalid_pos_;
+                    *forest.offset(node_right as isize) =  self.invalid_pos_;
                 }
                 break 'break16;
             }
@@ -931,8 +931,8 @@ unsafe extern fn InitDictionaryBackwardMatch(
     mut len : usize,
     mut len_code : usize
 ) {
-    (*self).distance = dist as u32;
-    (*self).length_and_code = (len << 5i32 | if len == len_code {
+    self.distance = dist as u32;
+    self.length_and_code = (len << 5i32 | if len == len_code {
                                                  0usize
                                              } else {
                                                  len_code
@@ -956,7 +956,7 @@ unsafe extern fn FindAllMatchesH10(
     let mut best_len : usize = 1usize;
     let short_match_max_backward
         : usize
-        = (if (*params).quality != 11i32 {
+        = (if  params.quality != 11i32 {
                16i32
            } else {
                64i32
@@ -1067,7 +1067,7 @@ unsafe extern fn FindAllMatchesH10(
                               ).wrapping_add(
                                   1usize
                               );
-                        if distance <= (*params).dist.max_distance {
+                        if distance <=  params.dist.max_distance {
                             InitDictionaryBackwardMatch(
                                 {
                                     let _old = matches;
@@ -1100,7 +1100,7 @@ unsafe extern fn BackwardMatchLength(
 unsafe extern fn MaxZopfliCandidates(
     mut params : *const BrotliEncoderParams
 ) -> usize {
-    (if (*params).quality <= 10i32 { 1i32 } else { 5i32 }) as usize
+    (if  params.quality <= 10i32 { 1i32 } else { 5i32 }) as usize
 }
 
 unsafe extern fn ComputeDistanceShortcut(
@@ -1217,15 +1217,15 @@ unsafe extern fn StartPosQueuePush(
     let mut offset
         : usize
         = !{
-               let _old = (*self).idx_;
-               (*self).idx_ = (*self).idx_.wrapping_add(1);
+               let _old =  self.idx_;
+               self.idx_ =  self.idx_.wrapping_add(1);
                _old
            } & 7usize;
     let mut len
         : usize
         = StartPosQueueSize(self as (*const StartPosQueue));
     let mut i : usize;
-    let mut q : *mut PosData = (*self).q_;
+    let mut q : *mut PosData =  self.q_;
     *q.offset(offset as isize) = *posdata;
     i = 1usize;
     while i < len {
@@ -1312,7 +1312,7 @@ unsafe extern fn StartPosQueueAt(
 unsafe extern fn ZopfliCostModelGetMinCostCmd(
     mut self : *const ZopfliCostModel
 ) -> f32 {
-    (*self).min_cost_cmd_
+    self.min_cost_cmd_
 }
 
 unsafe extern fn ComputeMinimumCopyLength(
@@ -1373,16 +1373,16 @@ unsafe extern fn UpdateZopfliNode(
         = &mut *nodes.offset(
                     pos.wrapping_add(len) as isize
                 ) as (*mut ZopfliNode);
-    (*next).length = (len | len.wrapping_add(
+    next.length = (len | len.wrapping_add(
                                 9u32 as usize
                             ).wrapping_sub(
                                 len_code
                             ) << 25i32) as u32;
-    (*next).distance = dist as u32;
-    (*next).dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
+    next.distance = dist as u32;
+    next.dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
                                                              start_pos
                                                          )) as u32;
-    (*next).u.cost = cost;
+    next.u.cost = cost;
 }
 
 unsafe extern fn BackwardMatchLengthCode(
@@ -1437,7 +1437,7 @@ unsafe extern fn UpdateNodes(
             = StartPosQueueAt(queue as (*const StartPosQueue),0usize);
         let mut min_cost
             : f32
-            = (*posdata).cost + ZopfliCostModelGetMinCostCmd(
+            =  posdata.cost + ZopfliCostModelGetMinCostCmd(
                                     model
                                 ) + ZopfliCostModelGetLiteralCosts(model,(*posdata).pos,pos);
         min_len = ComputeMinimumCopyLength(
@@ -1456,9 +1456,9 @@ unsafe extern fn UpdateNodes(
                 let mut posdata
                     : *const PosData
                     = StartPosQueueAt(queue as (*const StartPosQueue),k);
-                let start : usize = (*posdata).pos;
+                let start : usize =  posdata.pos;
                 let inscode : u16 = GetInsertLengthCode(pos.wrapping_sub(start));
-                let start_costdiff : f32 = (*posdata).costdiff;
+                let start_costdiff : f32 =  posdata.costdiff;
                 let base_cost
                     : f32
                     = start_costdiff + GetInsertExtra(
@@ -1600,8 +1600,8 @@ unsafe extern fn UpdateNodes(
                             let mut max_match_len : usize;
                             PrefixEncodeCopyDistance(
                                 dist_code,
-                                (*params).dist.num_direct_distance_codes as usize,
-                                (*params).dist.distance_postfix_bits as usize,
+                                params.dist.num_direct_distance_codes as usize,
+                                params.dist.distance_postfix_bits as usize,
                                 &mut dist_symbol as (*mut u16),
                                 &mut distextra as (*mut u32)
                             );
@@ -1676,7 +1676,7 @@ unsafe extern fn StoreH10(
     let mut self : *mut H10 = SelfH10(handle);
     let max_backward
         : usize
-        = (*self).window_mask_.wrapping_sub(16).wrapping_add(
+        =  self.window_mask_.wrapping_sub(16).wrapping_add(
               1usize
           );
     StoreAndFindMatchesH10(
@@ -1727,13 +1727,13 @@ unsafe extern fn CleanupZopfliCostModel(
     {
         BrotliFree(
             m,
-            (*self).literal_costs_ as (*mut std::os::raw::c_void)
+            self.literal_costs_ as (*mut std::os::raw::c_void)
         );
-        (*self).literal_costs_ = 0i32 as (*mut std::os::raw::c_void) as (*mut f32);
+        self.literal_costs_ = 0i32 as (*mut std::os::raw::c_void) as (*mut f32);
     }
     {
         BrotliFree(m,(*self).cost_dist_ as (*mut std::os::raw::c_void));
-        (*self).cost_dist_ = 0i32 as (*mut std::os::raw::c_void) as (*mut f32);
+        self.cost_dist_ = 0i32 as (*mut std::os::raw::c_void) as (*mut f32);
     }
 }
 
@@ -1741,7 +1741,7 @@ unsafe extern fn ZopfliNodeCommandLength(
     mut self : *const ZopfliNode
 ) -> u32 {
     ZopfliNodeCopyLength(self).wrapping_add(
-        (*self).dcode_insert_length & 0x7ffffffu32
+        self.dcode_insert_length & 0x7ffffffu32
     )
 }
 
@@ -1947,7 +1947,7 @@ pub unsafe extern fn BrotliCreateZopfliBackwardReferences(
 ) {
     let max_backward_limit
         : usize
-        = (1usize << (*params).lgwin).wrapping_sub(
+        = (1usize <<  params.lgwin).wrapping_sub(
               16usize
           );
     let mut nodes : *mut ZopfliNode;
@@ -1970,7 +1970,7 @@ pub unsafe extern fn BrotliCreateZopfliBackwardReferences(
         nodes,
         num_bytes.wrapping_add(1)
     );
-    *num_commands = (*num_commands).wrapping_add(
+    *num_commands =  num_commands.wrapping_add(
                         BrotliZopfliComputeShortestPath(
                             m,
                             num_bytes,
@@ -2005,7 +2005,7 @@ pub unsafe extern fn BrotliCreateZopfliBackwardReferences(
 }
 
 unsafe extern fn CommandCopyLen(mut self : *const Command) -> u32 {
-    (*self).copy_len_ & 0x1ffffffu32
+    self.copy_len_ & 0x1ffffffu32
 }
 
 unsafe extern fn SetCost(
@@ -2087,7 +2087,7 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
     let mut pos : usize = position.wrapping_sub(last_insert_len);
     let mut min_cost_cmd : f32 = kInfinity;
     let mut i : usize;
-    let mut cost_cmd : *mut f32 = (*self).cost_cmd_;
+    let mut cost_cmd : *mut f32 =  self.cost_cmd_;
     memset(
         histogram_literal as (*mut std::os::raw::c_void),
         0i32,
@@ -2165,9 +2165,9 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
     );
     SetCost(
         histogram_dist as (*const u32),
-        (*self).distance_histogram_size as usize,
+        self.distance_histogram_size as usize,
         0i32,
-        (*self).cost_dist_
+        self.cost_dist_
     );
     i = 0usize;
     while i < 704usize {
@@ -2179,11 +2179,11 @@ unsafe extern fn ZopfliCostModelSetFromCommands(
         }
         i = i.wrapping_add(1);
     }
-    (*self).min_cost_cmd_ = min_cost_cmd;
+    self.min_cost_cmd_ = min_cost_cmd;
     {
-        let mut literal_costs : *mut f32 = (*self).literal_costs_;
+        let mut literal_costs : *mut f32 =  self.literal_costs_;
         let mut literal_carry : f32 = 0.0f64 as (f32);
-        let mut num_bytes : usize = (*self).num_bytes_;
+        let mut num_bytes : usize =  self.num_bytes_;
         *literal_costs.offset(0) = 0.0f64 as (f32);
         i = 0usize;
         while i < num_bytes {
@@ -2320,7 +2320,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
 ) {
     let max_backward_limit
         : usize
-        = (1usize << (*params).lgwin).wrapping_sub(
+        = (1usize <<  params.lgwin).wrapping_sub(
               16usize
           );
     let mut num_matches
@@ -2548,7 +2548,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                     ringbuffer,
                     ringbuffer_mask,
                     commands as (*const Command),
-                    (*num_commands).wrapping_sub(orig_num_commands),
+                    num_commands.wrapping_sub(orig_num_commands),
                     orig_last_insert_len
                 );
             }
@@ -2560,7 +2560,7 @@ pub unsafe extern fn BrotliCreateHqZopfliBackwardReferences(
                 orig_dist_cache as (*const std::os::raw::c_void),
                 (4usize).wrapping_mul(core::mem::size_of::<i32>())
             );
-            *num_commands = (*num_commands).wrapping_add(
+            *num_commands =  num_commands.wrapping_add(
                                 ZopfliIterate(
                                     num_bytes,
                                     position,

--- a/corrosion/backward_references_hq_safe.rs
+++ b/corrosion/backward_references_hq_safe.rs
@@ -207,19 +207,19 @@ pub struct Command {
 fn ZopfliNodeCopyLength(
     mut xself : & ZopfliNode
 ) -> u32 {
-    (*xself).length & 0x1ffffffu32
+    xself.length & 0x1ffffffu32
 }
 
 fn ZopfliNodeCopyDistance(
     mut xself : & ZopfliNode
 ) -> u32 {
-    (*xself).distance
+    xself.distance
 }
 
 fn ZopfliNodeLengthCode(
     mut xself : & ZopfliNode
 ) -> u32 {
-    let modifier : u32 = (*xself).length >> 25i32;
+    let modifier : u32 =  xself.length >> 25i32;
     ZopfliNodeCopyLength(xself).wrapping_add(9).wrapping_sub(
         modifier
     )
@@ -234,7 +234,7 @@ fn brotli_min_size_t(
 fn ZopfliNodeDistanceCode(
     mut xself : & ZopfliNode
 ) -> u32 {
-    let short_code : u32 = (*xself).dcode_insert_length >> 27i32;
+    let short_code : u32 =  xself.dcode_insert_length >> 27i32;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(xself).wrapping_add(
             16u32
@@ -406,14 +406,14 @@ fn InitCommand(
     mut distance_code : usize
 ) {
     let mut delta : u32 = copylen_code_delta as i8 as u8 as u32;
-    (*xself).insert_len_ = insertlen as u32;
-    (*xself).copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
+    xself.insert_len_ = insertlen as u32;
+    xself.copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
     PrefixEncodeCopyDistance(
         distance_code,
-        (*dist).num_direct_distance_codes as usize,
-        (*dist).distance_postfix_bits as usize,
-        &mut (*xself).dist_prefix_ ,
-        &mut (*xself).dist_extra_ 
+        dist.num_direct_distance_codes as usize,
+        dist.distance_postfix_bits as usize,
+        &mut  xself.dist_prefix_ ,
+        &mut  xself.dist_extra_
     );
     GetLengthCode(
         insertlen,
@@ -423,7 +423,7 @@ fn InitCommand(
         } else {
             0i32
         },
-        &mut (*xself).cmd_prefix_ 
+        &mut  xself.cmd_prefix_
     );
 }
 
@@ -458,7 +458,7 @@ pub fn BrotliZopfliCreateCommands(
                 : usize
                 = ((*next).dcode_insert_length & 0x7ffffffu32) as usize;
             pos = pos.wrapping_add(insert_length);
-            offset = (*next).u.next;
+            offset =  next.u.next;
             if i == 0usize {
                 insert_length = insert_length.wrapping_add(*last_insert_len);
                 *last_insert_len = 0usize;
@@ -503,12 +503,12 @@ pub fn BrotliZopfliCreateCommands(
                     dist_cache[(0) ]= distance as i32;
                 }
             }
-            *num_literals = (*num_literals).wrapping_add(insert_length);
+            *num_literals =  num_literals.wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
         i = i.wrapping_add(1);
     }
-    *last_insert_len = (*last_insert_len).wrapping_add(
+    *last_insert_len =  last_insert_len.wrapping_add(
                            num_bytes.wrapping_sub(pos)
                        );
 }
@@ -524,7 +524,7 @@ pub struct MemoryManager {
 fn MaxZopfliLen(
     mut params : & [BrotliEncoderParams
 ]) -> usize {
-    (if (*params).quality <= 10i32 {
+    (if  params.quality <= 10i32 {
          150i32
      } else {
          325i32
@@ -573,12 +573,12 @@ fn InitZopfliCostModel(
     mut dist : & [BrotliDistanceParams],
     mut num_bytes : usize
 ) {
-    let mut distance_histogram_size : u32 = (*dist).alphabet_size;
+    let mut distance_histogram_size : u32 =  dist.alphabet_size;
     if distance_histogram_size > 544u32 {
         distance_histogram_size = 544u32;
     }
-    (*xself).num_bytes_ = num_bytes;
-    (*xself).literal_costs_ = if num_bytes.wrapping_add(
+    xself.num_bytes_ = num_bytes;
+    xself.literal_costs_ = if num_bytes.wrapping_add(
                                     2usize
                                 ) > 0usize {
                                  BrotliAllocate(
@@ -590,7 +590,7 @@ fn InitZopfliCostModel(
                              } else {
                                  0i32  
                              };
-    (*xself).cost_dist_ = if (*dist).alphabet_size > 0u32 {
+    xself.cost_dist_ = if  dist.alphabet_size > 0u32 {
                              BrotliAllocate(
                                  m,
                                  ((*dist).alphabet_size as usize).wrapping_mul(
@@ -600,7 +600,7 @@ fn InitZopfliCostModel(
                          } else {
                              0i32  
                          };
-    (*xself).distance_histogram_size = distance_histogram_size;
+    xself.distance_histogram_size = distance_histogram_size;
     if !(0i32 == 0) { }
 }
 
@@ -619,11 +619,11 @@ fn ZopfliCostModelSetFromLiteralCosts(
     mut ringbuffer : & [u8],
     mut ringbuffer_mask : usize
 ) {
-    let mut literal_costs : *mut f32 = (*xself).literal_costs_;
+    let mut literal_costs : *mut f32 =  xself.literal_costs_;
     let mut literal_carry : f32 = 0.0f64 as (f32);
-    let mut cost_dist : *mut f32 = (*xself).cost_dist_;
-    let mut cost_cmd : *mut f32 = (*xself).cost_cmd_;
-    let mut num_bytes : usize = (*xself).num_bytes_;
+    let mut cost_dist : *mut f32 =  xself.cost_dist_;
+    let mut cost_cmd : *mut f32 =  xself.cost_cmd_;
+    let mut num_bytes : usize =  xself.num_bytes_;
     let mut i : usize;
     BrotliEstimateBitCostsForLiterals(
         position,
@@ -660,7 +660,7 @@ fn ZopfliCostModelSetFromLiteralCosts(
         i = i.wrapping_add(1);
     }
     i = 0usize;
-    while i < (*xself).distance_histogram_size as usize {
+    while i <  xself.distance_histogram_size as usize {
         {
             cost_dist[(i as usize) ]= FastLog2(
                                                   (20u32).wrapping_add(
@@ -670,11 +670,11 @@ fn ZopfliCostModelSetFromLiteralCosts(
         }
         i = i.wrapping_add(1);
     }
-    (*xself).min_cost_cmd_ = FastLog2(11) as (f32);
+    xself.min_cost_cmd_ = FastLog2(11) as (f32);
 }
 
 fn InitStartPosQueue(mut xself : &mut StartPosQueue) {
-    (*xself).idx_ = 0usize;
+    xself.idx_ = 0usize;
 }
 
 fn BrotliUnalignedRead64(
@@ -732,8 +732,8 @@ fn FindMatchLengthWithLimit(
 fn InitBackwardMatch(
     mut xself : &mut BackwardMatch, mut dist : usize, mut len : usize
 ) {
-    (*xself).distance = dist as u32;
-    (*xself).length_and_code = (len << 5i32) as u32;
+    xself.distance = dist as u32;
+    xself.length_and_code = (len << 5i32) as u32;
 }
 
 
@@ -768,14 +768,14 @@ fn ForestH10(mut xself : &mut H10) -> *mut u32 {
 fn LeftChildIndexH10(
     mut xself : &mut H10, pos : usize
 ) -> usize {
-    (2usize).wrapping_mul(pos & (*xself).window_mask_)
+    (2usize).wrapping_mul(pos &  xself.window_mask_)
 }
 
 fn RightChildIndexH10(
     mut xself : &mut H10, pos : usize
 ) -> usize {
     (2usize).wrapping_mul(
-        pos & (*xself).window_mask_
+        pos &  xself.window_mask_
     ).wrapping_add(
         1
     )
@@ -822,8 +822,8 @@ fn StoreAndFindMatchesH10(
             let prev_ix_masked : usize = prev_ix & ring_buffer_mask;
             if backward == 0usize || backward > max_backward || depth_remaining == 0usize {
                 if should_reroot_tree != 0 {
-                    forest[(node_left as usize) ]= (*xself).invalid_pos_;
-                    forest[(node_right as usize) ]= (*xself).invalid_pos_;
+                    forest[(node_left as usize) ]=  xself.invalid_pos_;
+                    forest[(node_right as usize) ]=  xself.invalid_pos_;
                 }
                 break 'break16;
             }
@@ -931,8 +931,8 @@ fn InitDictionaryBackwardMatch(
     mut len : usize,
     mut len_code : usize
 ) {
-    (*xself).distance = dist as u32;
-    (*xself).length_and_code = (len << 5i32 | if len == len_code {
+    xself.distance = dist as u32;
+    xself.length_and_code = (len << 5i32 | if len == len_code {
                                                  0usize
                                              } else {
                                                  len_code
@@ -956,7 +956,7 @@ fn FindAllMatchesH10(
     let mut best_len : usize = 1;
     let short_match_max_backward
         : usize
-        = (if (*params).quality != 11i32 {
+        = (if  params.quality != 11i32 {
                16i32
            } else {
                64i32
@@ -1067,7 +1067,7 @@ fn FindAllMatchesH10(
                               ).wrapping_add(
                                   1
                               );
-                        if distance <= (*params).dist.max_distance {
+                        if distance <=  params.dist.max_distance {
                             InitDictionaryBackwardMatch(
                                 {
                                     let _old = matches;
@@ -1100,7 +1100,7 @@ fn BackwardMatchLength(
 fn MaxZopfliCandidates(
     mut params : & [BrotliEncoderParams
 ]) -> usize {
-    (if (*params).quality <= 10i32 { 1i32 } else { 5i32 }) as usize
+    (if  params.quality <= 10i32 { 1i32 } else { 5i32 }) as usize
 }
 
 fn ComputeDistanceShortcut(
@@ -1216,15 +1216,15 @@ fn StartPosQueuePush(
     let mut offset
         : usize
         = !{
-               let _old = (*xself).idx_;
-               (*xself).idx_ = (*xself).idx_.wrapping_add(1);
+               let _old =  xself.idx_;
+               xself.idx_ =  xself.idx_.wrapping_add(1);
                _old
            } & 7usize;
     let mut len
         : usize
         = StartPosQueueSize(xself );
     let mut i : usize;
-    let mut q : *mut PosData = (*xself).q_;
+    let mut q : *mut PosData =  xself.q_;
     q[(offset as usize) ]= *posdata;
     i = 1;
     while i < len {
@@ -1311,7 +1311,7 @@ fn StartPosQueueAt(
 fn ZopfliCostModelGetMinCostCmd(
     mut xself : & ZopfliCostModel
 ) -> f32 {
-    (*xself).min_cost_cmd_
+    xself.min_cost_cmd_
 }
 
 fn ComputeMinimumCopyLength(
@@ -1368,16 +1368,16 @@ fn GetInsertExtra(mut inscode : u16) -> u32 {
         = &mut nodes[(
                     pos.wrapping_add(len) as usize
                 ) ];
-    (*next).length = (len | len.wrapping_add(
+    next.length = (len | len.wrapping_add(
                                 9u32 as usize
                             ).wrapping_sub(
                                 len_code
                             ) << 25i32) as u32;
-    (*next).distance = dist as u32;
-    (*next).dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
+    next.distance = dist as u32;
+    next.dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
                                                              start_pos
                                                          )) as u32;
-    (*next).u.cost = cost;
+    next.u.cost = cost;
 }
 
 fn BackwardMatchLengthCode(
@@ -1432,7 +1432,7 @@ fn UpdateNodes(
             = StartPosQueueAt(queue ,0usize);
         let mut min_cost
             : f32
-            = (*posdata).cost + ZopfliCostModelGetMinCostCmd(
+            =  posdata.cost + ZopfliCostModelGetMinCostCmd(
                                     model
                                 ) + ZopfliCostModelGetLiteralCosts(model,(*posdata).pos,pos);
         min_len = ComputeMinimumCopyLength(
@@ -1451,9 +1451,9 @@ fn UpdateNodes(
                 let mut posdata
                     : *const PosData
                     = StartPosQueueAt(queue ,k);
-                let start : usize = (*posdata).pos;
+                let start : usize =  posdata.pos;
                 let inscode : u16 = GetInsertLengthCode(pos.wrapping_sub(start));
-                let start_costdiff : f32 = (*posdata).costdiff;
+                let start_costdiff : f32 =  posdata.costdiff;
                 let base_cost
                     : f32
                     = start_costdiff + GetInsertExtra(
@@ -1595,8 +1595,8 @@ fn UpdateNodes(
                             let mut max_match_len : usize;
                             PrefixEncodeCopyDistance(
                                 dist_code,
-                                (*params).dist.num_direct_distance_codes as usize,
-                                (*params).dist.distance_postfix_bits as usize,
+                                params.dist.num_direct_distance_codes as usize,
+                                params.dist.distance_postfix_bits as usize,
                                 &mut dist_symbol ,
                                 &mut distextra 
                             );
@@ -1671,7 +1671,7 @@ fn StoreH10(
     let mut xself : *mut H10 = SelfH10(handle);
     let max_backward
         : usize
-        = (*xself).window_mask_.wrapping_sub(16).wrapping_add(
+        =  xself.window_mask_.wrapping_sub(16).wrapping_add(
               1
           );
     StoreAndFindMatchesH10(
@@ -1722,13 +1722,13 @@ fn CleanupZopfliCostModel(
     {
         BrotliFree(
             m,
-            (*xself).literal_costs_ 
+            xself.literal_costs_
         );
-        (*xself).literal_costs_ = 0i32  ;
+        xself.literal_costs_ = 0i32  ;
     }
     {
         BrotliFree(m,(*xself).cost_dist_ );
-        (*xself).cost_dist_ = 0i32  ;
+        xself.cost_dist_ = 0i32  ;
     }
 }
 
@@ -1736,7 +1736,7 @@ fn ZopfliNodeCommandLength(
     mut xself : & ZopfliNode
 ) -> u32 {
     ZopfliNodeCopyLength(xself).wrapping_add(
-        (*xself).dcode_insert_length & 0x7ffffffu32
+        xself.dcode_insert_length & 0x7ffffffu32
     )
 }
 
@@ -1942,7 +1942,7 @@ pub fn BrotliCreateZopfliBackwardReferences(
 ]) {
     let max_backward_limit
         : usize
-        = (1 << (*params).lgwin).wrapping_sub(
+        = (1 <<  params.lgwin).wrapping_sub(
               16usize
           );
     let mut nodes : *mut ZopfliNode;
@@ -1965,7 +1965,7 @@ pub fn BrotliCreateZopfliBackwardReferences(
         nodes,
         num_bytes.wrapping_add(1)
     );
-    *num_commands = (*num_commands).wrapping_add(
+    *num_commands =  num_commands.wrapping_add(
                         BrotliZopfliComputeShortestPath(
                             m,
                             num_bytes,
@@ -2000,7 +2000,7 @@ pub fn BrotliCreateZopfliBackwardReferences(
 }
 
 fn CommandCopyLen(mut xself : & Command) -> u32 {
-    (*xself).copy_len_ & 0x1ffffffu32
+    xself.copy_len_ & 0x1ffffffu32
 }
 
 fn SetCost(
@@ -2082,7 +2082,7 @@ fn ZopfliCostModelSetFromCommands(
     let mut pos : usize = position.wrapping_sub(last_insert_len);
     let mut min_cost_cmd : f32 = kInfinity;
     let mut i : usize;
-    let mut cost_cmd : *mut f32 = (*xself).cost_cmd_;
+    let mut cost_cmd : *mut f32 =  xself.cost_cmd_;
     memset(
         histogram_literal ,
         0i32,
@@ -2160,9 +2160,9 @@ fn ZopfliCostModelSetFromCommands(
     );
     SetCost(
         histogram_dist ,
-        (*xself).distance_histogram_size as usize,
+        xself.distance_histogram_size as usize,
         0i32,
-        (*xself).cost_dist_
+        xself.cost_dist_
     );
     i = 0usize;
     while i < 704usize {
@@ -2173,11 +2173,11 @@ fn ZopfliCostModelSetFromCommands(
         }
         i = i.wrapping_add(1);
     }
-    (*xself).min_cost_cmd_ = min_cost_cmd;
+    xself.min_cost_cmd_ = min_cost_cmd;
     {
-        let mut literal_costs : *mut f32 = (*xself).literal_costs_;
+        let mut literal_costs : *mut f32 =  xself.literal_costs_;
         let mut literal_carry : f32 = 0.0f64 as (f32);
-        let mut num_bytes : usize = (*xself).num_bytes_;
+        let mut num_bytes : usize =  xself.num_bytes_;
         literal_costs[(0) ]= 0.0f64 as (f32);
         i = 0usize;
         while i < num_bytes {
@@ -2314,7 +2314,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
 ]) {
     let max_backward_limit
         : usize
-        = (1 << (*params).lgwin).wrapping_sub(
+        = (1 <<  params.lgwin).wrapping_sub(
               16usize
           );
     let mut num_matches
@@ -2542,7 +2542,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                     ringbuffer,
                     ringbuffer_mask,
                     commands ,
-                    (*num_commands).wrapping_sub(orig_num_commands),
+                    num_commands.wrapping_sub(orig_num_commands),
                     orig_last_insert_len
                 );
             }
@@ -2554,7 +2554,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences(
                 orig_dist_cache ,
                 (4usize).wrapping_mul(core::mem::size_of::<i32>())
             );
-            *num_commands = (*num_commands).wrapping_add(
+            *num_commands =  num_commands.wrapping_add(
                                 ZopfliIterate(
                                     num_bytes,
                                     position,

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -380,8 +380,8 @@ impl<'a> BackwardMatchMut<'a> {
 
 #[inline(always)]
 pub fn InitBackwardMatch(xself: &mut BackwardMatchMut, dist: usize, len: usize) {
-    (*xself).set_distance(dist as u32);
-    (*xself).set_length_and_code((len << 5i32) as u32);
+    xself.set_distance(dist as u32);
+    xself.set_length_and_code((len << 5i32) as u32);
 }
 
 macro_rules! LeftChildIndexH10 {
@@ -402,7 +402,7 @@ fn LeftChildIndexH10<AllocU32: Allocator<u32>,
      Params:H10Params>(
     mut xself : &mut H10<AllocU32, Buckets, Params>, pos : usize
 ) -> usize {
-    (2usize).wrapping_mul(pos & (*xself).window_mask_)
+    (2usize).wrapping_mul(pos & xself.window_mask_)
 }
 
 fn RightChildIndexH10<AllocU32: Allocator<u32>,
@@ -411,7 +411,7 @@ fn RightChildIndexH10<AllocU32: Allocator<u32>,
     mut xself : &mut H10<AllocU32, Buckets, Params>, pos : usize
 ) -> usize {
     (2usize).wrapping_mul(
-        pos & (*xself).window_mask_
+        pos & xself.window_mask_
     ).wrapping_add(
         1
     )

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -160,12 +160,12 @@ pub fn BrotliZopfliCreateCommands(
                     dist_cache[0] = distance as i32;
                 }
             }
-            *num_literals = (*num_literals).wrapping_add(insert_length);
+            *num_literals = num_literals.wrapping_add(insert_length);
             pos = pos.wrapping_add(copy_length);
         }
         i = i.wrapping_add(1);
     }
-    *last_insert_len = (*last_insert_len).wrapping_add(num_bytes.wrapping_sub(pos));
+    *last_insert_len = last_insert_len.wrapping_add(num_bytes.wrapping_sub(pos));
 }
 
 #[inline(always)]
@@ -307,8 +307,8 @@ fn InitDictionaryBackwardMatch(
     len: usize,
     len_code: usize,
 ) {
-    (*xself).set_distance(dist as u32);
-    (*xself).set_length_and_code(
+    xself.set_distance(dist as u32);
+    xself.set_length_and_code(
         (len << 5i32 | if len == len_code { 0usize } else { len_code }) as u32,
     );
 }
@@ -1145,7 +1145,7 @@ pub fn BrotliCreateZopfliBackwardReferences<
         return;
     }
     BrotliInitZopfliNodes(nodes.slice_mut(), num_bytes.wrapping_add(1));
-    *num_commands = (*num_commands).wrapping_add(BrotliZopfliComputeShortestPath(
+    *num_commands = num_commands.wrapping_add(BrotliZopfliComputeShortestPath(
         alloc,
         dictionary,
         num_bytes,
@@ -1599,7 +1599,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                     ringbuffer,
                     ringbuffer_mask,
                     commands,
-                    (*num_commands).wrapping_sub(orig_num_commands),
+                    num_commands.wrapping_sub(orig_num_commands),
                     orig_last_insert_len,
                 );
             }
@@ -1614,7 +1614,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
             {
                 *i = *j;
             }
-            *num_commands = (*num_commands).wrapping_add(ZopfliIterate(
+            *num_commands = num_commands.wrapping_add(ZopfliIterate(
                 num_bytes,
                 position,
                 ringbuffer,

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -1408,7 +1408,7 @@ impl<
                         * self.specialization.get_k_hash_mul())
                         & self.specialization.get_hash_mask();
                     let key = mixed_word >> shift;
-                    let minor_ix: usize = chunk_id & self.specialization.block_mask() as usize; //   *num_ref as usize & (*self).specialization.block_mask() as usize; //GIGANTIC HAX: overwrite firsst option
+                    let minor_ix: usize = chunk_id & self.specialization.block_mask() as usize; //   *num_ref as usize & self.specialization.block_mask() as usize; //GIGANTIC HAX: overwrite firsst option
                     let offset: usize =
                         minor_ix + (key << self.specialization.block_bits()) as usize;
                     buckets[offset] = (ix_offset + i) as u32;
@@ -2502,7 +2502,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                     distance_code,
                 );
             }
-            *num_literals = (*num_literals).wrapping_add(insert_length);
+            *num_literals = num_literals.wrapping_add(insert_length);
             insert_length = 0usize;
             hasher.StoreRange(
                 ringbuffer,
@@ -2538,7 +2538,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
     }
     insert_length = insert_length.wrapping_add(pos_end.wrapping_sub(position));
     *last_insert_len = insert_length;
-    *num_commands = (*num_commands).wrapping_add(new_commands_count);
+    *num_commands = num_commands.wrapping_add(new_commands_count);
 }
 pub fn BrotliCreateBackwardReferences<
     Alloc: alloc::Allocator<u16>

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -248,19 +248,19 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     static kTwoSymbolHistogramCost: super::util::floatX = 20i32 as super::util::floatX;
     static kThreeSymbolHistogramCost: super::util::floatX = 28i32 as super::util::floatX;
     static kFourSymbolHistogramCost: super::util::floatX = 37i32 as super::util::floatX;
-    let data_size: usize = (*histogram).slice().len();
+    let data_size: usize = histogram.slice().len();
     let mut count: i32 = 0i32;
     let mut s: [usize; 5] = [0; 5];
 
     let mut bits: super::util::floatX = 0.0 as super::util::floatX;
     let mut i: usize;
-    if (*histogram).total_count() == 0usize {
+    if histogram.total_count() == 0usize {
         return kOneSymbolHistogramCost;
     }
     i = 0usize;
     'break1: while i < data_size {
         {
-            if (*histogram).slice()[i] > 0u32 {
+            if histogram.slice()[i] > 0u32 {
                 s[count as usize] = i;
                 count += 1;
                 if count > 4i32 {
@@ -276,12 +276,12 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         return kOneSymbolHistogramCost;
     }
     if count == 2i32 {
-        return kTwoSymbolHistogramCost + (*histogram).total_count() as super::util::floatX;
+        return kTwoSymbolHistogramCost + histogram.total_count() as super::util::floatX;
     }
     if count == 3i32 {
-        let histo0: u32 = (*histogram).slice()[s[0]];
-        let histo1: u32 = (*histogram).slice()[s[1]];
-        let histo2: u32 = (*histogram).slice()[s[2]];
+        let histo0: u32 = histogram.slice()[s[0]];
+        let histo1: u32 = histogram.slice()[s[1]];
+        let histo2: u32 = histogram.slice()[s[2]];
         let histomax: u32 = brotli_max_uint32_t(histo0, brotli_max_uint32_t(histo1, histo2));
         return kThreeSymbolHistogramCost
             + (2u32).wrapping_mul(histo0.wrapping_add(histo1).wrapping_add(histo2))
@@ -294,7 +294,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         i = 0usize;
         while i < 4usize {
             {
-                histo[i] = (*histogram).slice()[s[i]];
+                histo[i] = histogram.slice()[s[i]];
             }
             i = i.wrapping_add(1);
         }
@@ -325,18 +325,18 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         // vectorization failed: it's faster to do things inline than split into two loops
         let mut nnz: usize = 0;
         let mut depth_histo = [0u32; 18];
-        let total_count = (*histogram).total_count() as super::util::floatX;
+        let total_count = histogram.total_count() as super::util::floatX;
         let log2total = FastLog2((*histogram).total_count() as u64);
         i = 0usize;
         while i < data_size {
-            if (*histogram).slice()[i] > 0u32 {
+            if histogram.slice()[i] > 0u32 {
                 let nnz_val = &mut nnz_data.slice_mut()[nnz >> 3];
                 *nnz_val = nnz_val.replace(nnz & 7, histogram.slice()[i] as i32);
                 i += 1;
                 nnz += 1;
             } else {
                 let mut reps: u32 = 1;
-                for hd in (*histogram).slice()[i + 1..data_size].iter() {
+                for hd in histogram.slice()[i + 1..data_size].iter() {
                     if *hd != 0 {
                         break;
                     }

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -169,7 +169,7 @@ fn CopyLiteralsToByteArray(
 }
 
 fn MyRand(seed: &mut u32) -> u32 {
-    *seed = (*seed).wrapping_mul(16807);
+    *seed = seed.wrapping_mul(16807);
     if *seed == 0u32 {
         *seed = 1u32;
     }
@@ -376,11 +376,11 @@ where
                     local_insert_cost
                         .clone_from_slice(insert_cost_slice.split_at(base_index).1.split_at(8).0);
                     for sub_index in 0usize..8usize {
-                        *cost_iter = (*cost_iter).replace(
+                        *cost_iter = cost_iter.replace(
                             sub_index,
-                            (*cost_iter).extract(sub_index) + local_insert_cost[sub_index],
+                            cost_iter.extract(sub_index) + local_insert_cost[sub_index],
                         );
-                        let final_cost = (*cost_iter).extract(sub_index);
+                        let final_cost = cost_iter.extract(sub_index);
                         if final_cost < min_cost {
                             min_cost = final_cost;
                             *block_id_ptr = (base_index + sub_index) as u8;
@@ -807,11 +807,11 @@ fn ClusterBlocks<
     <Alloc as Allocator<u32>>::free_cell(alloc, core::mem::take(&mut clusters));
     <Alloc as Allocator<HistogramType>>::free_cell(alloc, core::mem::take(&mut all_histograms));
     {
-        if (*split).types_alloc_size() < num_blocks {
-            let mut _new_size: usize = if (*split).types_alloc_size() == 0usize {
+        if split.types_alloc_size() < num_blocks {
+            let mut _new_size: usize = if split.types_alloc_size() == 0usize {
                 num_blocks
             } else {
-                (*split).types_alloc_size()
+                split.types_alloc_size()
             };
             while _new_size < num_blocks {
                 _new_size = _new_size.wrapping_mul(2);
@@ -826,11 +826,11 @@ fn ClusterBlocks<
         }
     }
     {
-        if (*split).lengths_alloc_size() < num_blocks {
-            let mut _new_size: usize = if (*split).lengths_alloc_size() == 0usize {
+        if split.lengths_alloc_size() < num_blocks {
+            let mut _new_size: usize = if split.lengths_alloc_size() == 0usize {
                 num_blocks
             } else {
-                (*split).lengths_alloc_size()
+                split.lengths_alloc_size()
             };
             while _new_size < num_blocks {
                 _new_size = _new_size.wrapping_mul(2);
@@ -907,11 +907,11 @@ fn SplitByteVector<
         return;
     } else if length < kMinLengthForBlockSplitting {
         {
-            if (*split).types_alloc_size() < split.num_blocks.wrapping_add(1) {
-                let mut _new_size: usize = if (*split).types_alloc_size() == 0usize {
+            if split.types_alloc_size() < split.num_blocks.wrapping_add(1) {
+                let mut _new_size: usize = if split.types_alloc_size() == 0usize {
                     split.num_blocks.wrapping_add(1)
                 } else {
-                    (*split).types_alloc_size()
+                    split.types_alloc_size()
                 };
 
                 while _new_size < split.num_blocks.wrapping_add(1) {
@@ -927,11 +927,11 @@ fn SplitByteVector<
             }
         }
         {
-            if (*split).lengths_alloc_size() < split.num_blocks.wrapping_add(1) {
-                let mut _new_size: usize = if (*split).lengths_alloc_size() == 0usize {
+            if split.lengths_alloc_size() < split.num_blocks.wrapping_add(1) {
+                let mut _new_size: usize = if split.lengths_alloc_size() == 0usize {
                     split.num_blocks.wrapping_add(1)
                 } else {
-                    (*split).lengths_alloc_size()
+                    split.lengths_alloc_size()
                 };
                 while _new_size < split.num_blocks.wrapping_add(1) {
                     _new_size = _new_size.wrapping_mul(2);

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -1900,7 +1900,7 @@ fn RunLengthCodeZeros(
         if v[i] != 0u32 {
             v[*out_size] = (v[i]).wrapping_add(*max_run_length_prefix);
             i = i.wrapping_add(1);
-            *out_size = (*out_size).wrapping_add(1);
+            *out_size = out_size.wrapping_add(1);
         } else {
             let mut reps: u32 = 1u32;
             let mut k: usize;
@@ -1917,7 +1917,7 @@ fn RunLengthCodeZeros(
                     let run_length_prefix: u32 = Log2FloorNonZero(reps as (u64));
                     let extra_bits: u32 = reps.wrapping_sub(1u32 << run_length_prefix);
                     v[*out_size] = run_length_prefix.wrapping_add(extra_bits << 9i32);
-                    *out_size = (*out_size).wrapping_add(1);
+                    *out_size = out_size.wrapping_add(1);
                     {
                         {
                             break;
@@ -1927,7 +1927,7 @@ fn RunLengthCodeZeros(
                     let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1);
                     v[*out_size] = max_prefix.wrapping_add(extra_bits << 9i32);
                     reps = reps.wrapping_sub((2u32 << max_prefix).wrapping_sub(1));
-                    *out_size = (*out_size).wrapping_add(1);
+                    *out_size = out_size.wrapping_add(1);
                 }
             }
         }
@@ -2227,7 +2227,7 @@ fn CleanupBlockEncoder<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 }
 
 pub fn JumpToByteBoundary(storage_ix: &mut usize, storage: &mut [u8]) {
-    *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+    *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
     storage[(*storage_ix >> 3i32)] = 0u8;
 }
 
@@ -3042,10 +3042,10 @@ pub fn BrotliStoreUncompressedMetaBlock<Cb, Alloc: BrotliAlloc>(
     JumpToByteBoundary(storage_ix, storage);
     let dst_start0 = (*storage_ix >> 3i32);
     storage[dst_start0..(dst_start0 + input0.len())].clone_from_slice(input0);
-    *storage_ix = (*storage_ix).wrapping_add(input0.len() << 3i32);
+    *storage_ix = storage_ix.wrapping_add(input0.len() << 3i32);
     let dst_start1 = (*storage_ix >> 3i32);
     storage[dst_start1..(dst_start1 + input1.len())].clone_from_slice(input1);
-    *storage_ix = (*storage_ix).wrapping_add(input1.len() << 3i32);
+    *storage_ix = storage_ix.wrapping_add(input1.len() << 3i32);
     BrotliWriteBitsPrepareStorage(*storage_ix, storage);
     if params.log_meta_block && !suppress_meta_block_logging {
         let cmds = [Command {

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -116,12 +116,12 @@ fn BrotliCompareAndPushToQueue<
                 /* Replace the top of the queue if needed. */
                 if *num_pairs < max_num_pairs {
                     pairs[*num_pairs] = pairs[0];
-                    *num_pairs = (*num_pairs).wrapping_add(1);
+                    *num_pairs = num_pairs.wrapping_add(1);
                 }
                 pairs[0] = p;
             } else if *num_pairs < max_num_pairs {
                 pairs[*num_pairs] = p;
-                *num_pairs = (*num_pairs).wrapping_add(1);
+                *num_pairs = num_pairs.wrapping_add(1);
             }
         }
     }
@@ -279,12 +279,12 @@ pub fn BrotliHistogramBitCostDistance<
     candidate: &HistogramType,
     scratch_space: &mut HistogramType::i32vec,
 ) -> super::util::floatX {
-    if (*histogram).total_count() == 0usize {
+    if histogram.total_count() == 0usize {
         0.0 as super::util::floatX
     } else {
         let mut tmp: HistogramType = histogram.clone();
         HistogramAddHistogram(&mut tmp, candidate);
-        BrotliPopulationCost(&tmp, scratch_space) - (*candidate).bit_cost()
+        BrotliPopulationCost(&tmp, scratch_space) - candidate.bit_cost()
     }
 }
 

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -254,9 +254,9 @@ fn EmitUncompressedMetaBlock(
 ) {
     RewindBitPosition(storage_ix_start, storage_ix, storage);
     BrotliStoreMetaBlockHeader(len, 1i32, storage_ix, storage);
-    *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+    *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
     memcpy(storage, (*storage_ix >> 3i32), begin, 0, len);
-    *storage_ix = (*storage_ix).wrapping_add(len << 3i32);
+    *storage_ix = storage_ix.wrapping_add(len << 3i32);
     storage[(*storage_ix >> 3i32)] = 0u8;
 }
 
@@ -710,7 +710,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
     let mut metablock_start = 0usize;
     let mut block_size = brotli_min_size_t(input_size, kFirstBlockSize);
     let mut total_block_size = block_size;
-    let mut mlen_storage_ix = (*storage_ix).wrapping_add(3);
+    let mut mlen_storage_ix = storage_ix.wrapping_add(3);
     let mut lit_depth = [0u8; 256];
     let mut lit_bits = [0u16; 256];
     let mut literal_ratio: usize;
@@ -1065,7 +1065,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                 metablock_start = input_index;
                 block_size = brotli_min_size_t(input_size, kFirstBlockSize);
                 total_block_size = block_size;
-                mlen_storage_ix = (*storage_ix).wrapping_add(3);
+                mlen_storage_ix = storage_ix.wrapping_add(3);
                 BrotliStoreMetaBlockHeader(block_size, 0i32, storage_ix, storage);
                 BrotliWriteBits(13usize, 0, storage_ix, storage);
                 literal_ratio = BuildAndStoreLiteralPrefixCode(
@@ -1161,7 +1161,7 @@ pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
         0i32;
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         BrotliWriteBits(1usize, 1, storage_ix, storage);
-        *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+        *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
         return;
     }
     if table_bits == 9usize {
@@ -1224,12 +1224,12 @@ pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
             storage,
         );
     }
-    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
+    if storage_ix.wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
         EmitUncompressedMetaBlock(input, input_size, initial_storage_ix, storage_ix, storage);
     }
     if is_last != 0 {
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         BrotliWriteBits(1usize, 1, storage_ix, storage);
-        *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+        *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
     }
 }

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -446,7 +446,7 @@ pub fn BrotliWriteBits(n_bits: usize, bits: u64, pos: &mut usize, array: &mut [u
     let mut v: u64 = p[0] as (u64);
     v |= bits << (*pos & 7);
     BROTLI_UNALIGNED_STORE64(p, v);
-    *pos = (*pos).wrapping_add(n_bits);
+    *pos = pos.wrapping_add(n_bits);
 }
 pub fn BrotliStoreMetaBlockHeader(
     len: usize,
@@ -686,9 +686,9 @@ fn EmitUncompressedMetaBlock(
     storage: &mut [u8],
 ) {
     BrotliStoreMetaBlockHeader(input_size, 1i32, storage_ix, storage);
-    *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+    *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
     memcpy(storage, (*storage_ix >> 3i32), input, 0, input_size);
-    *storage_ix = (*storage_ix).wrapping_add(input_size << 3i32);
+    *storage_ix = storage_ix.wrapping_add(input_size << 3i32);
     storage[(*storage_ix >> 3i32)] = 0u8;
 }
 #[allow(unused_variables)]
@@ -943,13 +943,13 @@ pub fn BrotliCompressFragmentTwoPass<AllocHT: alloc::Allocator<HuffmanTree>>(
             storage,
         );
     }
-    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
+    if storage_ix.wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
         RewindBitPosition(initial_storage_ix, storage_ix, storage);
         EmitUncompressedMetaBlock(input, input_size, storage_ix, storage);
     }
     if is_last != 0 {
         BrotliWriteBits(1, 1, storage_ix, storage);
         BrotliWriteBits(1, 1, storage_ix, storage);
-        *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+        *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
     }
 }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1656,9 +1656,9 @@ fn InjectFlushOrPushOutput<Alloc: BrotliAlloc>(
         let copy_output_size: usize = brotli_min_size_t(s.available_out_, *available_out);
         (*next_out_array)[(*next_out_offset)..(*next_out_offset + copy_output_size)]
             .clone_from_slice(&GetNextOut!(s)[..copy_output_size]);
-        //memcpy(*next_out, (*s).next_out_, copy_output_size);
-        *next_out_offset = (*next_out_offset).wrapping_add(copy_output_size);
-        *available_out = (*available_out).wrapping_sub(copy_output_size);
+        //memcpy(*next_out, s.next_out_, copy_output_size);
+        *next_out_offset = next_out_offset.wrapping_add(copy_output_size);
+        *available_out = available_out.wrapping_sub(copy_output_size);
         s.next_out_ = NextOutIncrement(&s.next_out_, (copy_output_size as i32));
         s.available_out_ = s.available_out_.wrapping_sub(copy_output_size);
         s.total_out_ = s.total_out_.wrapping_add(copy_output_size as u64);
@@ -2077,7 +2077,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
     let mut block_params = params.clone();
     if bytes == 0usize {
         BrotliWriteBits(2usize, 3, storage_ix, storage);
-        *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
+        *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;
         return;
     }
     if ShouldCompress(
@@ -2432,8 +2432,8 @@ where
             }
             let data = &mut s.ringbuffer_.data_mo.slice_mut()[s.ringbuffer_.buffer_index..];
 
-            //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
-            //        (*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
+            //(*s).storage_.slice_mut()[0] = s.last_bytes_ as u8;
+            //         s.storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
 
             let table: &mut [i32] =
                 GetHashTable!(s, s.params.quality, bytes as usize, &mut table_size);
@@ -2472,7 +2472,7 @@ where
             s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
         }
         UpdateLastProcessedPos(s);
-        // *output = &mut (*s).storage_.slice_mut();
+        // *output = &mut s.storage_.slice_mut();
         s.next_out_ = NextOut::DynamicStorage(0); // this always returns that
         *out_size = storage_ix >> 3i32;
         return 1i32;
@@ -2527,13 +2527,13 @@ where
                                          wrapped_last_processed_pos as usize,
                                          data,
                                          mask as usize,
-                                         &mut (*s).params,
-                                         (*s).hasher_,
-                                         (*s).dist_cache_.as_mut_ptr(),
-                                         &mut (*s).last_insert_len_,
+                                         &mut s.params,
+                                         s.hasher_,
+                                         s.dist_cache_.as_mut_ptr(),
+                                         &mut s.last_insert_len_,
                                          &mut *(*s).commands_[((*s).num_commands_ as usize)..],
-                                         &mut (*s).num_commands_,
-                                         &mut (*s).num_literals_);"####
+                                         &mut s.num_commands_,
+                                         &mut s.num_literals_);"####
         );
     } else if false && s.params.quality == 11i32 {
         panic!(
@@ -2543,13 +2543,13 @@ where
                                            wrapped_last_processed_pos as usize,
                                            data,
                                            mask as usize,
-                                           &mut (*s).params,
-                                           (*s).hasher_,
-                                           (*s).dist_cache_.as_mut_ptr(),
-                                           &mut (*s).last_insert_len_,
+                                           &mut s.params,
+                                           s.hasher_,
+                                           s.dist_cache_.as_mut_ptr(),
+                                           &mut s.last_insert_len_,
                                            &mut *(*s).commands_[((*s).num_commands_ as usize)..],
-                                           &mut (*s).num_commands_,
-                                           &mut (*s).num_literals_);"####
+                                           &mut s.num_commands_,
+                                           &mut s.num_literals_);"####
         );
     } else {
         BrotliCreateBackwardReferences(
@@ -2618,8 +2618,8 @@ where
     }
     {
         let metablock_size: u32 = s.input_pos_.wrapping_sub(s.last_flush_pos_) as u32;
-        //let mut storage_ix: usize = (*s).last_bytes_bits_ as usize;
-        //(*s).storage_.slice_mut()[0] = (*s).last_bytes_ as u8;
+        //let mut storage_ix: usize = s.last_bytes_bits_ as usize;
+        //(*s).storage_.slice_mut()[0] = s.last_bytes_ as u8;
         //(*s).storage_.slice_mut()[1] = ((*s).last_bytes_ >> 8) as u8;
 
         WriteMetaBlockInternal(
@@ -2794,13 +2794,13 @@ fn ProcessMetadata<
                         &next_in_array[*next_in_offset..(*next_in_offset + copy as usize)],
                     );
                 //memcpy(*next_out, *next_in, copy as usize);
-                // *next_in = (*next_in).offset(copy as isize);
+                // *next_in = next_in.offset(copy as isize);
                 *next_in_offset += copy as usize;
-                *available_in = (*available_in).wrapping_sub(copy as usize);
+                *available_in = available_in.wrapping_sub(copy as usize);
                 s.remaining_metadata_bytes_ = s.remaining_metadata_bytes_.wrapping_sub(copy);
                 *next_out_offset += copy as usize;
-                // *next_out = (*next_out).offset(copy as isize);
-                *available_out = (*available_out).wrapping_sub(copy as usize);
+                // *next_out = next_out.offset(copy as isize);
+                *available_out = available_out.wrapping_sub(copy as usize);
             } else {
                 let copy: u32 = brotli_min_uint32_t(s.remaining_metadata_bytes_, 16u32);
                 s.next_out_ = NextOut::TinyBuf(0);
@@ -2808,9 +2808,9 @@ fn ProcessMetadata<
                     &next_in_array[*next_in_offset..(*next_in_offset + copy as usize)],
                 );
                 //memcpy((*s).next_out_, *next_in, copy as usize);
-                // *next_in = (*next_in).offset(copy as isize);
+                // *next_in = next_in.offset(copy as isize);
                 *next_in_offset += copy as usize;
-                *available_in = (*available_in).wrapping_sub(copy as usize);
+                *available_in = available_in.wrapping_sub(copy as usize);
                 s.remaining_metadata_bytes_ = s.remaining_metadata_bytes_.wrapping_sub(copy);
                 s.available_out_ = copy as usize;
             }
@@ -2950,13 +2950,13 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 );
             }
             *next_in_offset += block_size;
-            *available_in = (*available_in).wrapping_sub(block_size);
+            *available_in = available_in.wrapping_sub(block_size);
             if inplace != 0 {
                 let out_bytes: usize = storage_ix >> 3i32;
                 0i32;
                 0i32;
                 *next_out_offset += out_bytes;
-                *available_out = (*available_out).wrapping_sub(out_bytes);
+                *available_out = available_out.wrapping_sub(out_bytes);
                 s.total_out_ = s.total_out_.wrapping_add(out_bytes as u64);
                 if let &mut Some(ref mut total_out_inner) = total_out {
                     *total_out_inner = s.total_out_ as usize;
@@ -3084,7 +3084,7 @@ pub fn BrotliEncoderCompressStream<
             let copy_input_size: usize = brotli_min_size_t(remaining_block_size, *available_in);
             CopyInputToRingBuffer(s, copy_input_size, &next_in_array[*next_in_offset..]);
             *next_in_offset += copy_input_size;
-            *available_in = (*available_in).wrapping_sub(copy_input_size);
+            *available_in = available_in.wrapping_sub(copy_input_size);
             {
                 {
                     continue;

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -481,13 +481,13 @@ fn BrotliWriteHuffmanTreeRepetitions(
     if previous_value as i32 != value as i32 {
         tree[*tree_size] = value;
         extra_bits_data[*tree_size] = 0u8;
-        *tree_size = (*tree_size).wrapping_add(1);
+        *tree_size = tree_size.wrapping_add(1);
         repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions == 7usize {
         tree[*tree_size] = value;
         extra_bits_data[*tree_size] = 0u8;
-        *tree_size = (*tree_size).wrapping_add(1);
+        *tree_size = tree_size.wrapping_add(1);
         repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions < 3usize {
@@ -497,7 +497,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
             {
                 tree[*tree_size] = value;
                 extra_bits_data[*tree_size] = 0u8;
-                *tree_size = (*tree_size).wrapping_add(1);
+                *tree_size = tree_size.wrapping_add(1);
             }
             i = i.wrapping_add(1);
         }
@@ -507,7 +507,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
         while 1i32 != 0 {
             tree[*tree_size] = 16u8;
             extra_bits_data[*tree_size] = (repetitions & 0x3usize) as u8;
-            *tree_size = (*tree_size).wrapping_add(1);
+            *tree_size = tree_size.wrapping_add(1);
             repetitions >>= 2i32;
             if repetitions == 0usize {
                 {
@@ -530,7 +530,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
     if repetitions == 11 {
         tree[*tree_size] = 0u8;
         extra_bits_data[*tree_size] = 0u8;
-        *tree_size = (*tree_size).wrapping_add(1);
+        *tree_size = tree_size.wrapping_add(1);
         repetitions = repetitions.wrapping_sub(1);
     }
     if repetitions < 3usize {
@@ -540,7 +540,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
             {
                 tree[*tree_size] = 0u8;
                 extra_bits_data[*tree_size] = 0u8;
-                *tree_size = (*tree_size).wrapping_add(1);
+                *tree_size = tree_size.wrapping_add(1);
             }
             i = i.wrapping_add(1);
         }
@@ -550,7 +550,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
         while 1i32 != 0 {
             tree[*tree_size] = 17u8;
             extra_bits_data[*tree_size] = (repetitions & 0x7usize) as u8;
-            *tree_size = (*tree_size).wrapping_add(1);
+            *tree_size = tree_size.wrapping_add(1);
             repetitions >>= 3i32;
             if repetitions == 0usize {
                 {

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -377,12 +377,12 @@ pub fn HistogramAddItem<HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> 
 ) {
     {
         let _rhs = 1;
-        let _lhs = &mut (*xself).slice_mut()[val];
+        let _lhs = &mut xself.slice_mut()[val];
         let val = (*_lhs).wrapping_add(_rhs as u32);
         *_lhs = val;
     }
-    let new_count = (*xself).total_count().wrapping_add(1);
-    (*xself).set_total_count(new_count);
+    let new_count = xself.total_count().wrapping_add(1);
+    xself.set_total_count(new_count);
 }
 pub fn HistogramAddVector<
     HistogramType: SliceWrapper<u32> + SliceWrapperMut<u32> + CostAccessors,
@@ -394,12 +394,12 @@ pub fn HistogramAddVector<
 ) where
     u64: core::convert::From<IntegerType>,
 {
-    let new_tc = (*xself).total_count().wrapping_add(n);
-    (*xself).set_total_count(new_tc);
+    let new_tc = xself.total_count().wrapping_add(n);
+    xself.set_total_count(new_tc);
     for p_item in p[..n].iter() {
         let _rhs = 1;
         let index: usize = u64::from(p_item.clone()) as usize;
-        let _lhs = &mut (*xself).slice_mut()[index];
+        let _lhs = &mut xself.slice_mut()[index];
         *_lhs = (*_lhs).wrapping_add(_rhs as u32);
     }
 }
@@ -411,8 +411,8 @@ pub fn HistogramClear<HistogramType: SliceWrapperMut<u32> + CostAccessors>(
     for data_elem in xself.slice_mut().iter_mut() {
         *data_elem = 0;
     }
-    (*xself).set_total_count(0);
-    (*xself).set_bit_cost(3.402e+38 as super::util::floatX);
+    xself.set_total_count(0);
+    xself.set_bit_cost(3.402e+38 as super::util::floatX);
 }
 pub fn ClearHistograms<HistogramType: SliceWrapperMut<u32> + CostAccessors>(
     array: &mut [HistogramType],
@@ -430,8 +430,8 @@ pub fn HistogramAddHistogram<
     xself: &mut HistogramType,
     v: &HistogramType,
 ) {
-    let old_total_count = (*xself).total_count();
-    (*xself).set_total_count(old_total_count + (*v).total_count());
+    let old_total_count = xself.total_count();
+    xself.set_total_count(old_total_count + v.total_count());
     let h0 = xself.slice_mut();
     let h1 = v.slice();
     let n = min(h0.len(), h1.len());


### PR DESCRIPTION
Derefs are mostly not needed. Searched for them with

` \(\*([a-z][a-z0-9_]*)\)\.` -> ` $1.`

And fixed (reverted) a few that didn't compile