### PR TITLE
Simplify non-wrapping += and *=

### DIFF
--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1813,34 +1813,20 @@ fn ChooseContextMap(
         + ShannonEntropy(&two_prefix_histo[3..], 3usize, &mut dummy);
     entropy[3] = 0i32 as (super::util::floatX);
     for i in 0usize..3usize {
-        let _rhs = ShannonEntropy(
+        entropy[3] += ShannonEntropy(
             &bigram_histo[(3usize).wrapping_mul(i)..],
             3usize,
             &mut dummy,
         );
-        let _lhs = &mut entropy[3];
-        *_lhs += _rhs;
     }
     let total: usize = monogram_histo[0]
         .wrapping_add(monogram_histo[1])
         .wrapping_add(monogram_histo[2]) as usize;
     0i32;
     entropy[0] = 1.0 as super::util::floatX / total as (super::util::floatX);
-    {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[1];
-        *_lhs *= _rhs;
-    }
-    {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[2];
-        *_lhs *= _rhs;
-    }
-    {
-        let _rhs = entropy[0];
-        let _lhs = &mut entropy[3];
-        *_lhs *= _rhs;
-    }
+    entropy[1] *= entropy[0];
+    entropy[2] *= entropy[0];
+    entropy[3] *= entropy[0];
     if quality < 7i32 {
         entropy[3] = entropy[1] * 10i32 as (super::util::floatX);
     }

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -722,11 +722,7 @@ fn ContextBlockSplitterFinishBlock<
                     );
                     combined_entropy[jx] =
                         BitsEntropy(combined_histo.slice()[jx].slice(), xself.alphabet_size_);
-                    {
-                        let _rhs = combined_entropy[jx] - entropy[i] - xself.last_entropy_[jx];
-                        let _lhs = &mut diff[j];
-                        *_lhs += _rhs;
-                    }
+                    diff[j] += combined_entropy[jx] - entropy[i] - xself.last_entropy_[jx];
                 }
                 j = j.wrapping_add(1);
             }


### PR DESCRIPTION
Use this replacement file as described in other recent PRs to replace boilerplate code.

Followed by `cargo fmt --all`
Some of these changes were in #158, but removed now.

<details>
<summary>replacement file content</summary>

```diff
@@
expression expr_r, expr_l;
@@
-{
-   let _rhs = expr_r;
-   let _lhs = &mut expr_l;
-   *_lhs *= _rhs;
+expr_l *= expr_r;
-}

@@
expression expr_r, expr_l, i, start, end;
@@
for i in start..end
{
-   let _rhs = expr_r;
-   let _lhs = &mut expr_l;
-   *_lhs += _rhs;
+expr_l += expr_r;
}

@@
expression expr_r, expr_l;
@@
-{
-   let _rhs = expr_r;
-   let _lhs = &mut expr_l;
-   *_lhs += _rhs;
+expr_l += expr_r;
-}
```

</details>