### PR TITLE
Remove explicit type for bitshifts

### DIFF
--- a/corrosion/backward_references_hq.rs
+++ b/corrosion/backward_references_hq.rs
@@ -67,7 +67,7 @@ pub unsafe extern fn ctzll(mut x : usize) -> usize {
     let mut count : u8 = 0u8;
     while x & 0usize != 0 {
         count = (count as i32 + 1i32) as u8;
-        x = x >> 1i32;
+        x = x >> 1;
     }
     count as usize
 }
@@ -78,17 +78,17 @@ static kCutoffTransformsCount : u32 = 10u32;
 
 static kCutoffTransforms
     : usize
-    = 0x71b520ausize << 32i32 | 0xda2d3200u32 as usize;
+    = 0x71b520ausize << 32 | 0xda2d3200u32 as usize;
 
 static kHashMul32 : u32 = 0x1e35a7bdu32;
 
 static kHashMul64
     : usize
-    = 0x1e35a7bdusize << 32i32 | 0x1e35a7bdusize;
+    = 0x1e35a7bdusize << 32 | 0x1e35a7bdusize;
 
 static kHashMul64Long
     : usize
-    = 0x1fe35a7bu32 as usize << 32i32 | 0xd3579bd3u32 as usize;
+    = 0x1fe35a7bu32 as usize << 32 | 0xd3579bd3u32 as usize;
 
 static kInfinity : f32 = 1.7e38f32;
 
