### PR TITLE
Manually cleanup floatX types

### DIFF
--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -14,7 +14,7 @@ use crate::enc::static_dict::{
 };
 use crate::enc::util::floatX;
 
-pub const kInfinity: floatX = 1.7e38 as floatX;
+pub const kInfinity: floatX = 1.7e38;
 
 #[derive(Clone, Copy, Debug)]
 pub enum Union1 {

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -6,6 +6,7 @@ use super::super::alloc::SliceWrapper;
 use super::histogram::CostAccessors;
 use super::util::{FastLog2, FastLog2u16};
 use super::vectorization::Mem256i;
+use crate::enc::floatX;
 
 static kCopyBase: [u32; 24] = [
     2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 22, 30, 38, 54, 70, 102, 134, 198, 326, 582, 1094, 2118,
@@ -19,40 +20,33 @@ static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;
 
-pub fn ShannonEntropy(
-    mut population: &[u32],
-    size: usize,
-    total: &mut usize,
-) -> super::util::floatX {
+pub fn ShannonEntropy(mut population: &[u32], size: usize, total: &mut usize) -> floatX {
     let mut sum: usize = 0usize;
-    let mut retval: super::util::floatX = 0i32 as super::util::floatX;
+    let mut retval: floatX = 0.0;
     let mut p: usize;
     if size & 1 != 0 && !population.is_empty() {
         p = population[0] as usize;
         population = population.split_at(1).1;
         sum = sum.wrapping_add(p);
-        retval -= p as super::util::floatX * FastLog2u16(p as u16);
+        retval -= (p as floatX) * FastLog2u16(p as u16);
     }
     for pop_iter in population.split_at((size >> 1) << 1).0 {
         p = *pop_iter as usize;
         sum = sum.wrapping_add(p);
-        retval -= p as super::util::floatX * FastLog2u16(p as u16);
+        retval -= (p as floatX) * FastLog2u16(p as u16);
     }
     if sum != 0 {
-        retval += sum as super::util::floatX * FastLog2(sum as u64); // not sure it's 16 bit
+        retval += (sum as floatX) * FastLog2(sum as u64); // not sure it's 16 bit
     }
     *total = sum;
     retval
 }
 
 #[inline(always)]
-pub fn BitsEntropy(population: &[u32], size: usize) -> super::util::floatX {
+pub fn BitsEntropy(population: &[u32], size: usize) -> floatX {
     let mut sum: usize = 0;
-    let mut retval: super::util::floatX = ShannonEntropy(population, size, &mut sum);
-    if retval < sum as super::util::floatX {
-        retval = sum as super::util::floatX;
-    }
-    retval
+    let retval = ShannonEntropy(population, size, &mut sum);
+    floatX::max(retval, sum as floatX)
 }
 
 const BROTLI_REPEAT_ZERO_CODE_LENGTH: usize = 17;
@@ -78,10 +72,10 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
     depth_histo: &mut [u32; BROTLI_CODE_LENGTH_CODES],
     nnz_data: &T,
     nnz: usize,
-    _total_count: super::util::floatX,
-    log2total: super::util::floatX,
-) -> super::util::floatX {
-    let mut bits: super::util::floatX = 0.0 as super::util::floatX;
+    _total_count: floatX,
+    log2total: floatX,
+) -> floatX {
+    let mut bits: floatX = 0.0;
     let mut max_depth: usize = 1;
     for i in 0..nnz {
         // Compute -log2(P(symbol)) = -log2(count(symbol)/total_count) =
@@ -90,15 +84,15 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
         let log2p = log2total - FastLog2u16(element as u16);
         // Approximate the bit depth by round(-log2(P(symbol)))
         let depth = min((log2p + 0.5) as u8, 15u8);
-        bits += element as super::util::floatX * log2p;
-        if (depth as usize > max_depth) {
+        bits += (element as floatX) * log2p;
+        if (depth as usize) > max_depth {
             max_depth = depth as usize;
         }
         depth_histo[depth as usize] += 1;
     }
 
     // Add the estimated encoding cost of the code length code histogram.
-    bits += (18 + 2 * max_depth) as super::util::floatX;
+    bits += (18 + 2 * max_depth) as floatX;
     // Add the entropy of the code length code histogram.
     bits += BitsEntropy(depth_histo, BROTLI_CODE_LENGTH_CODES);
     //println_stderr!("{:?} {:?}", &depth_histo[..], bits);
@@ -110,16 +104,16 @@ use alloc::SliceWrapperMut;
 pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     histogram: &HistogramType,
     nnz_data: &mut HistogramType::i32vec,
-) -> super::util::floatX {
-    static kOneSymbolHistogramCost: super::util::floatX = 12i32 as super::util::floatX;
-    static kTwoSymbolHistogramCost: super::util::floatX = 20i32 as super::util::floatX;
-    static kThreeSymbolHistogramCost: super::util::floatX = 28i32 as super::util::floatX;
-    static kFourSymbolHistogramCost: super::util::floatX = 37i32 as super::util::floatX;
+) -> floatX {
+    static kOneSymbolHistogramCost: floatX = 12.0;
+    static kTwoSymbolHistogramCost: floatX = 20.0;
+    static kThreeSymbolHistogramCost: floatX = 28.0;
+    static kFourSymbolHistogramCost: floatX = 37.0;
     let data_size: usize = histogram.slice().len();
     let mut count: i32 = 0i32;
     let mut s: [usize; 5] = [0; 5];
 
-    let mut bits: super::util::floatX = 0.0 as super::util::floatX;
+    let mut bits: floatX = 0.0;
     let mut i: usize;
     if histogram.total_count() == 0usize {
         return kOneSymbolHistogramCost;
@@ -141,7 +135,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         return kOneSymbolHistogramCost;
     }
     if count == 2i32 {
-        return kTwoSymbolHistogramCost + histogram.total_count() as super::util::floatX;
+        return kTwoSymbolHistogramCost + (histogram.total_count() as floatX);
     }
     if count == 3i32 {
         let histo0: u32 = histogram.slice()[s[0]];
@@ -149,9 +143,8 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         let histo2: u32 = histogram.slice()[s[2]];
         let histomax: u32 = max(histo0, max(histo1, histo2));
         return kThreeSymbolHistogramCost
-            + (2u32).wrapping_mul(histo0.wrapping_add(histo1).wrapping_add(histo2))
-                as super::util::floatX
-            - histomax as super::util::floatX;
+            + ((2u32).wrapping_mul(histo0.wrapping_add(histo1).wrapping_add(histo2)) as floatX)
+            - (histomax as floatX);
     }
     if count == 4i32 {
         let mut histo: [u32; 4] = [0; 4];
@@ -169,15 +162,15 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         let h23: u32 = histo[2].wrapping_add(histo[3]);
         let histomax: u32 = max(h23, histo[0]);
         return kFourSymbolHistogramCost
-            + (3u32).wrapping_mul(h23) as super::util::floatX
-            + (2u32).wrapping_mul(histo[0].wrapping_add(histo[1])) as super::util::floatX
-            - histomax as super::util::floatX;
+            + ((3u32).wrapping_mul(h23) as floatX)
+            + ((2u32).wrapping_mul(histo[0].wrapping_add(histo[1])) as floatX)
+            - (histomax as floatX);
     }
     if vectorize_population_cost {
         // vectorization failed: it's faster to do things inline than split into two loops
         let mut nnz: usize = 0;
         let mut depth_histo = [0u32; 18];
-        let total_count = histogram.total_count() as super::util::floatX;
+        let total_count = histogram.total_count() as floatX;
         let log2total = FastLog2(histogram.total_count() as u64);
         i = 0usize;
         while i < data_size {
@@ -205,7 +198,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                     let mut depth_histo_adds: u32 = 0;
                     while reps > 0u32 {
                         depth_histo_adds += 1;
-                        bits += 3i32 as super::util::floatX;
+                        bits += 3.0;
                         reps >>= 3i32;
                     }
                     depth_histo[BROTLI_REPEAT_ZERO_CODE_LENGTH] += depth_histo_adds;
@@ -216,7 +209,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
     } else {
         let mut max_depth: usize = 1;
         let mut depth_histo = [0u32; 18];
-        let log2total: super::util::floatX = FastLog2(histogram.total_count() as u64); // 64 bit here
+        let log2total = FastLog2(histogram.total_count() as u64); // 64 bit here
         let mut reps: u32 = 0;
         for histo in histogram.slice()[..data_size].iter() {
             if *histo != 0 {
@@ -227,15 +220,15 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                         reps -= 2;
                         while reps > 0u32 {
                             depth_histo[17] += 1;
-                            bits += 3 as super::util::floatX;
+                            bits += 3.0;
                             reps >>= 3;
                         }
                     }
                     reps = 0;
                 }
-                let log2p: super::util::floatX = log2total - FastLog2u16(*histo as u16);
-                let mut depth: usize = (log2p + 0.5 as super::util::floatX) as usize;
-                bits += *histo as super::util::floatX * log2p;
+                let log2p = log2total - FastLog2u16(*histo as u16);
+                let mut depth: usize = (log2p + 0.5) as usize;
+                bits += (*histo as floatX) * log2p;
                 depth = min(depth, 15);
                 max_depth = max(depth, max_depth);
                 depth_histo[depth] += 1;
@@ -243,7 +236,7 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
                 reps += 1;
             }
         }
-        bits += (18usize).wrapping_add((2usize).wrapping_mul(max_depth)) as super::util::floatX;
+        bits += (18usize).wrapping_add((2usize).wrapping_mul(max_depth)) as floatX;
         bits += BitsEntropy(&depth_histo[..], 18usize);
     }
     bits

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -24,11 +24,11 @@ static kMaxLiteralHistograms: usize = 100usize;
 
 static kMaxCommandHistograms: usize = 50usize;
 
-static kLiteralBlockSwitchCost: super::util::floatX = 28.1 as super::util::floatX;
+static kLiteralBlockSwitchCost: floatX = 28.1;
 
-static kCommandBlockSwitchCost: super::util::floatX = 13.5 as super::util::floatX;
+static kCommandBlockSwitchCost: floatX = 13.5;
 
-static kDistanceBlockSwitchCost: super::util::floatX = 14.6 as super::util::floatX;
+static kDistanceBlockSwitchCost: floatX = 14.6;
 
 static kLiteralStrideLength: usize = 70usize;
 
@@ -50,8 +50,8 @@ static kMinItersForRefining: usize = 100usize;
 fn update_cost_and_signal(
     num_histograms32: u32,
     ix: usize,
-    min_cost: super::util::floatX,
-    block_switch_cost: super::util::floatX,
+    min_cost: floatX,
+    block_switch_cost: floatX,
     cost: &mut [Mem256f],
     switch_signal: &mut [u8],
 ) {
@@ -214,9 +214,9 @@ fn RefineEntropyCodes<
     }
 }
 
-fn BitCost(count: usize) -> super::util::floatX {
+fn BitCost(count: usize) -> floatX {
     if count == 0usize {
-        -2.0 as super::util::floatX
+        -2.0
     } else {
         FastLog2(count as u64)
     }
@@ -228,10 +228,10 @@ fn FindBlocks<
 >(
     data: &[IntegerType],
     length: usize,
-    block_switch_bitcost: super::util::floatX,
+    block_switch_bitcost: floatX,
     num_histograms: usize,
     histograms: &[HistogramType],
-    insert_cost: &mut [super::util::floatX],
+    insert_cost: &mut [floatX],
     cost: &mut [Mem256f],
     switch_signal: &mut [u8],
     block_id: &mut [u8],
@@ -253,7 +253,7 @@ where
         return 1;
     }
     for item in insert_cost[..(data_size * num_histograms)].iter_mut() {
-        *item = 0.0 as super::util::floatX;
+        *item = 0.0;
     }
     for i in 0usize..num_histograms {
         insert_cost[i] = FastLog2((histograms[i]).total_count() as u32 as (u64));
@@ -277,8 +277,8 @@ where
         let ix: usize = byte_ix.wrapping_mul(bitmaplen);
         let insert_cost_ix: usize =
             u64::from(data_byte_ix.clone()).wrapping_mul(num_histograms as u64) as usize;
-        let mut min_cost: super::util::floatX = 1e38 as super::util::floatX;
-        let mut block_switch_cost: super::util::floatX = block_switch_bitcost;
+        let mut min_cost: floatX = 1e38;
+        let mut block_switch_cost: floatX = block_switch_bitcost;
         // main (vectorized) loop
         let insert_cost_slice = insert_cost.split_at(insert_cost_ix).1;
         for (v_index, cost_iter) in cost
@@ -288,7 +288,7 @@ where
             .enumerate()
         {
             let base_index = v_index << 3;
-            let mut local_insert_cost = [0.0 as super::util::floatX; 8];
+            let mut local_insert_cost = [0.0; 8];
             local_insert_cost
                 .clone_from_slice(insert_cost_slice.split_at(base_index).1.split_at(8).0);
             for sub_index in 0usize..8usize {
@@ -319,9 +319,7 @@ where
             k += 1;
         }
         if byte_ix < 2000usize {
-            block_switch_cost *= (0.77 as super::util::floatX
-                + 0.07 as super::util::floatX * byte_ix as (super::util::floatX)
-                    / 2000i32 as (super::util::floatX));
+            block_switch_cost *= (0.77 + 0.07 * (byte_ix as floatX) / 2000.0);
         }
         update_cost_and_signal(
             num_histograms as u32,
@@ -594,7 +592,7 @@ fn ClusterBlocks<
         for i in 0usize..num_blocks {
             let mut histo: HistogramType = HistogramType::default();
             let mut best_out: u32;
-            let mut best_bits: super::util::floatX;
+            let mut best_bits: floatX;
             HistogramClear(&mut histo);
             for _j in 0usize..block_lengths.slice()[i] as usize {
                 HistogramAddItem(&mut histo, u64::from(data[pos].clone()) as usize);
@@ -611,7 +609,7 @@ fn ClusterBlocks<
                 scratch_space,
             );
             for j in 0usize..num_final_clusters {
-                let cur_bits: super::util::floatX = BrotliHistogramBitCostDistance(
+                let cur_bits: floatX = BrotliHistogramBitCostDistance(
                     &mut histo,
                     &mut all_histograms.slice_mut()[(clusters.slice()[j] as usize)],
                     scratch_space,
@@ -698,7 +696,7 @@ fn SplitByteVector<
     Alloc: alloc::Allocator<u8>
         + alloc::Allocator<u16>
         + alloc::Allocator<u32>
-        + alloc::Allocator<super::util::floatX>
+        + alloc::Allocator<floatX>
         + alloc::Allocator<Mem256f>
         + alloc::Allocator<HistogramType>
         + alloc::Allocator<HistogramPair>,
@@ -710,7 +708,7 @@ fn SplitByteVector<
     literals_per_histogram: usize,
     max_histograms: usize,
     sampling_stride_length: usize,
-    block_switch_cost: super::util::floatX,
+    block_switch_cost: floatX,
     params: &BrotliEncoderParams,
     scratch_space: &mut HistogramType::i32vec,
     split: &mut BlockSplit<Alloc>,
@@ -822,7 +820,7 @@ fn SplitByteVector<
                 histograms.slice_mut(),
             );
         }
-        <Alloc as Allocator<super::util::floatX>>::free_cell(alloc, insert_cost);
+        <Alloc as Allocator<floatX>>::free_cell(alloc, insert_cost);
         <Alloc as Allocator<Mem256f>>::free_cell(alloc, cost);
         <Alloc as Allocator<u8>>::free_cell(alloc, switch_signal);
         <Alloc as Allocator<u16>>::free_cell(alloc, new_id);
@@ -844,7 +842,7 @@ pub fn BrotliSplitBlock<
     Alloc: alloc::Allocator<u8>
         + alloc::Allocator<u16>
         + alloc::Allocator<u32>
-        + alloc::Allocator<super::util::floatX>
+        + alloc::Allocator<floatX>
         + alloc::Allocator<Mem256f>
         + alloc::Allocator<HistogramLiteral>
         + alloc::Allocator<HistogramCommand>

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -26,8 +26,8 @@ impl Default for HistogramPair {
         HistogramPair {
             idx1: 0,
             idx2: 0,
-            cost_combo: 0.0 as super::util::floatX,
-            cost_diff: 0.0 as super::util::floatX,
+            cost_combo: 0.0,
+            cost_diff: 0.0,
         }
     }
 }
@@ -77,7 +77,7 @@ fn BrotliCompareAndPushToQueue<
         }
         p.idx1 = idx1;
         p.idx2 = idx2;
-        p.cost_diff = 0.5 as super::util::floatX
+        p.cost_diff = 0.5
             * ClusterCostDiff(
                 cluster_size[idx1 as usize] as usize,
                 cluster_size[idx2 as usize] as usize,
@@ -91,8 +91,8 @@ fn BrotliCompareAndPushToQueue<
             p.cost_combo = (out[idx1 as usize]).bit_cost();
             is_good_pair = true;
         } else {
-            let threshold: super::util::floatX = if *num_pairs == 0usize {
-                1e38 as super::util::floatX
+            let threshold = if *num_pairs == 0 {
+                1e38
             } else {
                 pairs[0].cost_diff.max(0.0)
             };
@@ -136,7 +136,7 @@ pub fn BrotliHistogramCombine<
     max_num_pairs: usize,
     scratch_space: &mut HistogramType::i32vec,
 ) -> usize {
-    let mut cost_diff_threshold: super::util::floatX = 0.0 as super::util::floatX;
+    let mut cost_diff_threshold: super::util::floatX = 0.0;
     let mut min_cluster_size: usize = 1;
     let mut num_pairs: usize = 0usize;
     {
@@ -160,7 +160,7 @@ pub fn BrotliHistogramCombine<
     while num_clusters > min_cluster_size {
         let mut i: usize;
         if (pairs[0]).cost_diff >= cost_diff_threshold {
-            cost_diff_threshold = 1e38 as super::util::floatX;
+            cost_diff_threshold = 1e38;
             min_cluster_size = max_clusters;
             {
                 continue;
@@ -252,7 +252,7 @@ pub fn BrotliHistogramBitCostDistance<
     scratch_space: &mut HistogramType::i32vec,
 ) -> super::util::floatX {
     if histogram.total_count() == 0usize {
-        0.0 as super::util::floatX
+        0.0
     } else {
         let mut tmp: HistogramType = histogram.clone();
         HistogramAddHistogram(&mut tmp, candidate);

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -20,7 +20,7 @@ use super::static_dict::{
 };
 use super::util::{FastLog2, Log2FloorNonZero};
 use crate::enc::compress_fragment_two_pass::store_meta_block_header;
-//use super::super::alloc::{SliceWrapper, SliceWrapperMut};
+use crate::enc::floatX;
 
 //static kHashMul32: u32 = 0x1e35a7bdu32;
 
@@ -551,12 +551,9 @@ fn ShouldMergeBlock(data: &[u8], len: usize, depths: &[u8]) -> bool {
             .wrapping_add(kSampleRate)
             .wrapping_sub(1)
             .wrapping_div(kSampleRate);
-        let mut r: super::util::floatX = (FastLog2(total as u64) + 0.5 as super::util::floatX)
-            * total as (super::util::floatX)
-            + 200i32 as (super::util::floatX);
+        let mut r: floatX = (FastLog2(total as u64) + 0.5) * (total as floatX) + 200.0;
         for i in 0usize..256usize {
-            r -= histo[i] as (super::util::floatX)
-                * (depths[i] as (super::util::floatX) + FastLog2(histo[i] as u64));
+            r -= (histo[i] as floatX) * ((depths[i] as floatX) + FastLog2(histo[i] as u64));
         }
         r >= 0.0
     }

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -14,9 +14,7 @@ use super::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
     BROTLI_UNALIGNED_STORE64,
 };
-use super::util::Log2FloorNonZero;
-//use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-
+use super::util::{floatX, Log2FloorNonZero};
 static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17) as usize;
 
 // returns number of commands inserted
@@ -389,14 +387,12 @@ fn CreateCommands(
 }
 
 fn ShouldCompress(input: &[u8], input_size: usize, num_literals: usize) -> bool {
-    let corpus_size: super::util::floatX = input_size as (super::util::floatX);
-    if num_literals as (super::util::floatX) < 0.98 as super::util::floatX * corpus_size {
+    let corpus_size = input_size as floatX;
+    if (num_literals as floatX) < 0.98 * corpus_size {
         true
     } else {
         let mut literal_histo: [u32; 256] = [0; 256];
-        let max_total_bit_cost: super::util::floatX =
-            corpus_size * 8i32 as (super::util::floatX) * 0.98 as super::util::floatX
-                / 43i32 as (super::util::floatX);
+        let max_total_bit_cost: floatX = corpus_size * 8.0 * 0.98 / 43.0;
         let mut i: usize;
         i = 0usize;
         while i < input_size {

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -314,7 +314,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
                 [Weights::new(); NUM_SPEEDS_TO_TRY],
                 [Weights::new(); NUM_SPEEDS_TO_TRY],
             ],
-            singleton_costs: [[[0.0 as floatX; NUM_SPEEDS_TO_TRY]; 2]; 3],
+            singleton_costs: [[[0.0; NUM_SPEEDS_TO_TRY]; 2]; 3],
         };
         if cdf_detect {
             init_cdfs(ret.cm_priors.slice_mut());
@@ -410,7 +410,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
         } else {
             1
         };
-        let mut ret = [0.0 as floatX; 2];
+        let mut ret = [0.0; 2];
         for high in 0..2 {
             ret[high] = min_cost_value(&self.singleton_costs[cost_type_index][high][..]);
         }

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -8,7 +8,9 @@ use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::block_split::BlockSplit;
 use super::command::Command;
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
+use super::util::floatX;
 use super::vectorization::Mem256i;
+
 static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;
@@ -17,7 +19,7 @@ static kBrotliMaxWindowBits: i32 = 24i32;
 pub struct HistogramLiteral {
     pub data_: [u32; 256],
     pub total_count_: usize,
-    pub bit_cost_: super::util::floatX,
+    pub bit_cost_: floatX,
 }
 impl Clone for HistogramLiteral {
     #[inline(always)]
@@ -35,7 +37,7 @@ impl Default for HistogramLiteral {
         HistogramLiteral {
             data_: [0; 256],
             total_count_: 0,
-            bit_cost_: 3.402e+38 as super::util::floatX,
+            bit_cost_: 3.402e+38,
         }
     }
 }
@@ -43,7 +45,7 @@ impl Default for HistogramLiteral {
 pub struct HistogramCommand {
     pub data_: [u32; 704],
     pub total_count_: usize,
-    pub bit_cost_: super::util::floatX,
+    pub bit_cost_: floatX,
 }
 impl Clone for HistogramCommand {
     #[inline(always)]
@@ -61,7 +63,7 @@ impl Default for HistogramCommand {
         HistogramCommand {
             data_: [0; 704],
             total_count_: 0,
-            bit_cost_: 3.402e+38 as super::util::floatX,
+            bit_cost_: 3.402e+38,
         }
     }
 }
@@ -75,7 +77,7 @@ const BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS: usize = 520;
 pub struct HistogramDistance {
     pub data_: [u32; BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS],
     pub total_count_: usize,
-    pub bit_cost_: super::util::floatX,
+    pub bit_cost_: floatX,
 }
 impl Clone for HistogramDistance {
     fn clone(&self) -> HistogramDistance {
@@ -91,7 +93,7 @@ impl Default for HistogramDistance {
         HistogramDistance {
             data_: [0; BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS],
             total_count_: 0,
-            bit_cost_: 3.402e+38 as super::util::floatX,
+            bit_cost_: 3.402e+38,
         }
     }
 }
@@ -100,8 +102,8 @@ pub trait CostAccessors {
     type i32vec: Sized + SliceWrapper<Mem256i> + SliceWrapperMut<Mem256i>;
     fn make_nnz_storage() -> Self::i32vec;
     fn total_count(&self) -> usize;
-    fn bit_cost(&self) -> super::util::floatX;
-    fn set_bit_cost(&mut self, cost: super::util::floatX);
+    fn bit_cost(&self) -> floatX;
+    fn set_bit_cost(&mut self, cost: floatX);
     fn set_total_count(&mut self, count: usize);
 }
 impl SliceWrapper<u32> for HistogramLiteral {
@@ -214,11 +216,11 @@ impl CostAccessors for HistogramLiteral {
         self.total_count_
     }
     #[inline(always)]
-    fn bit_cost(&self) -> super::util::floatX {
+    fn bit_cost(&self) -> floatX {
         self.bit_cost_
     }
     #[inline(always)]
-    fn set_bit_cost(&mut self, data: super::util::floatX) {
+    fn set_bit_cost(&mut self, data: floatX) {
         self.bit_cost_ = data;
     }
     #[inline(always)]
@@ -256,11 +258,11 @@ impl CostAccessors for HistogramCommand {
         self.total_count_
     }
     #[inline(always)]
-    fn bit_cost(&self) -> super::util::floatX {
+    fn bit_cost(&self) -> floatX {
         self.bit_cost_
     }
     #[inline(always)]
-    fn set_bit_cost(&mut self, data: super::util::floatX) {
+    fn set_bit_cost(&mut self, data: floatX) {
         self.bit_cost_ = data;
     }
     #[inline(always)]
@@ -299,11 +301,11 @@ impl CostAccessors for HistogramDistance {
         self.total_count_
     }
     #[inline(always)]
-    fn bit_cost(&self) -> super::util::floatX {
+    fn bit_cost(&self) -> floatX {
         self.bit_cost_
     }
     #[inline(always)]
-    fn set_bit_cost(&mut self, data: super::util::floatX) {
+    fn set_bit_cost(&mut self, data: floatX) {
         self.bit_cost_ = data;
     }
     #[inline(always)]
@@ -399,7 +401,7 @@ pub fn HistogramClear<HistogramType: SliceWrapperMut<u32> + CostAccessors>(
         *data_elem = 0;
     }
     xself.set_total_count(0);
-    xself.set_bit_cost(3.402e+38 as super::util::floatX);
+    xself.set_bit_cost(3.402e+38);
 }
 pub fn ClearHistograms<HistogramType: SliceWrapperMut<u32> + CostAccessors>(
     array: &mut [HistogramType],

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -2,10 +2,10 @@
 
 use core::cmp::min;
 
-use super::util::FastLog2f64;
+use super::util::{floatX, FastLog2f64};
 use crate::enc::utf8_util::is_mostly_utf8;
 
-static kMinUTF8Ratio: super::util::floatX = 0.75 as super::util::floatX;
+static kMinUTF8Ratio: floatX = 0.75;
 
 fn UTF8Position(last: usize, c: usize, clamp: usize) -> usize {
     if c < 128usize {
@@ -51,7 +51,7 @@ fn EstimateBitCostsForLiteralsUTF8(
     len: usize,
     mask: usize,
     data: &[u8],
-    cost: &mut [super::util::floatX],
+    cost: &mut [floatX],
 ) {
     let max_utf8: usize = DecideMultiByteStatsLevel(pos, len, mask, data);
     let mut histogram = [[0usize; 256]; 3];
@@ -170,7 +170,7 @@ fn EstimateBitCostsForLiteralsUTF8(
                 if i < 2000usize {
                     lit_cost += (0.7 - (2000usize).wrapping_sub(i) as (f64) / 2000.0 * 0.35);
                 }
-                cost[i] = lit_cost as (super::util::floatX);
+                cost[i] = lit_cost as floatX;
             }
         }
         i = i.wrapping_add(1);
@@ -182,7 +182,7 @@ pub fn BrotliEstimateBitCostsForLiterals(
     len: usize,
     mask: usize,
     data: &[u8],
-    cost: &mut [super::util::floatX],
+    cost: &mut [floatX],
 ) {
     if is_mostly_utf8(data, pos, mask, len, kMinUTF8Ratio) {
         EstimateBitCostsForLiteralsUTF8(pos, len, mask, data, cost);
@@ -232,7 +232,7 @@ pub fn BrotliEstimateBitCostsForLiterals(
                         lit_cost *= 0.5;
                         lit_cost += 0.5;
                     }
-                    cost[i] = lit_cost as (super::util::floatX);
+                    cost[i] = lit_cost as floatX;
                 }
             }
             i = i.wrapping_add(1);

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -491,18 +491,18 @@ impl<'a, Alloc: alloc::Allocator<s16> + alloc::Allocator<u32> + alloc::Allocator
             );
 
             let adv_score = score[WhichPrior::ADV as usize];
-            if adv_score + epsilon < stride_score as floatX
+            if adv_score + epsilon < (stride_score as floatX)
                 && adv_score + epsilon < cm_score
                 && adv_score + epsilon < slow_cm_score
                 && adv_score + epsilon < fast_cm_score
             {
                 bitmask[i] = 1;
-            } else if slow_cm_score + epsilon < stride_score as floatX
+            } else if slow_cm_score + epsilon < (stride_score as floatX)
                 && slow_cm_score + epsilon < cm_score
                 && slow_cm_score + epsilon < fast_cm_score
             {
                 bitmask[i] = 2;
-            } else if fast_cm_score + epsilon < stride_score as floatX
+            } else if fast_cm_score + epsilon < (stride_score as floatX)
                 && fast_cm_score + epsilon < cm_score
             {
                 bitmask[i] = 3;

--- a/src/enc/util.rs
+++ b/src/enc/util.rs
@@ -95,12 +95,13 @@ pub fn FastPow2(v: floatX) -> floatX {
     x *= x;
     x *= x;
     x *= x;
-    return (1 << round_down) as floatX * x;
+
+    (1 << round_down) as floatX * x
 }
 
 #[inline(always)]
 pub fn Log2FloorNonZero(v: u64) -> u32 {
-    (63u32 ^ v.leading_zeros())
+    63u32 ^ v.leading_zeros()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Remove where not needed (implied)
* Add parenthesis to make casting explicitly clear
* Add `use` statement to make it cleaner
* Cleanup logic in the bit_cost.rs - BitsEntropy, using `max`