### PR TITLE
Simplify `+=` expressions

### DIFF
--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -1248,22 +1248,16 @@ fn ZopfliCostModelSetFromCommands<AllocF: Allocator<floatX>>(
             let cmdcode: usize = (commands[i]).cmd_prefix_ as usize;
             let mut j: usize;
             {
-                let _rhs = 1;
-                let _lhs = &mut histogram_cmd[cmdcode];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                histogram_cmd[cmdcode] += 1;
             }
             if cmdcode >= 128usize {
-                let _rhs = 1;
-                let _lhs = &mut histogram_dist[distcode];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                histogram_dist[distcode] += 1;
             }
             j = 0usize;
             while j < inslength {
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut histogram_literal
-                        [(ringbuffer[(pos.wrapping_add(j) & ringbuffer_mask)] as usize)];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                    histogram_literal
+                        [(ringbuffer[(pos.wrapping_add(j) & ringbuffer_mask)] as usize)] += 1;
                 }
                 j = j.wrapping_add(1);
             }

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -563,9 +563,7 @@ fn ClusterBlocks<
             {
                 0i32;
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut block_lengths.slice_mut()[block_idx];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                    block_lengths.slice_mut()[block_idx] += 1;
                 }
                 if i.wrapping_add(1) == length
                     || block_ids[i] as i32 != block_ids[i.wrapping_add(1)] as i32

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -924,9 +924,7 @@ pub fn BrotliStoreHuffmanTree(
     i = 0usize;
     while i < huffman_tree_size {
         {
-            let _rhs = 1;
-            let _lhs = &mut huffman_tree_histogram[huffman_tree[i] as usize];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            huffman_tree_histogram[huffman_tree[i] as usize] += 1;
         }
         i = i.wrapping_add(1);
     }
@@ -1665,14 +1663,10 @@ fn BuildAndStoreBlockSplitCode(
         {
             let type_code: usize = NextBlockTypeCode(&mut type_code_calculator, types[i]);
             if i != 0usize {
-                let _rhs = 1;
-                let _lhs = &mut type_histo[type_code];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                type_histo[type_code] += 1;
             }
             {
-                let _rhs = 1;
-                let _lhs = &mut length_histo[BlockLengthPrefixCode(lengths[i]) as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                length_histo[BlockLengthPrefixCode(lengths[i]) as usize] += 1;
             }
         }
         i = i.wrapping_add(1);
@@ -1970,9 +1964,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     i = 0usize;
     while i < num_rle_symbols {
         {
-            let _rhs = 1;
-            let _lhs = &mut histogram[(rle_symbols.slice()[i] & kSymbolMask) as usize];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histogram[(rle_symbols.slice()[i] & kSymbolMask) as usize] += 1;
         }
         i = i.wrapping_add(1);
     }
@@ -2869,9 +2861,7 @@ pub fn BrotliStoreMetaBlockFast<Cb, Alloc: BrotliAlloc>(
                 while j != 0usize {
                     {
                         {
-                            let _rhs = 1;
-                            let _lhs = &mut histogram[input[(pos & mask)] as usize];
-                            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                            histogram[input[(pos & mask)] as usize] += 1;
                         }
                         pos = pos.wrapping_add(1);
                     }

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -189,9 +189,7 @@ pub fn BrotliHistogramCombine<
         HistogramSelfAddHistogram(out, (best_idx1 as usize), (best_idx2 as usize));
         (out[(best_idx1 as usize)]).set_bit_cost((pairs[0]).cost_combo);
         {
-            let _rhs = cluster_size[(best_idx2 as usize)];
-            let _lhs = &mut cluster_size[(best_idx1 as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs);
+            cluster_size[(best_idx1 as usize)] += cluster_size[(best_idx2 as usize)];
         }
         i = 0usize;
         while i < symbols_size {

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -53,9 +53,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         i = 0usize;
         while i < input_size {
             {
-                let _rhs = 1;
-                let _lhs = &mut histogram[input[i] as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                histogram[input[i] as usize] += 1;
             }
             i = i.wrapping_add(1);
         }
@@ -65,9 +63,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
             {
                 let adjust: u32 = (2u32).wrapping_mul(brotli_min_uint32_t(histogram[i], 11u32));
                 {
-                    let _rhs = adjust;
-                    let _lhs = &mut histogram[i];
-                    *_lhs = (*_lhs).wrapping_add(_rhs);
+                    histogram[i] += adjust;
                 }
                 histogram_total = histogram_total.wrapping_add(adjust as usize);
             }
@@ -78,9 +74,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
         i = 0usize;
         while i < input_size {
             {
-                let _rhs = 1;
-                let _lhs = &mut histogram[input[i] as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                histogram[input[i] as usize] += 1;
             }
             i = i.wrapping_add(kSampleRate);
         }
@@ -94,9 +88,7 @@ fn BuildAndStoreLiteralPrefixCode<AllocHT: alloc::Allocator<HuffmanTree>>(
                 let adjust: u32 = (1u32)
                     .wrapping_add((2u32).wrapping_mul(brotli_min_uint32_t(histogram[i], 11u32)));
                 {
-                    let _rhs = adjust;
-                    let _lhs = &mut histogram[i];
-                    *_lhs = (*_lhs).wrapping_add(_rhs);
+                    histogram[i] += adjust;
                 }
                 histogram_total = histogram_total.wrapping_add(adjust as usize);
             }
@@ -154,9 +146,7 @@ fn EmitInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[code];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[code] += 1;
         }
     } else if insertlen < 130usize {
         let tail: usize = insertlen.wrapping_sub(2);
@@ -178,9 +168,7 @@ fn EmitInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(inscode as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(inscode as usize)] += 1;
         }
     } else if insertlen < 2114usize {
         let tail: usize = insertlen.wrapping_sub(66);
@@ -199,9 +187,7 @@ fn EmitInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(code as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(code as usize)] += 1;
         }
     } else {
         BrotliWriteBits(depth[61] as usize, bits[61] as (u64), storage_ix, storage);
@@ -212,9 +198,7 @@ fn EmitInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[61];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[61] += 1;
         }
     }
 }
@@ -272,9 +256,7 @@ fn EmitLongInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[62];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[62] += 1;
         }
     } else {
         BrotliWriteBits(depth[63] as usize, bits[63] as (u64), storage_ix, storage);
@@ -285,9 +267,7 @@ fn EmitLongInsertLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[63];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[63] += 1;
         }
     }
 }