@@ -219,7 +219,7 @@ unsafe extern fn ZopfliNodeCopyDistance(
 unsafe extern fn ZopfliNodeLengthCode(
     mut self : *const ZopfliNode
 ) -> u32 {
-    let modifier : u32 = (*self).length >> 25i32;
+    let modifier : u32 = (*self).length >> 25;
     ZopfliNodeCopyLength(self).wrapping_add(9).wrapping_sub(
         modifier
     )
@@ -234,7 +234,7 @@ unsafe extern fn brotli_min_size_t(
 unsafe extern fn ZopfliNodeDistanceCode(
     mut self : *const ZopfliNode
 ) -> u32 {
-    let short_code : u32 = (*self).dcode_insert_length >> 27i32;
+    let short_code : u32 = (*self).dcode_insert_length >> 27;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(self).wrapping_add(
             16u32
@@ -249,7 +249,7 @@ unsafe extern fn ZopfliNodeDistanceCode(
 unsafe extern fn Log2FloorNonZero(mut n : usize) -> u32 {
     let mut result : u32 = 0u32;
     while {
-              n = n >> 1i32;
+              n = n >> 1;
               n
           } != 0 {
         result = result.wrapping_add(1);
@@ -290,7 +290,7 @@ unsafe extern fn PrefixEncodeCopyDistance(
             : usize
             = (2usize).wrapping_add(prefix) << bucket;
         let mut nbits : usize = bucket.wrapping_sub(postfix_bits);
-        *code = (nbits << 10i32 | (16usize).wrapping_add(
+        *code = (nbits << 10 | (16usize).wrapping_add(
                                       num_direct_codes
                                   ).wrapping_add(
                                       (2usize).wrapping_mul(
@@ -318,7 +318,7 @@ unsafe extern fn GetInsertLengthCode(
               ).wrapping_sub(
                   1u32
               );
-        ((nbits << 1i32) as usize).wrapping_add(
+        ((nbits << 1) as usize).wrapping_add(
             insertlen.wrapping_sub(2) >> nbits
         ).wrapping_add(
             2usize
@@ -349,7 +349,7 @@ unsafe extern fn GetCopyLengthCode(mut copylen : usize) -> u16 {
               ).wrapping_sub(
                   1u32
               );
-        ((nbits << 1i32) as usize).wrapping_add(
+        ((nbits << 1) as usize).wrapping_add(
             copylen.wrapping_sub(6) >> nbits
         ).wrapping_add(
             4usize
@@ -370,7 +370,7 @@ unsafe extern fn CombineLengthCodes(
 ) -> u16 {
     let mut bits64
         : u16
-        = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3i32) as u16;
+        = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3) as u16;
     if use_last_distance != 0 && (inscode as i32 < 8i32) && (copycode as i32 < 16i32) {
         if copycode as i32 < 8i32 {
             bits64 as i32
@@ -380,8 +380,8 @@ unsafe extern fn CombineLengthCodes(
     } else {
         let mut offset
             : i32
-            = 2i32 * ((copycode as i32 >> 3i32) + 3i32 * (inscode as i32 >> 3i32));
-        offset = (offset << 5i32) + 0x40i32 + (0x520d40i32 >> offset & 0xc0i32);
+            = 2i32 * ((copycode as i32 >> 3) + 3i32 * (inscode as i32 >> 3));
+        offset = (offset << 5) + 0x40i32 + (0x520d40i32 >> offset & 0xc0i32);
         (offset as u16 as i32 | bits64 as i32) as u16
     }
 }
@@ -407,7 +407,7 @@ unsafe extern fn InitCommand(
 ) {
     let mut delta : u32 = copylen_code_delta as i8 as u8 as u32;
     (*self).insert_len_ = insertlen as u32;
-    (*self).copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
+    (*self).copy_len_ = (copylen | (delta << 25) as usize) as u32;
     PrefixEncodeCopyDistance(
         distance_code,
         (*dist).num_direct_distance_codes as usize,
@@ -689,7 +689,7 @@ unsafe extern fn FindMatchLengthWithLimit(
     let mut matched : usize = 0usize;
     let mut limit2
         : usize
-        = (limit >> 3i32).wrapping_add(1);
+        = (limit >> 3).wrapping_add(1);
     while {
               limit2 = limit2.wrapping_sub(1);
               limit2
@@ -710,7 +710,7 @@ unsafe extern fn FindMatchLengthWithLimit(
                           s1.offset(matched as isize) as (*const std::os::raw::c_void)
                       );
             let mut matching_bits : usize = ctzll(x) as usize;
-            matched = matched.wrapping_add(matching_bits >> 3i32);
+            matched = matched.wrapping_add(matching_bits >> 3);
             return matched;
         }
     }
@@ -733,7 +733,7 @@ unsafe extern fn InitBackwardMatch(
     mut self : *mut BackwardMatch, mut dist : usize, mut len : usize
 ) {
     (*self).distance = dist as u32;
-    (*self).length_and_code = (len << 5i32) as u32;
+    (*self).length_and_code = (len << 5) as u32;
 }
 
 #[derive(Clone, Copy)]
@@ -758,7 +758,7 @@ unsafe extern fn HashBytesH10(mut data : *const u8) -> u32 {
           ).wrapping_mul(
               kHashMul32
           );
-    h >> 32i32 - 17i32
+    h >> 32 - 17i32
 }
 
 unsafe extern fn ForestH10(mut self : *mut H10) -> *mut u32 {
@@ -932,7 +932,7 @@ unsafe extern fn InitDictionaryBackwardMatch(
     mut len_code : usize
 ) {
     (*self).distance = dist as u32;
-    (*self).length_and_code = (len << 5i32 | if len == len_code {
+    (*self).length_and_code = (len << 5 | if len == len_code {
                                                  0usize
                                              } else {
                                                  len_code
@@ -1063,7 +1063,7 @@ unsafe extern fn FindAllMatchesH10(
                         let mut distance
                             : usize
                             = max_backward.wrapping_add(gap).wrapping_add(
-                                  (dict_id >> 5i32) as usize
+                                  (dict_id >> 5) as usize
                               ).wrapping_add(
                                   1usize
                               );
@@ -1094,7 +1094,7 @@ unsafe extern fn FindAllMatchesH10(
 unsafe extern fn BackwardMatchLength(
     mut self : *const BackwardMatch
 ) -> usize {
-    ((*self).length_and_code >> 5i32) as usize
+    ((*self).length_and_code >> 5) as usize
 }
 
 unsafe extern fn MaxZopfliCandidates(
@@ -1377,9 +1377,9 @@ unsafe extern fn UpdateZopfliNode(
                                 9u32 as usize
                             ).wrapping_sub(
                                 len_code
-                            ) << 25i32) as u32;
+                            ) << 25) as u32;
     (*next).distance = dist as u32;
-    (*next).dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
+    (*next).dcode_insert_length = (short_code << 27 | pos.wrapping_sub(
                                                              start_pos
                                                          )) as u32;
     (*next).u.cost = cost;
@@ -1605,7 +1605,7 @@ unsafe extern fn UpdateNodes(
                                 &mut dist_symbol as (*mut u16),
                                 &mut distextra as (*mut u32)
                             );
-                            distnumextra = (dist_symbol as i32 >> 10i32) as u32;
+                            distnumextra = (dist_symbol as i32 >> 10) as u32;
                             dist_cost = base_cost + distnumextra as (f32) + ZopfliCostModelGetDistanceCost(
                                                                                 model,
                                                                                 (dist_symbol as i32 & 0x3ffi32) as usize

--- a/corrosion/backward_references_hq_safe.rs
+++ b/corrosion/backward_references_hq_safe.rs
@@ -67,7 +67,7 @@ pub fn ctzll(mut x : usize) -> usize {
     let mut count : u8 = 0u8;
     while x & 0usize != 0 {
         count = (count as i32 + 1i32) as u8;
-        x = x >> 1i32;
+        x = x >> 1;
     }
     count as usize
 }
@@ -78,17 +78,17 @@ static kCutoffTransformsCount : u32 = 10u32;
 
 static kCutoffTransforms
     : usize
-    = 0x71b520ausize << 32i32 | 0xda2d3200u32 as usize;
+    = 0x71b520ausize << 32 | 0xda2d3200u32 as usize;
 
 static kHashMul32 : u32 = 0x1e35a7bdu32;
 
 static kHashMul64
     : usize
-    = 0x1e35a7bdusize << 32i32 | 0x1e35a7bdusize;
+    = 0x1e35a7bdusize << 32 | 0x1e35a7bdusize;
 
 static kHashMul64Long
     : usize
-    = 0x1fe35a7bu32 as usize << 32i32 | 0xd3579bd3u32 as usize;
+    = 0x1fe35a7bu32 as usize << 32 | 0xd3579bd3u32 as usize;
 
 static kInfinity : f32 = 1.7e38f32;
 
@@ -219,7 +219,7 @@ fn ZopfliNodeCopyDistance(
 fn ZopfliNodeLengthCode(
     mut xself : & ZopfliNode
 ) -> u32 {
-    let modifier : u32 = (*xself).length >> 25i32;
+    let modifier : u32 = (*xself).length >> 25;
     ZopfliNodeCopyLength(xself).wrapping_add(9).wrapping_sub(
         modifier
     )
@@ -234,7 +234,7 @@ fn brotli_min_size_t(
 fn ZopfliNodeDistanceCode(
     mut xself : & ZopfliNode
 ) -> u32 {
-    let short_code : u32 = (*xself).dcode_insert_length >> 27i32;
+    let short_code : u32 = (*xself).dcode_insert_length >> 27;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(xself).wrapping_add(
             16u32
@@ -249,7 +249,7 @@ fn ZopfliNodeDistanceCode(
 fn Log2FloorNonZero(mut n : usize) -> u32 {
     let mut result : u32 = 0u32;
     while {
-              n = n >> 1i32;
+              n = n >> 1;
               n
           } != 0 {
         result = result.wrapping_add(1);
@@ -290,7 +290,7 @@ fn PrefixEncodeCopyDistance(
             : usize
             = (2usize).wrapping_add(prefix) << bucket;
         let mut nbits : usize = bucket.wrapping_sub(postfix_bits);
-        *code = (nbits << 10i32 | (16usize).wrapping_add(
+        *code = (nbits << 10 | (16usize).wrapping_add(
                                       num_direct_codes
                                   ).wrapping_add(
                                       (2usize).wrapping_mul(
@@ -318,7 +318,7 @@ fn GetInsertLengthCode(
               ).wrapping_sub(
                   1u32
               );
-        ((nbits << 1i32) as usize).wrapping_add(
+        ((nbits << 1) as usize).wrapping_add(
             insertlen.wrapping_sub(2) >> nbits
         ).wrapping_add(
             2usize
@@ -349,7 +349,7 @@ fn GetCopyLengthCode(mut copylen : usize) -> u16 {
               ).wrapping_sub(
                   1u32
               );
-        ((nbits << 1i32) as usize).wrapping_add(
+        ((nbits << 1) as usize).wrapping_add(
             copylen.wrapping_sub(6) >> nbits
         ).wrapping_add(
             4usize
@@ -370,7 +370,7 @@ fn CombineLengthCodes(
 ) -> u16 {
     let mut bits64
         : u16
-        = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3i32) as u16;
+        = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3) as u16;
     if use_last_distance != 0 && (inscode as i32 < 8i32) && (copycode as i32 < 16i32) {
         if copycode as i32 < 8i32 {
             bits64 as i32
@@ -380,8 +380,8 @@ fn CombineLengthCodes(
     } else {
         let mut offset
             : i32
-            = 2i32 * ((copycode as i32 >> 3i32) + 3i32 * (inscode as i32 >> 3i32));
-        offset = (offset << 5i32) + 0x40i32 + (0x520d40i32 >> offset & 0xc0i32);
+            = 2i32 * ((copycode as i32 >> 3) + 3i32 * (inscode as i32 >> 3));
+        offset = (offset << 5) + 0x40i32 + (0x520d40i32 >> offset & 0xc0i32);
         (offset as u16 as i32 | bits64 as i32) as u16
     }
 }
@@ -407,7 +407,7 @@ fn InitCommand(
 ) {
     let mut delta : u32 = copylen_code_delta as i8 as u8 as u32;
     (*xself).insert_len_ = insertlen as u32;
-    (*xself).copy_len_ = (copylen | (delta << 25i32) as usize) as u32;
+    (*xself).copy_len_ = (copylen | (delta << 25) as usize) as u32;
     PrefixEncodeCopyDistance(
         distance_code,
         (*dist).num_direct_distance_codes as usize,
@@ -689,7 +689,7 @@ fn FindMatchLengthWithLimit(
     let mut matched : usize = 0usize;
     let mut limit2
         : usize
-        = (limit >> 3i32).wrapping_add(1);
+        = (limit >> 3).wrapping_add(1);
     while {
               limit2 = limit2.wrapping_sub(1);
               limit2
@@ -710,7 +710,7 @@ fn FindMatchLengthWithLimit(
                           s1[(matched as usize) ..]
                       );
             let mut matching_bits : usize = ctzll(x) as usize;
-            matched = matched.wrapping_add(matching_bits >> 3i32);
+            matched = matched.wrapping_add(matching_bits >> 3);
             return matched;
         }
     }
@@ -733,7 +733,7 @@ fn InitBackwardMatch(
     mut xself : &mut BackwardMatch, mut dist : usize, mut len : usize
 ) {
     (*xself).distance = dist as u32;
-    (*xself).length_and_code = (len << 5i32) as u32;
+    (*xself).length_and_code = (len << 5) as u32;
 }
 
 
@@ -758,7 +758,7 @@ fn HashBytesH10(mut data : & [u8]) -> u32 {
           ).wrapping_mul(
               kHashMul32
           );
-    h >> 32i32 - 17i32
+    h >> 32 - 17i32
 }
 
 fn ForestH10(mut xself : &mut H10) -> *mut u32 {
@@ -932,7 +932,7 @@ fn InitDictionaryBackwardMatch(
     mut len_code : usize
 ) {
     (*xself).distance = dist as u32;
-    (*xself).length_and_code = (len << 5i32 | if len == len_code {
+    (*xself).length_and_code = (len << 5 | if len == len_code {
                                                  0usize
                                              } else {
                                                  len_code
@@ -1063,7 +1063,7 @@ fn FindAllMatchesH10(
                         let mut distance
                             : usize
                             = max_backward.wrapping_add(gap).wrapping_add(
-                                  (dict_id >> 5i32) as usize
+                                  (dict_id >> 5) as usize
                               ).wrapping_add(
                                   1
                               );
@@ -1094,7 +1094,7 @@ fn FindAllMatchesH10(
 fn BackwardMatchLength(
     mut xself : & BackwardMatch
 ) -> usize {
-    ((*xself).length_and_code >> 5i32) as usize
+    ((*xself).length_and_code >> 5) as usize
 }
 
 fn MaxZopfliCandidates(
@@ -1372,9 +1372,9 @@ fn GetInsertExtra(mut inscode : u16) -> u32 {
                                 9u32 as usize
                             ).wrapping_sub(
                                 len_code
-                            ) << 25i32) as u32;
+                            ) << 25) as u32;
     (*next).distance = dist as u32;
-    (*next).dcode_insert_length = (short_code << 27i32 | pos.wrapping_sub(
+    (*next).dcode_insert_length = (short_code << 27 | pos.wrapping_sub(
                                                              start_pos
                                                          )) as u32;
     (*next).u.cost = cost;
@@ -1600,7 +1600,7 @@ fn UpdateNodes(
                                 &mut dist_symbol ,
                                 &mut distextra 
                             );
-                            distnumextra = (dist_symbol as i32 >> 10i32) as u32;
+                            distnumextra = (dist_symbol as i32 >> 10) as u32;
                             dist_cost = base_cost + distnumextra as (f32) + ZopfliCostModelGetDistanceCost(
                                                                                 model,
                                                                                 (dist_symbol as i32 & 0x3ffi32) as usize

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -381,7 +381,7 @@ impl<'a> BackwardMatchMut<'a> {
 #[inline(always)]
 pub fn InitBackwardMatch(xself: &mut BackwardMatchMut, dist: usize, len: usize) {
     (*xself).set_distance(dist as u32);
-    (*xself).set_length_and_code((len << 5i32) as u32);
+    (*xself).set_length_and_code((len << 5) as u32);
 }
 
 macro_rules! LeftChildIndexH10 {

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -38,13 +38,13 @@ static kInvalidMatch: u32 = 0xfffffffu32;
 
 static kCutoffTransformsCount: u32 = 10u32;
 
-static kCutoffTransforms: u64 = 0x71b520au64 << 32i32 | 0xda2d3200u32 as (u64);
+static kCutoffTransforms: u64 = 0x71b520au64 << 32 | 0xda2d3200u32 as (u64);
 
 pub static kHashMul32: u32 = 0x1e35a7bdu32;
 
-pub static kHashMul64: u64 = 0x1e35a7bdu64 << 32i32 | 0x1e35a7bdu64;
+pub static kHashMul64: u64 = 0x1e35a7bdu64 << 32 | 0x1e35a7bdu64;
 
-pub static kHashMul64Long: u64 = 0x1fe35a7bu32 as (u64) << 32i32 | 0xd3579bd3u32 as (u64);
+pub static kHashMul64Long: u64 = 0x1fe35a7bu32 as (u64) << 32 | 0xd3579bd3u32 as (u64);
 
 */
 pub const BROTLI_MAX_EFFECTIVE_DISTANCE_ALPHABET_SIZE: usize = 544;
@@ -78,7 +78,7 @@ fn ZopfliNodeCopyDistance(xself: &ZopfliNode) -> u32 {
 
 #[inline(always)]
 fn ZopfliNodeLengthCode(xself: &ZopfliNode) -> u32 {
-    let modifier: u32 = xself.length >> 25i32;
+    let modifier: u32 = xself.length >> 25;
     ZopfliNodeCopyLength(xself)
         .wrapping_add(9)
         .wrapping_sub(modifier)
@@ -91,7 +91,7 @@ fn brotli_min_size_t(a: usize, b: usize) -> usize {
 
 #[inline(always)]
 fn ZopfliNodeDistanceCode(xself: &ZopfliNode) -> u32 {
-    let short_code: u32 = xself.dcode_insert_length >> 27i32;
+    let short_code: u32 = xself.dcode_insert_length >> 27;
     if short_code == 0u32 {
         ZopfliNodeCopyDistance(xself)
             .wrapping_add(16)
@@ -308,9 +308,8 @@ fn InitDictionaryBackwardMatch(
     len_code: usize,
 ) {
     (*xself).set_distance(dist as u32);
-    (*xself).set_length_and_code(
-        (len << 5i32 | if len == len_code { 0usize } else { len_code }) as u32,
-    );
+    (*xself)
+        .set_length_and_code((len << 5 | if len == len_code { 0usize } else { len_code }) as u32);
 }
 
 pub fn StitchToPreviousBlockH10<
@@ -469,7 +468,7 @@ where
                     if dict_id < kInvalidMatch {
                         let distance: usize = max_backward
                             .wrapping_add(gap)
-                            .wrapping_add((dict_id >> 5i32) as usize)
+                            .wrapping_add((dict_id >> 5) as usize)
                             .wrapping_add(1);
                         if distance <= params.dist.max_distance {
                             InitDictionaryBackwardMatch(
@@ -491,7 +490,7 @@ where
 
 #[inline(always)]
 fn BackwardMatchLength(xself: &BackwardMatch) -> usize {
-    ((*xself).length_and_code() >> 5i32) as usize
+    ((*xself).length_and_code() >> 5) as usize
 }
 
 #[inline(always)]
@@ -713,7 +712,7 @@ fn UpdateZopfliNode(
     cost: floatX,
 ) {
     let next = &mut nodes[pos.wrapping_add(len)];
-    next.length = (len | len.wrapping_add(9u32 as usize).wrapping_sub(len_code) << 25i32) as u32;
+    next.length = (len | len.wrapping_add(9u32 as usize).wrapping_sub(len_code) << 25) as u32;
     next.distance = dist as u32;
     next.dcode_insert_length = pos.wrapping_sub(start_pos) as u32 | (short_code << 27) as u32;
     next.u = Union1::cost(cost);

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -23,13 +23,13 @@ pub static kInvalidMatch: u32 = 0xfffffffu32;
 
 static kCutoffTransformsCount: u32 = 10u32;
 
-static kCutoffTransforms: u64 = 0x71b520au64 << 32i32 | 0xda2d3200u32 as (u64);
+static kCutoffTransforms: u64 = 0x71b520au64 << 32 | 0xda2d3200u32 as (u64);
 
 pub static kHashMul32: u32 = 0x1e35a7bdu32;
 
-pub static kHashMul64: u64 = 0x1e35a7bdu64 << 32i32 | 0x1e35a7bdu64;
+pub static kHashMul64: u64 = 0x1e35a7bdu64 << 32 | 0x1e35a7bdu64;
 
-pub static kHashMul64Long: u64 = 0x1fe35a7bu32 as (u64) << 32i32 | 0xd3579bd3u32 as (u64);
+pub static kHashMul64Long: u64 = 0x1fe35a7bu32 as (u64) << 32 | 0xd3579bd3u32 as (u64);
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[repr(C)]
@@ -258,8 +258,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> BasicHashe
                 let mixed1 = self.HashBytes(word11.split_at(1).1);
                 let mixed2 = self.HashBytes(word11.split_at(2).1);
                 let mixed3 = self.HashBytes(word11.split_at(3).1);
-                let off: u32 =
-                    (i >> 3i32).wrapping_rem(self.buckets_.BUCKET_SWEEP() as usize) as u32;
+                let off: u32 = (i >> 3).wrapping_rem(self.buckets_.BUCKET_SWEEP() as usize) as u32;
                 let offset0: usize = mixed0 + off as usize;
                 let offset1: usize = mixed1 + off as usize;
                 let offset2: usize = mixed2 + off as usize;
@@ -312,7 +311,7 @@ impl<T: SliceWrapperMut<u32> + SliceWrapper<u32> + BasicHashComputer> AnyHasher 
     fn Store(&mut self, data: &[u8], mask: usize, ix: usize) {
         let (_, data_window) = data.split_at((ix & mask));
         let key: u32 = self.HashBytes(data_window) as u32;
-        let off: u32 = (ix >> 3i32).wrapping_rem(self.buckets_.BUCKET_SWEEP() as usize) as u32;
+        let off: u32 = (ix >> 3).wrapping_rem(self.buckets_.BUCKET_SWEEP() as usize) as u32;
         self.buckets_.slice_mut()[key.wrapping_add(off) as usize] = ix as u32;
     }
     fn StoreRange(&mut self, data: &[u8], mask: usize, ix_start: usize, ix_end: usize) {
@@ -1895,7 +1894,7 @@ fn TestStaticDictionaryItem(
     let backward: usize;
 
     let len: usize = item & 0x1fusize;
-    let dist: usize = item >> 5i32;
+    let dist: usize = item >> 5;
     let offset: usize =
         (dictionary.offsets_by_length[len] as usize).wrapping_add(len.wrapping_mul(dist));
     if len > max_length {
@@ -1908,7 +1907,7 @@ fn TestStaticDictionaryItem(
     {
         let cut: u64 = len.wrapping_sub(matchlen) as u64;
         let transform_id: usize =
-            (cut << 2i32).wrapping_add(kCutoffTransforms >> cut.wrapping_mul(6) & 0x3f) as usize;
+            (cut << 2).wrapping_add(kCutoffTransforms >> cut.wrapping_mul(6) & 0x3f) as usize;
         backward = max_backward
             .wrapping_add(dist)
             .wrapping_add(1)
@@ -1944,10 +1943,10 @@ fn SearchInStaticDictionary<HasherType: AnyHasher>(
     let mut is_match_found: i32 = 0i32;
     let opts = handle.Opts();
     let xself: &mut Struct1 = handle.GetHasherCommon();
-    if xself.dict_num_matches < xself.dict_num_lookups >> 7i32 {
+    if xself.dict_num_matches < xself.dict_num_lookups >> 7 {
         return 0i32;
     }
-    key = (Hash14(data) << 1i32) as usize; //FIXME: works for any kind of hasher??
+    key = (Hash14(data) << 1) as usize; //FIXME: works for any kind of hasher??
     i = 0usize;
     while i < if shallow != 0 { 1u32 } else { 2u32 } as usize {
         {

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -297,7 +297,7 @@ where
         return 0;
     }
     let data_size: usize = histograms[0].slice().len();
-    let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3i32;
+    let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3;
     let mut num_blocks: usize = 1;
     let mut i: usize;
     let mut j: usize;
@@ -431,7 +431,7 @@ where
             0i32;
             byte_ix -= 1;
             ix = ix.wrapping_sub(bitmaplen);
-            if switch_signal[ix.wrapping_add((cur_id as i32 >> 3i32) as usize)] as i32 & mask as i32
+            if switch_signal[ix.wrapping_add((cur_id as i32 >> 3) as usize)] as i32 & mask as i32
                 != 0
                 && cur_id as i32 != block_id[byte_ix] as i32
             {
@@ -970,7 +970,7 @@ fn SplitByteVector<
     {
         let mut block_ids = <Alloc as Allocator<u8>>::alloc_cell(alloc, length);
         let mut num_blocks: usize = 0usize;
-        let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3i32;
+        let bitmaplen: usize = num_histograms.wrapping_add(7) >> 3;
         let mut insert_cost = <Alloc as Allocator<super::util::floatX>>::alloc_cell(
             alloc,
             data_size.wrapping_mul(num_histograms),

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -984,7 +984,7 @@ pub fn BrotliStoreHuffmanTree(
 fn StoreStaticCodeLengthCode(storage_ix: &mut usize, storage: &mut [u8]) {
     BrotliWriteBits(
         40,
-        0xffu32 as (u64) << 32i32 | 0x55555554u32 as (u64),
+        0xffu32 as (u64) << 32 | 0x55555554u32 as (u64),
         storage_ix,
         storage,
     );
@@ -1916,7 +1916,7 @@ fn RunLengthCodeZeros(
                 if reps < 2u32 << max_prefix {
                     let run_length_prefix: u32 = Log2FloorNonZero(reps as (u64));
                     let extra_bits: u32 = reps.wrapping_sub(1u32 << run_length_prefix);
-                    v[*out_size] = run_length_prefix.wrapping_add(extra_bits << 9i32);
+                    v[*out_size] = run_length_prefix.wrapping_add(extra_bits << 9);
                     *out_size = (*out_size).wrapping_add(1);
                     {
                         {
@@ -1925,7 +1925,7 @@ fn RunLengthCodeZeros(
                     }
                 } else {
                     let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1);
-                    v[*out_size] = max_prefix.wrapping_add(extra_bits << 9i32);
+                    v[*out_size] = max_prefix.wrapping_add(extra_bits << 9);
                     reps = reps.wrapping_sub((2u32 << max_prefix).wrapping_sub(1));
                     *out_size = (*out_size).wrapping_add(1);
                 }
@@ -1947,7 +1947,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     let mut rle_symbols: AllocU32::AllocatedMemory;
     let mut max_run_length_prefix: u32 = 6u32;
     let mut num_rle_symbols: usize = 0usize;
-    static kSymbolMask: u32 = (1u32 << 9i32) - 1;
+    static kSymbolMask: u32 = (1u32 << 9) - 1;
     let mut depths: [u8; 272] = [0; 272];
     let mut bits: [u16; 272] = [0; 272];
     StoreVarLenUint8(num_clusters.wrapping_sub(1) as u64, storage_ix, storage);
@@ -2006,7 +2006,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     while i < num_rle_symbols {
         {
             let rle_symbol: u32 = rle_symbols.slice()[i] & kSymbolMask;
-            let extra_bits_val: u32 = rle_symbols.slice()[i] >> 9i32;
+            let extra_bits_val: u32 = rle_symbols.slice()[i] >> 9;
             BrotliWriteBits(
                 depths[rle_symbol as usize],
                 bits[rle_symbol as usize] as (u64),
@@ -2150,13 +2150,13 @@ fn StoreCommandExtra(cmd: &Command, storage_ix: &mut usize, storage: &mut [u8]) 
 fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
         ContextType::CONTEXT_LSB6 => (p1 as i32 & 0x3fi32) as u8,
-        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2i32) as u8,
+        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2) as u8,
         ContextType::CONTEXT_UTF8 => {
             (kUTF8ContextLookup[p1 as usize] as i32
                 | kUTF8ContextLookup[(p2 as i32 + 256i32) as usize] as i32) as u8
         }
         ContextType::CONTEXT_SIGNED => {
-            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3i32)
+            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3)
                 + kSigned3BitContextLookup[p2 as usize] as i32) as u8
         }
     }
@@ -2210,7 +2210,7 @@ fn CommandCopyLen(xself: &Command) -> u32 {
 }
 
 fn CommandDistanceContext(xself: &Command) -> u32 {
-    let r: u32 = (xself.cmd_prefix_ as i32 >> 6i32) as u32;
+    let r: u32 = (xself.cmd_prefix_ as i32 >> 6) as u32;
     let c: u32 = (xself.cmd_prefix_ as i32 & 7i32) as u32;
     if (r == 0u32 || r == 2u32 || r == 4u32 || r == 7u32) && (c <= 2u32) {
         return c;
@@ -2228,7 +2228,7 @@ fn CleanupBlockEncoder<Alloc: alloc::Allocator<u8> + alloc::Allocator<u16>>(
 
 pub fn JumpToByteBoundary(storage_ix: &mut usize, storage: &mut [u8]) {
     *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
-    storage[(*storage_ix >> 3i32)] = 0u8;
+    storage[(*storage_ix >> 3)] = 0u8;
 }
 
 pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
@@ -2454,7 +2454,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
                 prev_byte = input[(pos.wrapping_sub(1) & mask)];
                 if cmd.cmd_prefix_ as i32 >= 128i32 {
                     let dist_code: usize = cmd.dist_prefix_ as usize & 0x3ff;
-                    let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10i32; //FIXME: from command
+                    let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10; //FIXME: from command
                     let distextra: u64 = cmd.dist_extra_ as (u64);
                     if mb.distance_context_map_size == 0usize {
                         StoreSymbol(&mut distance_enc, dist_code, storage_ix, storage);
@@ -2565,7 +2565,7 @@ fn StoreDataWithHuffmanCodes(
             pos = pos.wrapping_add(CommandCopyLen(&cmd) as usize);
             if CommandCopyLen(&cmd) != 0 && (cmd.cmd_prefix_ as i32 >= 128i32) {
                 let dist_code: usize = cmd.dist_prefix_ as usize & 0x3ff;
-                let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10i32;
+                let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10;
                 let distextra: u32 = cmd.dist_extra_;
                 BrotliWriteBits(
                     dist_depth[dist_code],
@@ -2702,7 +2702,7 @@ pub fn BrotliStoreMetaBlockTrivial<Alloc: BrotliAlloc, Cb>(
 fn StoreStaticCommandHuffmanTree(storage_ix: &mut usize, storage: &mut [u8]) {
     BrotliWriteBits(
         56,
-        0x926244u32 as (u64) << 32i32 | 0x16307003,
+        0x926244u32 as (u64) << 32 | 0x16307003,
         storage_ix,
         storage,
     );
@@ -3040,12 +3040,12 @@ pub fn BrotliStoreUncompressedMetaBlock<Cb, Alloc: BrotliAlloc>(
     let (input0, input1) = InputPairFromMaskedInput(input, position, len, mask);
     BrotliStoreUncompressedMetaBlockHeader(len, storage_ix, storage);
     JumpToByteBoundary(storage_ix, storage);
-    let dst_start0 = (*storage_ix >> 3i32);
+    let dst_start0 = (*storage_ix >> 3);
     storage[dst_start0..(dst_start0 + input0.len())].clone_from_slice(input0);
-    *storage_ix = (*storage_ix).wrapping_add(input0.len() << 3i32);
-    let dst_start1 = (*storage_ix >> 3i32);
+    *storage_ix = (*storage_ix).wrapping_add(input0.len() << 3);
+    let dst_start1 = (*storage_ix >> 3);
     storage[dst_start1..(dst_start1 + input1.len())].clone_from_slice(input1);
-    *storage_ix = (*storage_ix).wrapping_add(input1.len() << 3i32);
+    *storage_ix = (*storage_ix).wrapping_add(input1.len() << 3);
     BrotliWriteBitsPrepareStorage(*storage_ix, storage);
     if params.log_meta_block && !suppress_meta_block_logging {
         let cmds = [Command {

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -25,7 +25,7 @@ pub fn CommandCopyLen(xself: &Command) -> u32 {
 }
 
 pub fn CommandDistanceContext(xself: &Command) -> u32 {
-    let r: u32 = (xself.cmd_prefix_ as i32 >> 6i32) as u32;
+    let r: u32 = (xself.cmd_prefix_ as i32 >> 6) as u32;
     let c: u32 = (xself.cmd_prefix_ as i32 & 7i32) as u32;
     if (r == 0u32 || r == 2u32 || r == 4u32 || r == 7u32) && (c <= 2u32) {
         c
@@ -63,7 +63,7 @@ pub fn GetInsertLengthCode(insertlen: usize) -> u16 {
         insertlen as u16
     } else if insertlen < 130usize {
         let nbits: u32 = Log2FloorNonZero(insertlen.wrapping_sub(2) as u64).wrapping_sub(1);
-        ((nbits << 1i32) as usize)
+        ((nbits << 1) as usize)
             .wrapping_add(insertlen.wrapping_sub(2) >> nbits)
             .wrapping_add(2) as u16
     } else if insertlen < 2114usize {
@@ -83,7 +83,7 @@ pub fn GetCopyLengthCode(copylen: usize) -> u16 {
         copylen.wrapping_sub(2) as u16
     } else if copylen < 134usize {
         let nbits: u32 = Log2FloorNonZero(copylen.wrapping_sub(6) as u64).wrapping_sub(1);
-        ((nbits << 1i32) as usize)
+        ((nbits << 1) as usize)
             .wrapping_add(copylen.wrapping_sub(6) >> nbits)
             .wrapping_add(4) as u16
     } else if copylen < 2118usize {
@@ -95,7 +95,7 @@ pub fn GetCopyLengthCode(copylen: usize) -> u16 {
 
 #[inline(always)]
 pub fn CombineLengthCodes(inscode: u16, copycode: u16, use_last_distance: i32) -> u16 {
-    let bits64: u16 = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3i32) as u16;
+    let bits64: u16 = (copycode as u32 & 0x7u32 | (inscode as u32 & 0x7u32) << 3) as u16;
     if use_last_distance != 0 && ((inscode as i32) < 8i32) && ((copycode as i32) < 16i32) {
         if (copycode as i32) < 8i32 {
             bits64
@@ -104,8 +104,8 @@ pub fn CombineLengthCodes(inscode: u16, copycode: u16, use_last_distance: i32) -
             (bits64 as i32 | s64 as i32) as u16
         }
     } else {
-        let sub_offset: i32 = 2i32 * ((copycode as i32 >> 3i32) + 3i32 * (inscode as i32 >> 3i32));
-        let offset = (sub_offset << 5i32) + 0x40i32 + (0x520d40i32 >> sub_offset & 0xc0i32);
+        let sub_offset: i32 = 2i32 * ((copycode as i32 >> 3) + 3i32 * (inscode as i32 >> 3));
+        let offset = (sub_offset << 5) + 0x40i32 + (0x520d40i32 >> sub_offset & 0xc0i32);
         (offset as u16 as i32 | bits64 as i32) as u16
     }
 }
@@ -153,7 +153,7 @@ pub fn PrefixEncodeCopyDistance(
         .wrapping_add((2u64).wrapping_mul(nbits.wrapping_sub(1)).wrapping_add(prefix) <<
                       postfix_bits)
         .wrapping_add(postfix) as u16;*/
-        //*extra_bits = (nbits << 24i32 | dist.wrapping_sub(offset) >> postfix_bits) as u32;
+        //*extra_bits = (nbits << 24 | dist.wrapping_sub(offset) >> postfix_bits) as u32;
     }
 }
 pub fn CommandRestoreDistanceCode(xself: &Command, dist: &BrotliDistanceParams) -> u32 {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -29,7 +29,7 @@ static kCmdHistoSeed: [u32; 128] = [
 ];
 
 fn Hash(p: &[u8], shift: usize) -> u32 {
-    let h: u64 = (BROTLI_UNALIGNED_LOAD64(p) << 24i32).wrapping_mul(kHashMul32 as (u64));
+    let h: u64 = (BROTLI_UNALIGNED_LOAD64(p) << 24).wrapping_mul(kHashMul32 as (u64));
     (h >> shift) as u32
 }
 fn IsMatch(p1: &[u8], p2: &[u8]) -> i32 {
@@ -54,7 +54,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
     let mut histogram: [u32; 256] = [0; 256];
     let mut histogram_total: usize;
     let mut i: usize;
-    if input_size < (1i32 << 15i32) as usize {
+    if input_size < (1i32 << 15) as usize {
         i = 0usize;
         while i < input_size {
             {
@@ -167,7 +167,7 @@ fn EmitInsertLen(
         let tail: usize = insertlen.wrapping_sub(2);
         let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
-        let inscode: usize = ((nbits << 1i32) as usize)
+        let inscode: usize = ((nbits << 1) as usize)
             .wrapping_add(prefix)
             .wrapping_add(42);
         BrotliWriteBits(
@@ -239,7 +239,7 @@ fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mu
     let mask: usize = (1u32 << bitpos).wrapping_sub(1) as usize;
     {
         let _rhs = mask as u8;
-        let _lhs = &mut storage[(new_storage_ix >> 3i32)];
+        let _lhs = &mut storage[(new_storage_ix >> 3)];
         *_lhs = (*_lhs as i32 & _rhs as i32) as u8;
     }
     *storage_ix = new_storage_ix;
@@ -255,9 +255,9 @@ fn EmitUncompressedMetaBlock(
     RewindBitPosition(storage_ix_start, storage_ix, storage);
     BrotliStoreMetaBlockHeader(len, 1i32, storage_ix, storage);
     *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
-    memcpy(storage, (*storage_ix >> 3i32), begin, 0, len);
-    *storage_ix = (*storage_ix).wrapping_add(len << 3i32);
-    storage[(*storage_ix >> 3i32)] = 0u8;
+    memcpy(storage, (*storage_ix >> 3), begin, 0, len);
+    *storage_ix = (*storage_ix).wrapping_add(len << 3);
+    storage[(*storage_ix >> 3)] = 0u8;
 }
 
 fn EmitLongInsertLen(
@@ -374,9 +374,7 @@ fn EmitCopyLenLastDistance(
         let tail: usize = copylen.wrapping_sub(8);
         let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
-        let code: usize = ((nbits << 1i32) as usize)
-            .wrapping_add(prefix)
-            .wrapping_add(4);
+        let code: usize = ((nbits << 1) as usize).wrapping_add(prefix).wrapping_add(4);
         BrotliWriteBits(
             depth[(code as usize)] as usize,
             bits[(code as usize)] as (u64),
@@ -396,7 +394,7 @@ fn EmitCopyLenLastDistance(
         }
     } else if copylen < 136usize {
         let tail: usize = copylen.wrapping_sub(8);
-        let code: usize = (tail >> 5i32).wrapping_add(30);
+        let code: usize = (tail >> 5).wrapping_add(30);
         BrotliWriteBits(
             depth[code] as usize,
             bits[code] as (u64),
@@ -466,7 +464,7 @@ fn EmitCopyLenLastDistance(
 
 fn HashBytesAtOffset(v: u64, offset: i32, shift: usize) -> u32 {
     {
-        let h: u64 = (v >> (8i32 * offset) << 24i32).wrapping_mul(kHashMul32 as (u64));
+        let h: u64 = (v >> (8i32 * offset) << 24).wrapping_mul(kHashMul32 as (u64));
         (h >> shift) as u32
     }
 }
@@ -495,7 +493,7 @@ fn EmitCopyLen(
         let tail: usize = copylen.wrapping_sub(6);
         let nbits: u32 = Log2FloorNonZero(tail as u64).wrapping_sub(1);
         let prefix: usize = tail >> nbits;
-        let code: usize = ((nbits << 1i32) as usize)
+        let code: usize = ((nbits << 1) as usize)
             .wrapping_add(prefix)
             .wrapping_add(20);
         BrotliWriteBits(
@@ -591,7 +589,7 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> i32 {
 
 fn UpdateBits(mut n_bits: usize, mut bits: u32, mut pos: usize, array: &mut [u8]) {
     while n_bits > 0usize {
-        let byte_pos: usize = pos >> 3i32;
+        let byte_pos: usize = pos >> 3;
         let n_unchanged_bits: usize = pos & 7usize;
         let n_changed_bits: usize =
             brotli_min_size_t(n_bits, (8usize).wrapping_sub(n_unchanged_bits));
@@ -703,8 +701,8 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
     let mut ip_end = 0usize;
     let mut next_emit = 0usize;
     let base_ip = 0usize;
-    static kFirstBlockSize: usize = (3i32 << 15i32) as usize;
-    static kMergeBlockSize: usize = (1i32 << 16i32) as usize;
+    static kFirstBlockSize: usize = (3i32 << 15) as usize;
+    static kMergeBlockSize: usize = (1i32 << 16) as usize;
     let kInputMarginBytes = 16usize;
     let kMinMatchLen = 5usize;
     let mut metablock_start = 0usize;
@@ -737,7 +735,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
     }
     BrotliWriteBits(
         *cmd_code_numbits & 7usize,
-        cmd_code[*cmd_code_numbits >> 3i32] as u64,
+        cmd_code[*cmd_code_numbits >> 3] as u64,
         storage_ix,
         storage,
     );
@@ -775,7 +773,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                                         let _old = skip;
                                         skip = skip.wrapping_add(1);
                                         _old
-                                    } >> 5i32;
+                                    } >> 5;
                                     ip_index = next_ip;
                                     next_ip =
                                         ip_index.wrapping_add(bytes_between_hash_lookups as usize);
@@ -801,7 +799,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             }
                         }
                         if !(ip_index.wrapping_sub(candidate)
-                            > (1usize << 18i32).wrapping_sub(16) as isize as usize
+                            > (1usize << 18).wrapping_sub(16) as isize as usize
                             && (code_block_selection as i32
                                 == CodeBlockState::EMIT_COMMANDS as i32))
                         {
@@ -927,7 +925,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                             &input_ptr[ip_index + 5..],
                             ip_end.wrapping_sub(ip_index).wrapping_sub(5),
                         ));
-                        if ip_index.wrapping_sub(candidate) > (1usize << 18i32).wrapping_sub(16) {
+                        if ip_index.wrapping_sub(candidate) > (1usize << 18).wrapping_sub(16) {
                             break;
                         }
                         ip_index = ip_index.wrapping_add(matched);
@@ -992,7 +990,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
             input_size = input_size.wrapping_sub(block_size);
             block_size = brotli_min_size_t(input_size, kMergeBlockSize);
             if input_size > 0
-                && (total_block_size.wrapping_add(block_size) <= (1i32 << 20i32) as usize)
+                && (total_block_size.wrapping_add(block_size) <= (1i32 << 20) as usize)
                 && (ShouldMergeBlock(&input_ptr[input_index..], block_size, &mut lit_depth[..])
                     != 0)
             {
@@ -1224,7 +1222,7 @@ pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
             storage,
         );
     }
-    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
+    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3) {
         EmitUncompressedMetaBlock(input, input_size, initial_storage_ix, storage_ix, storage);
     }
     if is_last != 0 {

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -13,7 +13,7 @@ use super::static_dict::{
 };
 use super::util::{brotli_min_size_t, Log2FloorNonZero};
 use core;
-static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17i32) as usize;
+static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17) as usize;
 
 // returns number of commands inserted
 fn EmitInsertLen(insertlen: u32, commands: &mut &mut [u32]) -> usize {
@@ -23,24 +23,24 @@ fn EmitInsertLen(insertlen: u32, commands: &mut &mut [u32]) -> usize {
         let tail: u32 = insertlen.wrapping_sub(2);
         let nbits: u32 = Log2FloorNonZero(tail as (u64)).wrapping_sub(1);
         let prefix: u32 = tail >> nbits;
-        let inscode: u32 = (nbits << 1i32).wrapping_add(prefix).wrapping_add(2);
+        let inscode: u32 = (nbits << 1).wrapping_add(prefix).wrapping_add(2);
         let extra: u32 = tail.wrapping_sub(prefix << nbits);
-        (*commands)[0] = inscode | extra << 8i32;
+        (*commands)[0] = inscode | extra << 8;
     } else if insertlen < 2114u32 {
         let tail: u32 = insertlen.wrapping_sub(66);
         let nbits: u32 = Log2FloorNonZero(tail as (u64));
         let code: u32 = nbits.wrapping_add(10);
         let extra: u32 = tail.wrapping_sub(1u32 << nbits);
-        (*commands)[0] = code | extra << 8i32;
+        (*commands)[0] = code | extra << 8;
     } else if insertlen < 6210u32 {
         let extra: u32 = insertlen.wrapping_sub(2114);
-        (*commands)[0] = 21u32 | extra << 8i32;
+        (*commands)[0] = 21u32 | extra << 8;
     } else if insertlen < 22594u32 {
         let extra: u32 = insertlen.wrapping_sub(6210);
-        (*commands)[0] = 22u32 | extra << 8i32;
+        (*commands)[0] = 22u32 | extra << 8;
     } else {
         let extra: u32 = insertlen.wrapping_sub(22594);
-        (*commands)[0] = 23u32 | extra << 8i32;
+        (*commands)[0] = 23u32 | extra << 8;
     }
     let remainder = core::mem::take(commands);
     let _ = core::mem::replace(commands, &mut remainder[1..]);
@@ -57,7 +57,7 @@ fn EmitDistance(distance: u32, commands: &mut &mut [u32]) -> usize {
         .wrapping_add(prefix)
         .wrapping_add(80);
     let extra: u32 = d.wrapping_sub(offset);
-    (*commands)[0] = distcode | extra << 8i32;
+    (*commands)[0] = distcode | extra << 8;
     let remainder = core::mem::take(commands);
     let _ = core::mem::replace(commands, &mut remainder[1..]);
     1
@@ -73,17 +73,17 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
         let tail: usize = copylen.wrapping_sub(8);
         let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1) as usize;
         let prefix: usize = tail >> nbits;
-        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(28);
+        let code: usize = (nbits << 1).wrapping_add(prefix).wrapping_add(28);
         let extra: usize = tail.wrapping_sub(prefix << nbits);
-        (*commands)[0] = (code | extra << 8i32) as u32;
+        (*commands)[0] = (code | extra << 8) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         1
     } else if copylen < 136usize {
         let tail: usize = copylen.wrapping_sub(8);
-        let code: usize = (tail >> 5i32).wrapping_add(54);
+        let code: usize = (tail >> 5).wrapping_add(54);
         let extra: usize = tail & 31usize;
-        (*commands)[0] = (code | extra << 8i32) as u32;
+        (*commands)[0] = (code | extra << 8) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         (*commands)[0] = 64u32;
@@ -95,7 +95,7 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
         let nbits: usize = Log2FloorNonZero(tail as u64) as usize;
         let code: usize = nbits.wrapping_add(52);
         let extra: usize = tail.wrapping_sub(1usize << nbits);
-        (*commands)[0] = (code | extra << 8i32) as u32;
+        (*commands)[0] = (code | extra << 8) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         (*commands)[0] = 64u32;
@@ -104,7 +104,7 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
         2
     } else {
         let extra: usize = copylen.wrapping_sub(2120);
-        (*commands)[0] = (63usize | extra << 8i32) as u32;
+        (*commands)[0] = (63usize | extra << 8) as u32;
         let remainder = core::mem::take(commands);
         let _ = core::mem::replace(commands, &mut remainder[1..]);
         (*commands)[0] = 64u32;
@@ -129,18 +129,18 @@ fn EmitCopyLen(copylen: usize, commands: &mut &mut [u32]) -> usize {
         let tail: usize = copylen.wrapping_sub(6);
         let nbits: usize = Log2FloorNonZero(tail as u64).wrapping_sub(1) as usize;
         let prefix: usize = tail >> nbits;
-        let code: usize = (nbits << 1i32).wrapping_add(prefix).wrapping_add(44);
+        let code: usize = (nbits << 1).wrapping_add(prefix).wrapping_add(44);
         let extra: usize = tail.wrapping_sub(prefix << nbits);
-        (*commands)[0] = (code | extra << 8i32) as u32;
+        (*commands)[0] = (code | extra << 8) as u32;
     } else if copylen < 2118usize {
         let tail: usize = copylen.wrapping_sub(70);
         let nbits: usize = Log2FloorNonZero(tail as u64) as usize;
         let code: usize = nbits.wrapping_add(52);
         let extra: usize = tail.wrapping_sub(1usize << nbits);
-        (*commands)[0] = (code | extra << 8i32) as u32;
+        (*commands)[0] = (code | extra << 8) as u32;
     } else {
         let extra: usize = copylen.wrapping_sub(2118);
-        (*commands)[0] = (63usize | extra << 8i32) as u32;
+        (*commands)[0] = (63usize | extra << 8) as u32;
     }
     let remainder = core::mem::take(commands);
     let _ = core::mem::replace(commands, &mut remainder[1..]);
@@ -213,7 +213,7 @@ fn CreateCommands(
                                 let _old = skip;
                                 skip = skip.wrapping_add(1);
                                 _old
-                            }) >> 5i32;
+                            }) >> 5;
                             ip_index = next_ip;
                             0i32;
                             next_ip = ip_index.wrapping_add(bytes_between_hash_lookups as usize);
@@ -249,7 +249,7 @@ fn CreateCommands(
                     }
                 }
                 if !(ip_index.wrapping_sub(candidate)
-                    > (1usize << 18i32).wrapping_sub(16) as isize as usize
+                    > (1usize << 18).wrapping_sub(16) as isize as usize
                     && (goto_emit_remainder == 0))
                 {
                     break;
@@ -332,7 +332,7 @@ fn CreateCommands(
                 }
             }
             while ip_index.wrapping_sub(candidate)
-                <= (1usize << 18i32).wrapping_sub(16) as isize as usize
+                <= (1usize << 18).wrapping_sub(16) as isize as usize
                 && (IsMatch(&base_ip[ip_index..], &base_ip[candidate..], min_match) != 0)
             {
                 let base_index: usize = ip_index;
@@ -442,7 +442,7 @@ fn ShouldCompress(input: &[u8], input_size: usize, num_literals: usize) -> i32 {
 }
 
 pub fn BrotliWriteBits(n_bits: usize, bits: u64, pos: &mut usize, array: &mut [u8]) {
-    let p = &mut array[(*pos >> 3i32)..];
+    let p = &mut array[(*pos >> 3)..];
     let mut v: u64 = p[0] as (u64);
     v |= bits << (*pos & 7);
     BROTLI_UNALIGNED_STORE64(p, v);
@@ -456,9 +456,9 @@ pub fn BrotliStoreMetaBlockHeader(
 ) {
     let mut nibbles: u64 = 6;
     BrotliWriteBits(1, 0, storage_ix, storage);
-    if len <= (1u32 << 16i32) as usize {
+    if len <= (1u32 << 16) as usize {
         nibbles = 4;
-    } else if len <= (1u32 << 20i32) as usize {
+    } else if len <= (1u32 << 20) as usize {
         nibbles = 5;
     }
     BrotliWriteBits(2, nibbles.wrapping_sub(4), storage_ix, storage);
@@ -648,7 +648,7 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
         {
             let cmd: u32 = commands[i];
             let code: u32 = cmd & 0xffu32;
-            let extra: u32 = cmd >> 8i32;
+            let extra: u32 = cmd >> 8;
             0i32;
             BrotliWriteBits(
                 cmd_depths[code as usize] as usize,
@@ -687,9 +687,9 @@ fn EmitUncompressedMetaBlock(
 ) {
     BrotliStoreMetaBlockHeader(input_size, 1i32, storage_ix, storage);
     *storage_ix = (*storage_ix).wrapping_add(7u32 as usize) & !7u32 as usize;
-    memcpy(storage, (*storage_ix >> 3i32), input, 0, input_size);
-    *storage_ix = (*storage_ix).wrapping_add(input_size << 3i32);
-    storage[(*storage_ix >> 3i32)] = 0u8;
+    memcpy(storage, (*storage_ix >> 3), input, 0, input_size);
+    *storage_ix = (*storage_ix).wrapping_add(input_size << 3);
+    storage[(*storage_ix >> 3)] = 0u8;
 }
 #[allow(unused_variables)]
 #[inline(always)]
@@ -793,7 +793,7 @@ fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mu
     let mask: usize = (1u32 << bitpos).wrapping_sub(1) as usize;
     {
         let _rhs = mask as u8;
-        let _lhs = &mut storage[(new_storage_ix >> 3i32)];
+        let _lhs = &mut storage[(new_storage_ix >> 3)];
         *_lhs = (*_lhs as i32 & _rhs as i32) as u8;
     }
     *storage_ix = new_storage_ix;
@@ -943,7 +943,7 @@ pub fn BrotliCompressFragmentTwoPass<AllocHT: alloc::Allocator<HuffmanTree>>(
             storage,
         );
     }
-    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3i32) {
+    if (*storage_ix).wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3) {
         RewindBitPosition(initial_storage_ix, storage_ix, storage);
         EmitUncompressedMetaBlock(input, input_size, storage_ix, storage);
     }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -82,7 +82,7 @@ use enc::input_pair::InputReferenceMut;
 //fn BrotliInitZopfliNodes(array: &mut [ZopfliNode], length: usize);
 //fn BrotliWipeOutMemoryManager(m: &mut [MemoryManager]);
 
-static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17i32) as usize;
+static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17) as usize;
 
 static kMinUTF8Ratio: super::util::floatX = 0.75 as super::util::floatX;
 
@@ -682,10 +682,10 @@ fn EncodeWindowBits(
         *last_bytes = 1u16;
         *last_bytes_bits = 7u8;
     } else if lgwin > 17i32 {
-        *last_bytes = ((lgwin - 17i32) << 1i32 | 1i32) as u16;
+        *last_bytes = ((lgwin - 17i32) << 1 | 1i32) as u16;
         *last_bytes_bits = 4u8;
     } else {
-        *last_bytes = ((lgwin - 8i32) << 4i32 | 1i32) as u16;
+        *last_bytes = ((lgwin - 8i32) << 4 | 1i32) as u16;
         *last_bytes_bits = 7u8;
     }
 }
@@ -873,8 +873,8 @@ fn RingBufferWrite<AllocU8: alloc::Allocator<u8>>(
         .wrapping_sub(1)];
     rb.data_mo.slice_mut()[rb.buffer_index.wrapping_sub(1)] = data_1;
     rb.pos_ = rb.pos_.wrapping_add(n as u32);
-    if rb.pos_ > 1u32 << 30i32 {
-        rb.pos_ = rb.pos_ & (1u32 << 30i32).wrapping_sub(1) | 1u32 << 30i32;
+    if rb.pos_ > 1u32 << 30 {
+        rb.pos_ = rb.pos_ & (1u32 << 30).wrapping_sub(1) | 1u32 << 30;
     }
 }
 
@@ -918,7 +918,7 @@ fn ChooseHasher(params: &mut BrotliEncoderParams) {
         hparams.block_bits = H9_BLOCK_BITS as i32;
         hparams.bucket_bits = H9_BUCKET_BITS as i32;
         hparams.hash_len = 4;
-    } else if params.quality == 4 && (params.size_hint >= (1i32 << 20i32) as usize) {
+    } else if params.quality == 4 && (params.size_hint >= (1i32 << 20) as usize) {
         hparams.type_ = 54i32;
     } else if params.quality < 5 {
         hparams.type_ = params.quality;
@@ -930,7 +930,7 @@ fn ChooseHasher(params: &mut BrotliEncoderParams) {
         } else {
             42i32
         };
-    } else if ((params.q9_5 && params.size_hint > (1 << 20i32)) || params.size_hint > (1 << 22i32))
+    } else if ((params.q9_5 && params.size_hint > (1 << 20)) || params.size_hint > (1 << 22))
         && (params.lgwin >= 19i32)
     {
         hparams.type_ = 6i32;
@@ -947,7 +947,7 @@ fn ChooseHasher(params: &mut BrotliEncoderParams) {
     } else {
         hparams.type_ = 5i32;
         hparams.block_bits = core::cmp::min(params.quality - 1, 9);
-        hparams.bucket_bits = if params.quality < 7 && params.size_hint <= (1 << 20i32) {
+        hparams.bucket_bits = if params.quality < 7 && params.size_hint <= (1 << 20) {
             14i32
         } else {
             15i32
@@ -1324,9 +1324,9 @@ pub fn BrotliEncoderMaxCompressedSizeMulti(input_size: usize, num_threads: usize
 
 pub fn BrotliEncoderMaxCompressedSize(input_size: usize) -> usize {
     let magic_size = 16usize;
-    let num_large_blocks: usize = input_size >> 14i32;
-    let tail: usize = input_size.wrapping_sub(num_large_blocks << 24i32);
-    let tail_overhead: usize = (if tail > (1i32 << 20i32) as usize {
+    let num_large_blocks: usize = input_size >> 14;
+    let tail: usize = input_size.wrapping_sub(num_large_blocks << 24);
+    let tail_overhead: usize = (if tail > (1i32 << 20) as usize {
         4i32
     } else {
         3i32
@@ -1362,7 +1362,7 @@ fn InitOrStitchToPreviousBlock<Alloc: alloc::Allocator<u16> + alloc::Allocator<u
 
 pub fn InitInsertCommand(xself: &mut Command, insertlen: usize) {
     xself.insert_len_ = insertlen as u32;
-    xself.copy_len_ = (4i32 << 25i32) as u32;
+    xself.copy_len_ = (4i32 << 25) as u32;
     xself.dist_extra_ = 0u32;
     xself.dist_prefix_ = (1u16 << 10) | BROTLI_NUM_DISTANCE_SHORT_CODES as u16;
     GetLengthCode(insertlen, 4usize, 0i32, &mut xself.cmd_prefix_);
@@ -1376,7 +1376,7 @@ fn ShouldCompress(
     num_literals: usize,
     num_commands: usize,
 ) -> i32 {
-    if num_commands < (bytes >> 8i32).wrapping_add(2)
+    if num_commands < (bytes >> 8).wrapping_add(2)
         && num_literals as (super::util::floatX)
             > 0.99 as super::util::floatX * bytes as (super::util::floatX)
     {
@@ -1462,20 +1462,16 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
     while size > 0usize {
         let mut nibbles: u32 = 0u32;
 
-        let chunk_size: u32 = if size > (1u32 << 24i32) as usize {
-            1u32 << 24i32
+        let chunk_size: u32 = if size > (1u32 << 24) as usize {
+            1u32 << 24
         } else {
             size as u32
         };
-        if chunk_size > 1u32 << 16i32 {
-            nibbles = if chunk_size > 1u32 << 20i32 {
-                2i32
-            } else {
-                1i32
-            } as u32;
+        if chunk_size > 1u32 << 16 {
+            nibbles = if chunk_size > 1u32 << 20 { 2i32 } else { 1i32 } as u32;
         }
-        let bits: u32 = nibbles << 1i32
-            | chunk_size.wrapping_sub(1) << 3i32
+        let bits: u32 = nibbles << 1
+            | chunk_size.wrapping_sub(1) << 3
             | 1u32 << (19u32).wrapping_add((4u32).wrapping_mul(nibbles));
         output[{
             let _old = result;
@@ -1486,18 +1482,18 @@ fn MakeUncompressedStream(input: &[u8], input_size: usize, output: &mut [u8]) ->
             let _old = result;
             result = result.wrapping_add(1);
             _old
-        }] = (bits >> 8i32) as u8;
+        }] = (bits >> 8) as u8;
         output[{
             let _old = result;
             result = result.wrapping_add(1);
             _old
-        }] = (bits >> 16i32) as u8;
+        }] = (bits >> 16) as u8;
         if nibbles == 2u32 {
             output[{
                 let _old = result;
                 result = result.wrapping_add(1);
                 _old
-            }] = (bits >> 24i32) as u8;
+            }] = (bits >> 24) as u8;
         }
         output[result..(result + chunk_size as usize)]
             .clone_from_slice(&input[offset..(offset + chunk_size as usize)]);
@@ -1630,14 +1626,14 @@ fn InjectBytePaddingBlock<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<A
     }
     destination[0] = seal as u8;
     if seal_bits > 8usize {
-        destination[1] = (seal >> 8i32) as u8;
+        destination[1] = (seal >> 8) as u8;
     }
     if seal_bits > 16usize {
-        destination[2] = (seal >> 16i32) as u8;
+        destination[2] = (seal >> 16) as u8;
     }
     s.available_out_ = s
         .available_out_
-        .wrapping_add(seal_bits.wrapping_add(7) >> 3i32);
+        .wrapping_add(seal_bits.wrapping_add(7) >> 3);
 }
 fn InjectFlushOrPushOutput<Alloc: BrotliAlloc>(
     s: &mut BrotliEncoderStateStruct<Alloc>,
@@ -1681,7 +1677,7 @@ fn UpdateSizeHint<Alloc: BrotliAlloc>(
     if s.params.size_hint == 0usize {
         let delta: u64 = UnprocessedInputSize(s);
         let tail: u64 = available_in as u64;
-        let limit: u32 = 1u32 << 30i32;
+        let limit: u32 = 1u32 << 30;
         let total: u32;
         if delta >= u64::from(limit)
             || tail >= u64::from(limit)
@@ -1697,10 +1693,10 @@ fn UpdateSizeHint<Alloc: BrotliAlloc>(
 
 fn WrapPosition(position: u64) -> u32 {
     let mut result: u32 = position as u32;
-    let gb: u64 = position >> 30i32;
+    let gb: u64 = position >> 30;
     if gb > 2 {
-        result = result & (1u32 << 30i32).wrapping_sub(1)
-            | ((gb.wrapping_sub(1) & 1) as u32).wrapping_add(1) << 30i32;
+        result = result & (1u32 << 30).wrapping_sub(1)
+            | ((gb.wrapping_sub(1) & 1) as u32).wrapping_add(1) << 30;
     }
     result
 }
@@ -1722,9 +1718,9 @@ fn GetBrotliStorage<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Alloc>,
 
 fn MaxHashTableSize(quality: i32) -> usize {
     (if quality == 0i32 {
-        1i32 << 15i32
+        1i32 << 15
     } else {
-        1i32 << 17i32
+        1i32 << 17
     }) as usize
 }
 
@@ -2007,7 +2003,7 @@ fn DecideOverLiteralContextModeling(
             {
                 static lut: [i32; 4] = [0, 0, 1, 2];
                 let stride_end_pos: usize = start_pos.wrapping_add(64);
-                let mut prev: i32 = lut[(input[(start_pos & mask)] as i32 >> 6i32) as usize] * 3i32;
+                let mut prev: i32 = lut[(input[(start_pos & mask)] as i32 >> 6) as usize] * 3i32;
                 let mut pos: usize;
                 pos = start_pos.wrapping_add(1);
                 while pos < stride_end_pos {
@@ -2015,11 +2011,11 @@ fn DecideOverLiteralContextModeling(
                         let literal: u8 = input[(pos & mask)];
                         {
                             let _rhs = 1;
-                            let cur_ind = (prev + lut[(literal as i32 >> 6i32) as usize]);
+                            let cur_ind = (prev + lut[(literal as i32 >> 6) as usize]);
                             let _lhs = &mut bigram_prefix_histo[cur_ind as usize];
                             *_lhs = (*_lhs).wrapping_add(_rhs as u32);
                         }
-                        prev = lut[(literal as i32 >> 6i32) as usize] * 3i32;
+                        prev = lut[(literal as i32 >> 6) as usize] * 3i32;
                     }
                     pos = pos.wrapping_add(1);
                 }
@@ -2236,7 +2232,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
         );
         mb.destroy(alloc);
     }
-    if bytes + 4 + saved_byte_location < (*storage_ix >> 3i32) {
+    if bytes + 4 + saved_byte_location < (*storage_ix >> 3) {
         dist_cache[..4].clone_from_slice(&saved_dist_cache[..4]);
         //memcpy(dist_cache,
         //     saved_dist_cache,
@@ -2355,8 +2351,8 @@ where
     if let IsFirst::NothingWritten = s.is_first_mb {
         if s.params.magic_number {
             BrotliWriteMetadataMetaBlock(&s.params, &mut storage_ix, s.storage_.slice_mut());
-            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3i32)] as u16
-                | ((s.storage_.slice()[1 + (storage_ix >> 3i32)] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3)] as u16
+                | ((s.storage_.slice()[1 + (storage_ix >> 3)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
             s.next_out_ = NextOut::DynamicStorage(0);
             catable_header_size = storage_ix >> 3;
@@ -2387,8 +2383,8 @@ where
                 false, /* suppress meta-block logging */
                 callback,
             );
-            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3i32)] as u16
-                | ((s.storage_.slice()[1 + (storage_ix >> 3i32)] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3)] as u16
+                | ((s.storage_.slice()[1 + (storage_ix >> 3)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
             s.prev_byte2_ = s.prev_byte_;
             s.prev_byte_ = data[s.last_flush_pos_ as usize & mask as usize];
@@ -2467,14 +2463,14 @@ where
                     s.storage_.slice_mut(),
                 );
             }
-            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3i32)] as u16
-                | ((s.storage_.slice()[(storage_ix >> 3i32) + 1] as u16) << 8);
+            s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3)] as u16
+                | ((s.storage_.slice()[(storage_ix >> 3) + 1] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
         }
         UpdateLastProcessedPos(s);
         // *output = &mut (*s).storage_.slice_mut();
         s.next_out_ = NextOut::DynamicStorage(0); // this always returns that
-        *out_size = storage_ix >> 3i32;
+        *out_size = storage_ix >> 3;
         return 1i32;
     }
     {
@@ -2647,8 +2643,8 @@ where
             callback,
         );
 
-        s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3i32)] as u16
-            | ((s.storage_.slice()[1 + (storage_ix >> 3i32)] as u16) << 8);
+        s.last_bytes_ = s.storage_.slice()[(storage_ix >> 3)] as u16
+            | ((s.storage_.slice()[1 + (storage_ix >> 3)] as u16) << 8);
         s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
         s.last_flush_pos_ = s.input_pos_;
         if UpdateLastProcessedPos(s) != 0 {
@@ -2666,7 +2662,7 @@ where
         s.saved_dist_cache_
             .clone_from_slice(s.dist_cache_.split_at(4).0);
         s.next_out_ = NextOut::DynamicStorage(0); // this always returns that
-        *out_size = storage_ix >> 3i32;
+        *out_size = storage_ix >> 3;
         1i32
     }
 }
@@ -2700,7 +2696,7 @@ fn WriteMetadataHeader<Alloc: BrotliAlloc>(s: &mut BrotliEncoderStateStruct<Allo
             header,
         );
     }
-    storage_ix.wrapping_add(7u32 as usize) >> 3i32
+    storage_ix.wrapping_add(7u32 as usize) >> 3
 }
 
 fn brotli_min_uint32_t(a: u32, b: u32) -> u32 {
@@ -2729,7 +2725,7 @@ fn ProcessMetadata<
     total_out: &mut Option<usize>,
     metablock_callback: &mut MetaBlockCallback,
 ) -> i32 {
-    if *available_in > (1u32 << 24i32) as usize {
+    if *available_in > (1u32 << 24) as usize {
         return 0i32;
     }
     if s.stream_state_ as i32 == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as i32 {
@@ -2952,7 +2948,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             *next_in_offset += block_size;
             *available_in = (*available_in).wrapping_sub(block_size);
             if inplace != 0 {
-                let out_bytes: usize = storage_ix >> 3i32;
+                let out_bytes: usize = storage_ix >> 3;
                 0i32;
                 0i32;
                 *next_out_offset += out_bytes;
@@ -2962,12 +2958,12 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                     *total_out_inner = s.total_out_ as usize;
                 }
             } else {
-                let out_bytes: usize = storage_ix >> 3i32;
+                let out_bytes: usize = storage_ix >> 3;
                 s.next_out_ = NextOut::DynamicStorage(0);
                 s.available_out_ = out_bytes;
             }
-            s.last_bytes_ = storage[(storage_ix >> 3i32)] as u16
-                | ((storage[1 + (storage_ix >> 3i32)] as u16) << 8);
+            s.last_bytes_ =
+                storage[(storage_ix >> 3)] as u16 | ((storage[1 + (storage_ix >> 3)] as u16) << 8);
             s.last_bytes_bits_ = (storage_ix & 7u32 as usize) as u8;
             if force_flush != 0 {
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -276,7 +276,7 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     }
     {
         let mut nonzeros: usize = 0usize;
-        let mut smallest_nonzero: u32 = (1i32 << 30i32) as u32;
+        let mut smallest_nonzero: u32 = (1i32 << 30) as u32;
         i = 0usize;
         while i < length {
             {
@@ -638,7 +638,7 @@ fn BrotliReverseBits(num_bits: usize, mut bits: u16) -> u16 {
     while i < num_bits {
         {
             retval <<= 4i32;
-            bits = (bits as i32 >> 4i32) as u16;
+            bits = (bits as i32 >> 4) as u16;
             retval |= kLut[(bits as i32 & 0xfi32) as usize];
         }
         i = i.wrapping_add(4);
@@ -669,7 +669,7 @@ pub fn BrotliConvertBitDepthsToSymbols(depth: &[u8], len: usize, bits: &mut [u16
     i = 1;
     while i < MAX_HUFFMAN_BITS {
         {
-            code = (code + bl_count[i.wrapping_sub(1)] as i32) << 1i32;
+            code = (code + bl_count[i.wrapping_sub(1)] as i32) << 1;
             next_code[i] = code as u16;
         }
         i = i.wrapping_add(1);

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -465,14 +465,14 @@ pub fn HistogramSelfAddHistogram<
 pub fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
         ContextType::CONTEXT_SIGNED => {
-            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3i32)
+            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3)
                 + kSigned3BitContextLookup[p2 as usize] as i32) as u8
         }
         ContextType::CONTEXT_UTF8 => {
             (kUTF8ContextLookup[p1 as usize] as i32
                 | kUTF8ContextLookup[(p2 as i32 + 256i32) as usize] as i32) as u8
         }
-        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2i32) as u8,
+        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2) as u8,
         ContextType::CONTEXT_LSB6 => (p1 as i32 & 0x3fi32) as u8, /* else {
                                                                   0u8
                                                                   }*/
@@ -518,7 +518,7 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
                 {
                     BlockSplitIteratorNext(&mut literal_it);
                     let context: usize = if !context_modes.is_empty() {
-                        (literal_it.type_ << 6i32).wrapping_add(Context(
+                        (literal_it.type_ << 6).wrapping_add(Context(
                             prev_byte,
                             prev_byte2,
                             context_modes[literal_it.type_],
@@ -543,7 +543,7 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
                 if cmd.cmd_prefix_ as i32 >= 128i32 {
                     BlockSplitIteratorNext(&mut dist_it);
                     let context: usize =
-                        (dist_it.type_ << 2i32).wrapping_add(CommandDistanceContext(cmd) as usize);
+                        (dist_it.type_ << 2).wrapping_add(CommandDistanceContext(cmd) as usize);
                     HistogramAddItem(
                         &mut copy_dist_histograms[(context as usize)],
                         cmd.dist_prefix_ as usize & 0x3ff,

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -107,13 +107,13 @@ fn compute_huffman_table_index_for_context_map(
 pub fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
         ContextType::CONTEXT_LSB6 => (p1 as i32 & 0x3fi32) as u8,
-        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2i32) as u8,
+        ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2) as u8,
         ContextType::CONTEXT_UTF8 => {
             (kUTF8ContextLookup[p1 as usize] as i32
                 | kUTF8ContextLookup[(p2 as i32 + 256i32) as usize] as i32) as u8
         }
         ContextType::CONTEXT_SIGNED => {
-            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3i32)
+            (((kSigned3BitContextLookup[p1 as usize] as i32) << 3)
                 + kSigned3BitContextLookup[p2 as usize] as i32) as u8
         }
     }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -224,7 +224,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         &mut mb.distance_split,
     );
     if params.disable_literal_context_modeling == 0 {
-        literal_context_multiplier = (1i32 << 6i32) as usize;
+        literal_context_multiplier = (1i32 << 6) as usize;
         literal_context_modes =
             <Alloc as Allocator<ContextType>>::alloc_cell(alloc, mb.literal_split.num_types);
         for item in literal_context_modes.slice_mut().iter_mut() {
@@ -237,7 +237,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         .wrapping_mul(literal_context_multiplier);
     literal_histograms =
         <Alloc as Allocator<HistogramLiteral>>::alloc_cell(alloc, literal_histograms_size);
-    let distance_histograms_size: usize = mb.distance_split.num_types << 2i32;
+    let distance_histograms_size: usize = mb.distance_split.num_types << 2;
     distance_histograms =
         <Alloc as Allocator<HistogramDistance>>::alloc_cell(alloc, distance_histograms_size);
     mb.command_histograms_size = mb.command_split.num_types;
@@ -260,7 +260,7 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         distance_histograms.slice_mut(),
     );
     <Alloc as Allocator<ContextType>>::free_cell(alloc, literal_context_modes);
-    mb.literal_context_map_size = mb.literal_split.num_types << 6i32;
+    mb.literal_context_map_size = mb.literal_split.num_types << 6;
     mb.literal_context_map =
         <Alloc as Allocator<u32>>::alloc_cell(alloc, mb.literal_context_map_size);
     mb.literal_histograms_size = mb.literal_context_map_size;
@@ -282,16 +282,16 @@ pub fn BrotliBuildMetaBlock<Alloc: BrotliAlloc>(
         while i != 0usize {
             let mut j: usize = 0usize;
             i = i.wrapping_sub(1);
-            while j < (1i32 << 6i32) as usize {
+            while j < (1i32 << 6) as usize {
                 {
                     let val = mb.literal_context_map.slice()[i];
-                    mb.literal_context_map.slice_mut()[(i << 6i32).wrapping_add(j)] = val;
+                    mb.literal_context_map.slice_mut()[(i << 6).wrapping_add(j)] = val;
                 }
                 j = j.wrapping_add(1);
             }
         }
     }
-    mb.distance_context_map_size = mb.distance_split.num_types << 2i32;
+    mb.distance_context_map_size = mb.distance_split.num_types << 2;
     mb.distance_context_map =
         <Alloc as Allocator<u32>>::alloc_cell(alloc, mb.distance_context_map_size);
     mb.distance_histograms_size = mb.distance_context_map_size;
@@ -883,7 +883,7 @@ fn MapStaticContexts<
     mb: &mut MetaBlockSplit<Alloc>,
 ) {
     let mut i: usize;
-    mb.literal_context_map_size = mb.literal_split.num_types << 6i32;
+    mb.literal_context_map_size = mb.literal_split.num_types << 6;
     let new_literal_context_map =
         <Alloc as Allocator<u32>>::alloc_cell(m32, mb.literal_context_map_size);
     <Alloc as Allocator<u32>>::free_cell(
@@ -896,9 +896,9 @@ fn MapStaticContexts<
             let offset: u32 = i.wrapping_mul(num_contexts) as u32;
             let mut j: usize;
             j = 0usize;
-            while j < (1u32 << 6i32) as usize {
+            while j < (1u32 << 6) as usize {
                 {
-                    mb.literal_context_map.slice_mut()[(i << 6i32).wrapping_add(j)] =
+                    mb.literal_context_map.slice_mut()[(i << 6).wrapping_add(j)] =
                         offset.wrapping_add(static_context_map[j]);
                 }
                 j = j.wrapping_add(1);

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -84,7 +84,7 @@ macro_rules! sub_match {
                 $matched = $matched.wrapping_add(8) as u32 as usize;
             } else {
                 $matched = $matched
-                    .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3i32) as usize)
+                    .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3) as usize)
                     as u32 as usize;
                 return $matched;
             }
@@ -103,7 +103,7 @@ macro_rules! sub_match8 {
             $matched = $matched.wrapping_add(8) as u32 as usize;
         } else {
             $matched = $matched
-                .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3i32) as usize)
+                .wrapping_add((($s2_as_64 ^ $s1_as_64).trailing_zeros() >> 3) as usize)
                 as u32 as usize;
             return $matched;
         }
@@ -398,7 +398,7 @@ fn brotli_min_uint32_t(a: u32, b: u32) -> u32 {
 
 #[allow(unused)]
 fn AddMatch(distance: usize, len: usize, len_code: usize, mut matches: &mut [u32]) {
-    let match_: u32 = (distance << 5i32).wrapping_add(len_code) as u32;
+    let match_: u32 = (distance << 5).wrapping_add(len_code) as u32;
     matches[len] = brotli_min_uint32_t(matches[len], match_);
 }
 

--- a/src/enc/utf8_util.rs
+++ b/src/enc/utf8_util.rs
@@ -12,7 +12,7 @@ fn BrotliParseAsUTF8(symbol: &mut i32, input: &[u8], size: usize) -> usize {
         && (input[0] as i32 & 0xe0i32 == 0xc0i32)
         && (input[1] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0] as i32 & 0x1fi32) << 6i32 | input[1] as i32 & 0x3fi32;
+        *symbol = (input[0] as i32 & 0x1fi32) << 6 | input[1] as i32 & 0x3fi32;
         if *symbol > 0x7fi32 {
             return 2usize;
         }
@@ -22,8 +22,8 @@ fn BrotliParseAsUTF8(symbol: &mut i32, input: &[u8], size: usize) -> usize {
         && (input[1] as i32 & 0xc0i32 == 0x80i32)
         && (input[2] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0] as i32 & 0xfi32) << 12i32
-            | (input[1] as i32 & 0x3fi32) << 6i32
+        *symbol = (input[0] as i32 & 0xfi32) << 12
+            | (input[1] as i32 & 0x3fi32) << 6
             | input[2] as i32 & 0x3fi32;
         if *symbol > 0x7ffi32 {
             return 3usize;
@@ -35,9 +35,9 @@ fn BrotliParseAsUTF8(symbol: &mut i32, input: &[u8], size: usize) -> usize {
         && (input[2] as i32 & 0xc0i32 == 0x80i32)
         && (input[3] as i32 & 0xc0i32 == 0x80i32)
     {
-        *symbol = (input[0] as i32 & 0x7i32) << 18i32
-            | (input[1] as i32 & 0x3fi32) << 12i32
-            | (input[2] as i32 & 0x3fi32) << 6i32
+        *symbol = (input[0] as i32 & 0x7i32) << 18
+            | (input[1] as i32 & 0x3fi32) << 12
+            | (input[2] as i32 & 0x3fi32) << 6
             | input[3] as i32 & 0x3fi32;
         if *symbol > 0xffffi32 && (*symbol <= 0x10ffffi32) {
             return 4usize;


### PR DESCRIPTION
There is no point in using type qualifier for bitshift param:

```
foo >> 2i32   ->   foo >> 2
```

Replacing

```
(<<|>>) (\d+)[ui](size|\d+)
```

with `$1 $2`