### PR TITLE
removed packed_simd dependency and use nightly's portable_simd directly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ incremental = false
 "alloc-stdlib" = { version = "~0.2", optional = true }
 "brotli-decompressor" = { version = "~2.5", default-features = false }
 "sha2" = { version = "~0.10", optional = true }
-"packed_simd" = { git = "https://github.com/programingjd/packed_simd.git", rev = "53efe013875b7f23ecc1edd840a20c4cbce3f302", default-features = false, features = ["into_bits"], optional = true }
 
 [features]
 default = ["std", "ffi-api"]
@@ -43,4 +42,4 @@ seccomp = ["brotli-decompressor/seccomp"]
 std = ["alloc-stdlib", "brotli-decompressor/std"]
 validation = ["sha2"]
 vector_scratch_space = []
-simd = ["packed_simd/into_bits"]
+simd = []

--- a/src/enc/compat.rs
+++ b/src/enc/compat.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "simd", allow(unused))]
-use core::ops::{Add, AddAssign, BitAnd, Mul, Shr, Sub};
-use std::ops::{Index, IndexMut};
+use core::ops::{Add, AddAssign, BitAnd, Index, IndexMut, Mul, Shr, Sub};
 
 #[derive(Default, Copy, Clone, Debug)]
 pub struct Compat16x16([i16; 16]);

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -43,13 +43,13 @@ pub mod singlethreading;
 pub mod threading;
 pub mod worker_pool;
 #[cfg(feature = "simd")]
-use packed_simd::{f32x8, i16x16, i32x8};
+use std::simd::{f32x8, i16x16, i32x8};
 #[cfg(feature = "simd")]
-pub type s16 = i16x16;
+pub type s16 = std::simd::i16x16;
 #[cfg(feature = "simd")]
-pub type v8 = f32x8;
+pub type v8 = std::simd::f32x8;
 #[cfg(feature = "simd")]
-pub type s8 = i32x8;
+pub type s8 = std::simd::i32x8;
 #[cfg(not(feature = "simd"))]
 pub type s16 = compat::Compat16x16;
 #[cfg(not(feature = "simd"))]

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -3,65 +3,62 @@
 
 use enc::util::FastLog2;
 use enc::{s8, v8};
+#[cfg(feature = "simd")]
+use std::simd::Simd;
 pub type Mem256f = v8;
 pub type Mem256i = s8;
 pub type v256 = v8;
 pub type v256i = s8;
 pub fn sum8(x: v256) -> f32 {
-    x.extract(0)
-        + x.extract(1)
-        + x.extract(2)
-        + x.extract(3)
-        + x.extract(4)
-        + x.extract(5)
-        + x.extract(6)
-        + x.extract(7)
+    x[0] + x[1] + x[2] + x[3] + x[4] + x[5] + x[6] + x[7]
 }
 
 pub fn sum8i(x: v256i) -> i32 {
-    x.extract(0)
-        .wrapping_add(x.extract(1))
-        .wrapping_add(x.extract(2))
-        .wrapping_add(x.extract(3))
-        .wrapping_add(x.extract(4))
-        .wrapping_add(x.extract(5))
-        .wrapping_add(x.extract(6))
-        .wrapping_add(x.extract(7))
+    x[0].wrapping_add(x[1])
+        .wrapping_add(x[2])
+        .wrapping_add(x[3])
+        .wrapping_add(x[4])
+        .wrapping_add(x[5])
+        .wrapping_add(x[6])
+        .wrapping_add(x[7])
 }
 
 pub fn log2i(x: v256i) -> v256 {
-    v256::new(
-        FastLog2(x.extract(0) as u64),
-        FastLog2(x.extract(1) as u64),
-        FastLog2(x.extract(2) as u64),
-        FastLog2(x.extract(3) as u64),
-        FastLog2(x.extract(4) as u64),
-        FastLog2(x.extract(5) as u64),
-        FastLog2(x.extract(6) as u64),
-        FastLog2(x.extract(7) as u64),
-    )
+    [
+        FastLog2(x[0] as u64),
+        FastLog2(x[1] as u64),
+        FastLog2(x[2] as u64),
+        FastLog2(x[3] as u64),
+        FastLog2(x[4] as u64),
+        FastLog2(x[5] as u64),
+        FastLog2(x[6] as u64),
+        FastLog2(x[7] as u64),
+    ]
+    .into()
 }
 pub fn cast_i32_to_f32(x: v256i) -> v256 {
-    v256::new(
-        x.extract(0) as f32,
-        x.extract(1) as f32,
-        x.extract(2) as f32,
-        x.extract(3) as f32,
-        x.extract(4) as f32,
-        x.extract(5) as f32,
-        x.extract(6) as f32,
-        x.extract(7) as f32,
-    )
+    [
+        x[0] as f32,
+        x[1] as f32,
+        x[2] as f32,
+        x[3] as f32,
+        x[4] as f32,
+        x[5] as f32,
+        x[6] as f32,
+        x[7] as f32,
+    ]
+    .into()
 }
 pub fn cast_f32_to_i32(x: v256) -> v256i {
-    v256i::new(
-        x.extract(0) as i32,
-        x.extract(1) as i32,
-        x.extract(2) as i32,
-        x.extract(3) as i32,
-        x.extract(4) as i32,
-        x.extract(5) as i32,
-        x.extract(6) as i32,
-        x.extract(7) as i32,
-    )
+    [
+        x[0] as i32,
+        x[1] as i32,
+        x[2] as i32,
+        x[3] as i32,
+        x[4] as i32,
+        x[5] as i32,
+        x[6] as i32,
+        x[7] as i32,
+    ]
+    .into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![cfg_attr(feature = "benchmark", feature(test))]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 #![cfg_attr(
     feature = "no-stdlib-ffi-binding",
     cfg_attr(not(feature = "std"), feature(lang_items))
@@ -15,8 +16,6 @@
 extern crate std;
 #[cfg(feature = "std")]
 extern crate alloc_stdlib;
-#[cfg(feature = "simd")]
-extern crate packed_simd;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc_no_stdlib as alloc;


### PR DESCRIPTION
In my last pull request, I created a fork of the packed-simd crate to fix the errors due to the changes in nightly's portable_simd.
These fixes didn't last very long as new changes in nightly broke the fork a few days later.
This time I got rid of the packed-simd dependency completely and used the new nightly portable_simd api directly.