@@ -339,9 +319,7 @@ fn EmitDistance(
     );
     BrotliWriteBits(nbits as usize, d.wrapping_sub(offset), storage_ix, storage);
     {
-        let _rhs = 1;
-        let _lhs = &mut histo[(distcode as usize)];
-        *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+        histo[(distcode as usize)] += 1;
     }
 }
 
@@ -361,9 +339,7 @@ fn EmitCopyLenLastDistance(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[copylen.wrapping_sub(4)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[copylen.wrapping_sub(4)] += 1;
         }
     } else if copylen < 72usize {
         let tail: usize = copylen.wrapping_sub(8);
@@ -383,9 +359,7 @@ fn EmitCopyLenLastDistance(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(code as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(code as usize)] += 1;
         }
     } else if copylen < 136usize {
         let tail: usize = copylen.wrapping_sub(8);
@@ -399,14 +373,10 @@ fn EmitCopyLenLastDistance(
         BrotliWriteBits(5usize, tail as u64 & 31, storage_ix, storage);
         BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[code];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[code] += 1;
         }
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[64];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[64] += 1;
         }
     } else if copylen < 2120usize {
         let tail: usize = copylen.wrapping_sub(72);
@@ -426,14 +396,10 @@ fn EmitCopyLenLastDistance(
         );
         BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(code as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(code as usize)] += 1;
         }
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[64];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[64] += 1;
         }
     } else {
         BrotliWriteBits(depth[39] as usize, bits[39] as (u64), storage_ix, storage);
@@ -445,14 +411,10 @@ fn EmitCopyLenLastDistance(
         );
         BrotliWriteBits(depth[64] as usize, bits[64] as (u64), storage_ix, storage);
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[39];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[39] += 1;
         }
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[64];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[64] += 1;
         }
     }
 }
