### PR TITLE
Clean up some nested curly braces

### DIFF
--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -2463,9 +2463,7 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                         } < 4i32
                             && (position.wrapping_add(hasher.HashTypeLength()) < pos_end)
                         {
-                            {
-                                break 'continue7;
-                            }
+                            break 'continue7;
                         }
                     }
                     break 'break6;

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -266,9 +266,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 s[count as usize] = i;
                 count += 1;
                 if count > 4i32 {
-                    {
-                        break 'break1;
-                    }
+                    break 'break1;
                 }
             }
         }
@@ -346,9 +344,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 }
                 i += reps as usize;
                 if i == data_size {
-                    {
-                        break;
-                    }
+                    break;
                 }
                 if reps < 3 {
                     depth_histo[0] += reps

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -832,9 +832,7 @@ fn BrotliStoreHuffmanTreeOfHuffmanTreeToBitMask(
                     as i32
                     != 0i32
                 {
-                    {
-                        break 'break5;
-                    }
+                    break 'break5;
                 }
             }
             codes_to_store = codes_to_store.wrapping_sub(1);
@@ -940,9 +938,7 @@ pub fn BrotliStoreHuffmanTree(
                 } else if num_codes == 1i32 {
                     num_codes = 2i32;
                     {
-                        {
-                            break 'break3;
-                        }
+                        break 'break3;
                     }
                 }
             }
@@ -1117,9 +1113,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                         k -= 1;
                     }
                     if BrotliSetDepth(2i32 * n - 1i32, tree.slice_mut(), depth, 14i32) {
-                        {
-                            break 'break11;
-                        }
+                        break 'break11;
                     }
                 }
             }
@@ -1574,9 +1568,7 @@ fn BuildAndStoreHuffmanTree(
                 if count < 4usize {
                     s4[count] = i;
                 } else if count > 4usize {
-                    {
-                        break 'break31;
-                    }
+                    break 'break31;
                 }
                 count = count.wrapping_add(1);
             }