@@ -480,9 +442,7 @@ fn EmitCopyLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[copylen.wrapping_add(14)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[copylen.wrapping_add(14)] += 1;
         }
     } else if copylen < 134usize {
         let tail: usize = copylen.wrapping_sub(6);
@@ -504,9 +464,7 @@ fn EmitCopyLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(code as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(code as usize)] += 1;
         }
     } else if copylen < 2118usize {
         let tail: usize = copylen.wrapping_sub(70);
@@ -525,9 +483,7 @@ fn EmitCopyLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[(code as usize)];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[(code as usize)] += 1;
         }
     } else {
         BrotliWriteBits(depth[39] as usize, bits[39] as (u64), storage_ix, storage);
@@ -538,9 +494,7 @@ fn EmitCopyLen(
             storage,
         );
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[39];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            histo[39] += 1;
         }
     }
 }
@@ -552,9 +506,7 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> bool {
     i = 0usize;
     while i < len {
         {
-            let _rhs = 1;
-            let _lhs = &mut histo[data[i] as usize];
-            *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+            histo[data[i] as usize] += 1;
         }
         i = i.wrapping_add(kSampleRate);
     }
@@ -862,9 +814,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
                                 storage,
                             );
                             {
-                                let _rhs = 1u32;
-                                let _lhs = &mut cmd_histo[64];
-                                *_lhs = (*_lhs).wrapping_add(_rhs);
+                                cmd_histo[64] += 1u32;
                             }
                         } else {
                             EmitDistance(

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -422,9 +422,7 @@ fn ShouldCompress(input: &[u8], input_size: usize, num_literals: usize) -> bool 
         i = 0usize;
         while i < input_size {
             {
-                let _rhs = 1;
-                let _lhs = &mut literal_histo[input[i] as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                literal_histo[input[i] as usize] += 1;
             }
             i = i.wrapping_add(43);
         }
@@ -578,9 +576,7 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
     i = 0usize;
     while i < num_literals {
         {
-            let _rhs = 1;
-            let _lhs = &mut lit_histo[literals[i] as usize];
-            *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+            lit_histo[literals[i] as usize] += 1;
         }
         i = i.wrapping_add(1);
     }
@@ -600,32 +596,22 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
             let code: u32 = commands[i] & 0xffu32;
             0i32;
             {
-                let _rhs = 1;
-                let _lhs = &mut cmd_histo[code as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                cmd_histo[code as usize] += 1;
             }
         }
         i = i.wrapping_add(1);
     }
     {
-        let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[1];
-        *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+        cmd_histo[1] += 1;
     }
     {
-        let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[2];
-        *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+        cmd_histo[2] += 1;
     }
     {
-        let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[64];
-        *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+        cmd_histo[64] += 1;
     }
     {
-        let _rhs = 1i32;
-        let _lhs = &mut cmd_histo[84];
-        *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+        cmd_histo[84] += 1;
     }
     BuildAndStoreCommandPrefixCode(
         &mut cmd_histo[..],

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1403,9 +1403,7 @@ fn ShouldCompress(
         while i < t {
             {
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut literal_histo[data[(pos as usize & mask)] as usize];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as u32);
+                    literal_histo[data[(pos as usize & mask)] as usize] += 1;
                 }
                 pos = pos.wrapping_add(kSampleRate);
             }
@@ -1822,14 +1820,10 @@ fn ChooseContextMap(
     while i < 9usize {
         {
             {
-                let _rhs = bigram_histo[i];
-                let _lhs = &mut monogram_histo[i.wrapping_rem(3)];
-                *_lhs = (*_lhs).wrapping_add(_rhs);
+                monogram_histo[i.wrapping_rem(3)] += bigram_histo[i];
             }
             {
-                let _rhs = bigram_histo[i];
-                let _lhs = &mut two_prefix_histo[i.wrapping_rem(6)];
-                *_lhs = (*_lhs).wrapping_add(_rhs);
+                two_prefix_histo[i.wrapping_rem(6)] += bigram_histo[i];
             }
         }
         i = i.wrapping_add(1);
@@ -1841,13 +1835,11 @@ fn ChooseContextMap(
     i = 0usize;
     while i < 3usize {
         {
-            let _rhs = ShannonEntropy(
+            entropy[3] += ShannonEntropy(
                 &bigram_histo[(3usize).wrapping_mul(i)..],
                 3usize,
                 &mut dummy,
             );
-            let _lhs = &mut entropy[3];
-            *_lhs += _rhs;
         }
         i = i.wrapping_add(1);
     }
@@ -1857,19 +1849,13 @@ fn ChooseContextMap(
     0i32;
     entropy[0] = 1.0 as super::util::floatX / total as (super::util::floatX);
     {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[1];
-        *_lhs *= _rhs;
+        entropy[1] *= entropy[0];
     }
     {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[2];
-        *_lhs *= _rhs;
+        entropy[2] *= entropy[0];
     }
     {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[3];
-        *_lhs *= _rhs;
+        entropy[3] *= entropy[0];
     }
     if quality < 7i32 {
         entropy[3] = entropy[1] * 10i32 as (super::util::floatX);

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -34,9 +34,7 @@ fn DecideMultiByteStatsLevel(pos: usize, len: usize, mask: usize, data: &[u8]) -
         {
             let c: usize = data[(pos.wrapping_add(i) & mask)] as usize;
             {
-                let _rhs = 1;
-                let _lhs = &mut counts[UTF8Position(last_c, c, 2usize)];
-                *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                counts[UTF8Position(last_c, c, 2usize)] += 1;
             }
             last_c = c;
         }
@@ -72,14 +70,10 @@ fn EstimateBitCostsForLiteralsUTF8(
             {
                 let c: usize = data[(pos.wrapping_add(i) & mask)] as usize;
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut histogram[utf8_pos][c];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                    histogram[utf8_pos][c] += 1;
                 }
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut in_window_utf8[utf8_pos];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                    in_window_utf8[utf8_pos] += 1;
                 }
                 utf8_pos = UTF8Position(last_c, c, max_utf8);
                 last_c = c;
@@ -111,15 +105,12 @@ fn EstimateBitCostsForLiteralsUTF8(
                 }) as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut histogram[utf8_pos2]
-                        [data[(pos.wrapping_add(i).wrapping_sub(window_half) & mask)] as usize];
-                    *_lhs = (*_lhs).wrapping_sub(_rhs as usize);
+                    histogram[utf8_pos2]
+                        [data[(pos.wrapping_add(i).wrapping_sub(window_half) & mask)] as usize] -=
+                        1;
                 }
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut in_window_utf8[utf8_pos2];
-                    *_lhs = (*_lhs).wrapping_sub(_rhs as usize);
+                    in_window_utf8[utf8_pos2] -= 1;
                 }
             }
             if i.wrapping_add(window_half) < len {
@@ -135,15 +126,12 @@ fn EstimateBitCostsForLiteralsUTF8(
                     & mask)] as usize;
                 let utf8_pos2: usize = UTF8Position(last_c, c, max_utf8);
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut histogram[utf8_pos2]
-                        [data[(pos.wrapping_add(i).wrapping_add(window_half) & mask)] as usize];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                    histogram[utf8_pos2]
+                        [data[(pos.wrapping_add(i).wrapping_add(window_half) & mask)] as usize] +=
+                        1;
                 }
                 {
-                    let _rhs = 1;
-                    let _lhs = &mut in_window_utf8[utf8_pos2];
-                    *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                    in_window_utf8[utf8_pos2] += 1;
                 }
             }
             {
@@ -200,9 +188,7 @@ pub fn BrotliEstimateBitCostsForLiterals(
         i = 0usize;
         while i < in_window {
             {
-                let _rhs = 1;
-                let _lhs = &mut histogram[data[(pos.wrapping_add(i) & mask)] as usize];
-                *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                histogram[data[(pos.wrapping_add(i) & mask)] as usize] += 1;
             }
             i = i.wrapping_add(1);
         }
@@ -212,19 +198,15 @@ pub fn BrotliEstimateBitCostsForLiterals(
                 let mut histo: usize;
                 if i >= window_half {
                     {
-                        let _rhs = 1;
-                        let _lhs = &mut histogram
-                            [data[(pos.wrapping_add(i).wrapping_sub(window_half) & mask)] as usize];
-                        *_lhs = (*_lhs).wrapping_sub(_rhs as usize);
+                        histogram[data[(pos.wrapping_add(i).wrapping_sub(window_half) & mask)]
+                            as usize] -= 1;
                     }
                     in_window = in_window.wrapping_sub(1);
                 }
                 if i.wrapping_add(window_half) < len {
                     {
-                        let _rhs = 1;
-                        let _lhs = &mut histogram
-                            [data[(pos.wrapping_add(i).wrapping_add(window_half) & mask)] as usize];
-                        *_lhs = (*_lhs).wrapping_add(_rhs as usize);
+                        histogram[data[(pos.wrapping_add(i).wrapping_add(window_half) & mask)]
+                            as usize] += 1;
                     }
                     in_window = in_window.wrapping_add(1);
                 }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -643,9 +643,8 @@ fn BlockSplitterFinishBlock<
             xself.target_block_size_ = xself.min_block_size_;
         } else {
             {
-                let _rhs = xself.block_size_ as u32;
-                let _lhs = &mut split.lengths.slice_mut()[xself.num_blocks_.wrapping_sub(1)];
-                *_lhs = (*_lhs).wrapping_add(_rhs);
+                split.lengths.slice_mut()[xself.num_blocks_.wrapping_sub(1)] +=
+                    xself.block_size_ as u32;
             }
             histograms[xself.last_histogram_ix_[0]] = combined_histo[0].clone();
             xself.last_entropy_[0] = combined_entropy[0];
@@ -733,9 +732,7 @@ fn ContextBlockSplitterFinishBlock<
                         combined_entropy[jx] =
                             BitsEntropy(combined_histo.slice()[jx].slice(), xself.alphabet_size_);
                         {
-                            let _rhs = combined_entropy[jx] - entropy[i] - xself.last_entropy_[jx];
-                            let _lhs = &mut diff[j];
-                            *_lhs += _rhs;
+                            diff[j] += combined_entropy[jx] - entropy[i] - xself.last_entropy_[jx];
                         }
                     }
                     j = j.wrapping_add(1);

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -58,9 +58,11 @@ fn oneshot_compress(
         unsafe { define_allocator_memory_pool!(96, u64, [0; 32 * 1024], calloc) };
     let stack_f64_buffer =
         unsafe { define_allocator_memory_pool!(48, super::util::floatX, [0; 128 * 1024], calloc) };
-    let mut stack_global_buffer_v8 = define_allocator_memory_pool!(64, v8, [v8::default(); 1024 * 16], stack);
+    let mut stack_global_buffer_v8 =
+        define_allocator_memory_pool!(64, v8, [v8::default(); 1024 * 16], stack);
     let mf8 = StackAllocatedFreelist64::<v8>::new_allocator(&mut stack_global_buffer_v8, bzero);
-    let mut stack_16x16_buffer = define_allocator_memory_pool!(64, s16, [s16::default(); 1024 * 16], stack);
+    let mut stack_16x16_buffer =
+        define_allocator_memory_pool!(64, s16, [s16::default(); 1024 * 16], stack);
     let m16x16 = StackAllocatedFreelist64::<s16>::new_allocator(&mut stack_16x16_buffer, bzero);
 
     let stack_hl_buffer =

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -1,10 +1,10 @@
 #![allow(unknown_lints)]
 #![allow(unused_macros)]
 
-use enc::util::FastLog2;
-use enc::{s8, v8};
 #[cfg(feature = "simd")]
 use core::simd::Simd;
+use enc::util::FastLog2;
+use enc::{s8, v8};
 pub type Mem256f = v8;
 pub type Mem256i = s8;
 pub type v256 = v8;


### PR DESCRIPTION
Regex to search for. The reason this is safe is because the release build of the `+=` is using wrapping_add already. See [rust docs](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#integer-overflow)

```regex
\{
\s+let _rhs = ([^;{}]+);
\s+let _lhs = &mut ([^;{}]+);
\s+\*_lhs = \(\*_lhs\)\.wrapping_add\(_rhs( as [ui](size|\d+))?\);
\s+\}
```

Replace with `{ $2 += $1; }`

Same for subtraction:

```regex
\{
\s+let _rhs = ([^;{}]+);
\s+let _lhs = &mut ([^;{}]+);
\s+\*_lhs = \(\*_lhs\)\.wrapping_sub\(_rhs( as [ui](size|\d+))?\);
\s+\}
```

Replace with `{ $2 -= $1; }`

```regex
\{
\s+let _rhs = ([^;{}]+);
\s+let _lhs = &mut ([^;{}]+);
\s+\*_lhs ([-*+/&])= _rhs;
\s+\}
```

with `{ $2 $3= $1; }`

Run `cargo fmt --all`