@@ -1919,9 +1911,7 @@ fn RunLengthCodeZeros(
                     v[*out_size] = run_length_prefix.wrapping_add(extra_bits << 9);
                     *out_size = out_size.wrapping_add(1);
                     {
-                        {
-                            break;
-                        }
+                        break;
                     }
                 } else {
                     let extra_bits: u32 = (1u32 << max_prefix).wrapping_sub(1);

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -178,9 +178,7 @@ pub fn BrotliHistogramCombine<
             cost_diff_threshold = 1e38 as super::util::floatX;
             min_cluster_size = max_clusters;
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
         /* Take the best pair from the top of heap. */
@@ -229,9 +227,7 @@ pub fn BrotliHistogramCombine<
                             || (p).idx2 == best_idx2
                         {
                             /* Remove invalid pair from the queue. */
-                            {
-                                break 'continue12;
-                            }
+                            break 'continue12;
                         }
                         if HistogramPairIsLess(&pairs[0], &p) {
                             /* Replace the top of the queue if needed. */

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -458,10 +458,8 @@ fn EmitCopyLenLastDistance(
 }
 
 fn HashBytesAtOffset(v: u64, offset: i32, shift: usize) -> u32 {
-    {
-        let h: u64 = (v >> (8i32 * offset) << 24).wrapping_mul(kHashMul32 as (u64));
-        (h >> shift) as u32
-    }
+    let h: u64 = (v >> (8i32 * offset) << 24).wrapping_mul(kHashMul32 as (u64));
+    (h >> shift) as u32
 }
 
 fn EmitCopyLen(

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -215,9 +215,7 @@ fn CreateCommands(
                             if next_ip > ip_limit {
                                 goto_emit_remainder = 1i32;
                                 {
-                                    {
-                                        break 'break3;
-                                    }
+                                    break 'break3;
                                 }
                             }
                             next_hash = Hash(&base_ip[next_ip..], shift, min_match);
@@ -228,9 +226,7 @@ fn CreateCommands(
                             {
                                 table[(hash as usize)] = ip_index.wrapping_sub(0) as i32;
                                 {
-                                    {
-                                        break 'break3;
-                                    }
+                                    break 'break3;
                                 }
                             }
                             candidate = table[(hash as usize)] as usize;
@@ -251,9 +247,7 @@ fn CreateCommands(
                 }
             }
             if goto_emit_remainder != 0 {
-                {
-                    break;
-                }
+                break;
             }
             {
                 let base: usize = ip_index;
@@ -286,9 +280,7 @@ fn CreateCommands(
                 if ip_index >= ip_limit {
                     goto_emit_remainder = 1i32;
                     {
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
                 {
@@ -345,9 +337,7 @@ fn CreateCommands(
                 if ip_index >= ip_limit {
                     goto_emit_remainder = 1i32;
                     {
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
                 {

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -2737,14 +2737,10 @@ fn ProcessMetadata<
         if InjectFlushOrPushOutput(s, available_out, next_out_array, next_out_offset, total_out)
             != 0
         {
-            {
-                continue;
-            }
+            continue;
         }
         if s.available_out_ != 0usize {
-            {
-                break;
-            }
+            break;
         }
         if s.input_pos_ != s.last_flush_pos_ {
             let mut avail_out: usize = s.available_out_;
@@ -2754,9 +2750,7 @@ fn ProcessMetadata<
                 return 0i32;
             }
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
         if s.stream_state_ as i32 == BrotliEncoderStreamState::BROTLI_STREAM_METADATA_HEAD as i32 {
@@ -2764,18 +2758,14 @@ fn ProcessMetadata<
             s.available_out_ = WriteMetadataHeader(s);
             s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_METADATA_BODY;
             {
-                {
-                    continue;
-                }
+                continue;
             }
         } else {
             if s.remaining_metadata_bytes_ == 0u32 {
                 s.remaining_metadata_bytes_ = !(0u32);
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING;
                 {
-                    {
-                        break;
-                    }
+                    break;
                 }
             }
             if *available_out != 0 {
@@ -2807,9 +2797,7 @@ fn ProcessMetadata<
                 s.available_out_ = copy as usize;
             }
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
     }
@@ -2872,9 +2860,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
         if InjectFlushOrPushOutput(s, available_out, next_out_array, next_out_offset, total_out)
             != 0
         {
-            {
-                continue;
-            }
+            continue;
         }
         if s.available_out_ == 0usize
             && (s.stream_state_ as i32 == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as i32)
@@ -2895,9 +2881,7 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             if force_flush && block_size == 0 {
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FLUSH_REQUESTED;
                 {
-                    {
-                        continue;
-                    }
+                    continue;
                 }
             }
             if max_out_size <= *available_out {
@@ -2966,15 +2950,11 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
             }
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
         {
-            {
-                break;
-            }
+            break;
         }
     }
     if command_buf.slice().len() == kCompressFragmentTwoPassBlockSize
@@ -3076,17 +3056,13 @@ pub fn BrotliEncoderCompressStream<
             *next_in_offset += copy_input_size;
             *available_in = available_in.wrapping_sub(copy_input_size);
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
         if InjectFlushOrPushOutput(s, available_out, next_out_array, next_out_offset, total_out)
             != 0
         {
-            {
-                continue;
-            }
+            continue;
         }
         if s.available_out_ == 0usize
             && (s.stream_state_ as i32 == BrotliEncoderStreamState::BROTLI_STREAM_PROCESSING as i32)
@@ -3114,15 +3090,11 @@ pub fn BrotliEncoderCompressStream<
                 s.stream_state_ = BrotliEncoderStreamState::BROTLI_STREAM_FINISHED;
             }
             {
-                {
-                    continue;
-                }
+                continue;
             }
         }
         {
-            {
-                break;
-            }
+            break;
         }
     }
     CheckFlushComplete(s);

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -41,9 +41,7 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
             stack[level as usize] = (pool[(p as usize)]).index_right_or_value_ as i32;
             p = (pool[(p as usize)]).index_left_ as i32;
             {
-                {
-                    continue;
-                }
+                continue;
             }
         } else {
             let pp = pool[(p as usize)];
@@ -96,9 +94,7 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
                         _old
                     } == 0
                     {
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
                 items[k] = tmp;
@@ -190,9 +186,7 @@ pub fn BrotliCreateHuffmanTree(
             if n == 1 {
                 depth[((tree[0]).index_right_or_value_ as usize)] = 1u8;
                 {
-                    {
-                        break 'break1;
-                    }
+                    break 'break1;
                 }
             }
             SortHuffmanTreeItems(tree, n, SortHuffmanTree {});
@@ -237,9 +231,7 @@ pub fn BrotliCreateHuffmanTree(
                 depth,
                 tree_limit,
             ) {
-                {
-                    break 'break1;
-                }
+                break 'break1;
             }
         }
         count_limit = count_limit.wrapping_mul(2);
@@ -510,9 +502,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
             *tree_size = tree_size.wrapping_add(1);
             repetitions >>= 2i32;
             if repetitions == 0usize {
-                {
-                    break;
-                }
+                break;
             }
             repetitions = repetitions.wrapping_sub(1);
         }
@@ -553,9 +543,7 @@ fn BrotliWriteHuffmanTreeRepetitionsZeros(
             *tree_size = tree_size.wrapping_add(1);
             repetitions >>= 3i32;
             if repetitions == 0usize {
-                {
-                    break;
-                }
+                break;
             }
             repetitions = repetitions.wrapping_sub(1);
         }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -597,15 +597,13 @@ fn BlockSplitterFinishBlock<
         let mut diff: [super::util::floatX; 2] =
             [0.0 as super::util::floatX, 0.0 as super::util::floatX];
         for j in 0..2 {
-            {
-                let last_histogram_ix: usize = xself.last_histogram_ix_[j];
-                HistogramAddHistogram(&mut combined_histo[j], &histograms[last_histogram_ix]);
-                combined_entropy[j] = BitsEntropy(
-                    &mut combined_histo[j].slice_mut()[0..],
-                    xself.alphabet_size_,
-                );
-                diff[j] = combined_entropy[j] - entropy - xself.last_entropy_[j];
-            }
+            let last_histogram_ix: usize = xself.last_histogram_ix_[j];
+            HistogramAddHistogram(&mut combined_histo[j], &histograms[last_histogram_ix]);
+            combined_entropy[j] = BitsEntropy(
+                &mut combined_histo[j].slice_mut()[0..],
+                xself.alphabet_size_,
+            );
+            diff[j] = combined_entropy[j] - entropy - xself.last_entropy_[j];
         }
         if split.num_types < 256usize
             && (diff[0] > xself.split_threshold_)

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -518,9 +518,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     len = len.wrapping_add(1);
                 }
                 if matchlen < l || l.wrapping_add(6) >= max_length {
-                    {
-                        continue;
-                    }
+                    continue;
                 }
                 let s: &[u8] = data.split_at(l as usize).1;
                 if s[0] as i32 == b' ' as i32 {
@@ -1130,9 +1128,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 );
                 has_found_match = 1i32;
                 if l.wrapping_add(2) >= max_length {
-                    {
-                        continue;
-                    }
+                    continue;
                 }
                 let s: &[u8] = data.split_at(l.wrapping_add(1) as usize).1;
                 if s[0] as i32 == b' ' as i32 {
@@ -1227,9 +1223,7 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                 );
                 has_found_match = 1i32;
                 if l.wrapping_add(2) >= max_length {
-                    {
-                        continue;
-                    }
+                    continue;
                 }
                 let s: &[u8] = data.split_at(l.wrapping_add(1)).1;
                 if s[0] as i32 == b' ' as i32 {

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -58,9 +58,11 @@ fn oneshot_compress(
         unsafe { define_allocator_memory_pool!(96, u64, [0; 32 * 1024], calloc) };
     let stack_f64_buffer =
         unsafe { define_allocator_memory_pool!(48, super::util::floatX, [0; 128 * 1024], calloc) };
-    let mut stack_global_buffer_v8 = define_allocator_memory_pool!(64, v8, [v8::default(); 1024 * 16], stack);
+    let mut stack_global_buffer_v8 =
+        define_allocator_memory_pool!(64, v8, [v8::default(); 1024 * 16], stack);
     let mf8 = StackAllocatedFreelist64::<v8>::new_allocator(&mut stack_global_buffer_v8, bzero);
-    let mut stack_16x16_buffer = define_allocator_memory_pool!(64, s16, [s16::default(); 1024 * 16], stack);
+    let mut stack_16x16_buffer =
+        define_allocator_memory_pool!(64, s16, [s16::default(); 1024 * 16], stack);
     let m16x16 = StackAllocatedFreelist64::<s16>::new_allocator(&mut stack_16x16_buffer, bzero);
 
     let stack_hl_buffer =

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -1,10 +1,10 @@
 #![allow(unknown_lints)]
 #![allow(unused_macros)]
 
-use enc::util::FastLog2;
-use enc::{s8, v8};
 #[cfg(feature = "simd")]
 use core::simd::Simd;
+use enc::util::FastLog2;
+use enc::{s8, v8};
 pub type Mem256f = v8;
 pub type Mem256i = s8;
 pub type v256 = v8;


### PR DESCRIPTION
I used a very powerful tool [coccinelle](https://gitlab.inria.fr/coccinelle/coccinelleforrust) (its C version is used for Linux kernel refactorings).  Highly recommend installing it as it has a potential to simplify refactorings while not dealing with regex errors.

To install it, run

```sh
cargo install --git https://gitlab.inria.fr/coccinelle/coccinelleforrust
```

Afterward, create this file as `target/repl.cocci` with the following content. Using `target/` ensures that it will be ignored by git.

```diff
@@
@@

 {
-    {
    ...
-    }
 }
```

and run this command from the root of the repo:

```shell
cfr --apply -c target/repl.cocci src/
cargo fmt --all
```

Afterwards, I manually reverted two macro_rules! changes -- those are the only ones that should continue having nested curlies.