### PR TITLE
Manually fix several for loops

### DIFF
--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -227,7 +227,7 @@ impl<AllocF: Allocator<floatX>> ZopfliCostModel<AllocF> {
             } else {
                 AllocF::AllocatedMemory::default()
             },
-        distance_histogram_size: min(dist.alphabet_size, 544),
+            distance_histogram_size: min(dist.alphabet_size, 544),
         }
     }
 
@@ -401,12 +401,8 @@ where
         );
         matches_offset += loc_offset;
     }
-    i = 0usize;
-    while i <= 37usize {
-        {
-            dict_matches[i] = kInvalidMatch;
-        }
-        i = i.wrapping_add(1);
+    for i in 0..=37 {
+        dict_matches[i] = kInvalidMatch
     }
     {
         let minlen = max(4, best_len.wrapping_add(1));
@@ -421,27 +417,22 @@ where
         {
             assert!(params.use_dictionary);
             let maxlen = min(37, max_length);
-            let mut l: usize;
-            l = minlen;
-            while l <= maxlen {
-                {
-                    let dict_id: u32 = dict_matches[l];
-                    if dict_id < kInvalidMatch {
-                        let distance: usize = max_backward
-                            .wrapping_add(gap)
-                            .wrapping_add((dict_id >> 5) as usize)
-                            .wrapping_add(1);
-                        if distance <= params.dist.max_distance {
-                            BackwardMatchMut(&mut matches[matches_offset]).init_dictionary(
-                                distance,
-                                l,
-                                (dict_id & 31u32) as usize,
-                            );
-                            matches_offset += 1;
-                        }
+            for l in minlen..=maxlen {
+                let dict_id: u32 = dict_matches[l];
+                if dict_id < kInvalidMatch {
+                    let distance: usize = max_backward
+                        .wrapping_add(gap)
+                        .wrapping_add((dict_id >> 5) as usize)
+                        .wrapping_add(1);
+                    if distance <= params.dist.max_distance {
+                        BackwardMatchMut(&mut matches[matches_offset]).init_dictionary(
+                            distance,
+                            l,
+                            (dict_id & 31u32) as usize,
+                        );
+                        matches_offset += 1;
                     }
                 }
-                l = l.wrapping_add(1);
             }
         }
     }
@@ -537,20 +528,13 @@ fn StartPosQueuePush(xself: &mut StartPosQueue, posdata: &PosData) {
     let mut offset: usize = !xself.idx_ & 7usize;
     xself.idx_ = xself.idx_.wrapping_add(1);
     let len: usize = StartPosQueueSize(xself);
-    let mut i: usize;
     let q: &mut [PosData; 8] = &mut xself.q_;
     q[offset] = *posdata;
-    i = 1usize;
-    while i < len {
-        {
-            if (q[(offset & 7usize)]).costdiff > (q[(offset.wrapping_add(1) & 7usize)]).costdiff {
-                let mut __brotli_swap_tmp: PosData = q[(offset & 7usize)];
-                q[(offset & 7usize)] = q[(offset.wrapping_add(1) & 7usize)];
-                q[(offset.wrapping_add(1) & 7usize)] = __brotli_swap_tmp;
-            }
-            offset = offset.wrapping_add(1);
+    for _i in 1..len {
+        if q[offset & 7].costdiff > q[(offset + 1) & 7].costdiff {
+            q.swap(offset & 7, (offset + 1) & 7);
         }
-        i = i.wrapping_add(1);
+        offset = offset.wrapping_add(1);
     }
 }
 
@@ -780,41 +764,33 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                             }
                             {
                                 let dist_cost = base_cost + model.get_distance_cost(j);
-                                let mut l: usize;
-                                l = best_len.wrapping_add(1);
-                                while l <= len {
-                                    {
-                                        let copycode: u16 = GetCopyLengthCode(l);
-                                        let cmdcode: u16 = CombineLengthCodes(
-                                            inscode,
-                                            copycode,
-                                            (j == 0usize) as i32,
-                                        );
-                                        let cost: floatX =
-                                            (if cmdcode < 128 { base_cost } else { dist_cost })
-                                                + (GetCopyExtra(copycode) as floatX)
-                                                + model.get_command_cost(cmdcode);
-                                        if cost
-                                            < match (nodes[pos.wrapping_add(l)]).u {
-                                                Union1::cost(cost) => cost,
-                                                _ => 0.0,
-                                            }
-                                        {
-                                            UpdateZopfliNode(
-                                                nodes,
-                                                pos,
-                                                start,
-                                                l,
-                                                l,
-                                                backward,
-                                                j.wrapping_add(1),
-                                                cost,
-                                            );
-                                            result = max(result, l);
+                                for l in best_len.wrapping_add(1)..=len {
+                                    let copycode: u16 = GetCopyLengthCode(l);
+                                    let cmdcode: u16 =
+                                        CombineLengthCodes(inscode, copycode, (j == 0usize) as i32);
+                                    let cost: floatX =
+                                        (if cmdcode < 128 { base_cost } else { dist_cost })
+                                            + (GetCopyExtra(copycode) as floatX)
+                                            + model.get_command_cost(cmdcode);
+                                    if cost
+                                        < match (nodes[pos.wrapping_add(l)]).u {
+                                            Union1::cost(cost) => cost,
+                                            _ => 0.0,
                                         }
-                                        best_len = l;
+                                    {
+                                        UpdateZopfliNode(
+                                            nodes,
+                                            pos,
+                                            start,
+                                            l,
+                                            l,
+                                            backward,
+                                            j.wrapping_add(1),
+                                            cost,
+                                        );
+                                        result = max(result, l);
                                     }
-                                    l = l.wrapping_add(1);
+                                    best_len = l;
                                 }
                             }
                         }
@@ -1212,7 +1188,7 @@ impl<AllocF: Allocator<floatX>> ZopfliCostModel<AllocF> {
             self.cost_dist_.slice_mut(),
         );
         for i in 0usize..704usize {
-        min_cost_cmd = min_cost_cmd.min(cost_cmd[i]);
+            min_cost_cmd = min_cost_cmd.min(cost_cmd[i]);
         }
         self.min_cost_cmd_ = min_cost_cmd;
         {

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -294,16 +294,11 @@ pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(
         for i in 0usize..4usize {
             histo[i] = histogram.slice()[s[i]];
         }
-        for i in 0usize..4usize {
-            let mut j: usize;
-            j = i.wrapping_add(1);
-            while j < 4usize {
-                {
-                    if histo[j] > histo[i] {
-                        histo.swap(j, i);
-                    }
+        for i in 0..4 {
+            for j in i + 1..4 {
+                if histo[j] > histo[i] {
+                    histo.swap(j, i);
                 }
-                j = j.wrapping_add(1);
             }
         }
         let h23: u32 = histo[2].wrapping_add(histo[3]);

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -138,23 +138,18 @@ pub fn BrotliHistogramCombine<
     {
         /* We maintain a vector of histogram pairs, with the property that the pair
         with the maximum bit cost reduction is the first. */
-        for idx1 in 0usize..num_clusters {
-            let mut idx2: usize;
-            idx2 = idx1.wrapping_add(1);
-            while idx2 < num_clusters {
-                {
-                    BrotliCompareAndPushToQueue(
-                        out,
-                        cluster_size,
-                        clusters[idx1],
-                        clusters[idx2],
-                        max_num_pairs,
-                        scratch_space,
-                        pairs,
-                        &mut num_pairs,
-                    );
-                }
-                idx2 = idx2.wrapping_add(1);
+        for idx1 in 0..num_clusters {
+            for idx2 in idx1 + 1..num_clusters {
+                BrotliCompareAndPushToQueue(
+                    out,
+                    cluster_size,
+                    clusters[idx1],
+                    clusters[idx2],
+                    max_num_pairs,
+                    scratch_space,
+                    pairs,
+                    &mut num_pairs,
+                );
             }
         }
     }

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -75,52 +75,40 @@ pub fn SortHuffmanTreeItems<Comparator: HuffmanComparator>(
     comparator: Comparator,
 ) {
     static gaps: [usize; 6] = [132, 57, 23, 10, 4, 1];
-    if n < 13usize {
-        let mut i: usize;
-        i = 1;
-        while i < n {
-            {
-                let mut tmp: HuffmanTree = items[i];
-                let mut k: usize = i;
-                let mut j: usize = i.wrapping_sub(1);
-                while comparator.Cmp(&mut tmp, &mut items[j]) {
-                    items[k] = items[j];
-                    k = j;
-                    if {
-                        let _old = j;
-                        j = j.wrapping_sub(1);
-                        _old
-                    } == 0
-                    {
-                        break;
-                    }
+    if n < 13 {
+        for i in 1..n {
+            let mut tmp: HuffmanTree = items[i];
+            let mut k: usize = i;
+            let mut j: usize = i.wrapping_sub(1);
+            while comparator.Cmp(&mut tmp, &mut items[j]) {
+                items[k] = items[j];
+                k = j;
+                if {
+                    let _old = j;
+                    j = j.wrapping_sub(1);
+                    _old
+                } == 0
+                {
+                    break;
                 }
-                items[k] = tmp;
             }
-            i = i.wrapping_add(1);
+            items[k] = tmp;
         }
     } else {
         let mut g: i32 = if n < 57usize { 2i32 } else { 0i32 };
         while g < 6i32 {
             {
                 let gap: usize = gaps[g as usize];
-                let mut i: usize;
-                i = gap;
-                while i < n {
-                    {
-                        let mut j: usize = i;
-                        let mut tmp: HuffmanTree = items[i];
-                        while j >= gap
-                            && (comparator.Cmp(&mut tmp, &mut items[j.wrapping_sub(gap)]))
+                for i in gap..n {
+                    let mut j: usize = i;
+                    let mut tmp: HuffmanTree = items[i];
+                    while j >= gap && (comparator.Cmp(&mut tmp, &mut items[j.wrapping_sub(gap)])) {
                         {
-                            {
-                                items[j] = items[j.wrapping_sub(gap)];
-                            }
-                            j = j.wrapping_sub(gap);
+                            items[j] = items[j.wrapping_sub(gap)];
                         }
-                        items[j] = tmp;
+                        j = j.wrapping_sub(gap);
                     }
-                    i = i.wrapping_add(1);
+                    items[j] = tmp;
                 }
             }
             g += 1;
@@ -231,7 +219,6 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     let mut limit: usize;
     let mut sum: usize;
     let streak_limit: usize = 1240usize;
-    let mut i: usize;
     for i in 0usize..length {
         if counts[i] != 0 {
             nonzero_count = nonzero_count.wrapping_add(1);
@@ -262,18 +249,11 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
         }
         if smallest_nonzero < 4u32 {
             let zeros: usize = length.wrapping_sub(nonzeros);
-            if zeros < 6usize {
-                i = 1;
-                while i < length.wrapping_sub(1) {
-                    {
-                        if counts[i.wrapping_sub(1)] != 0u32
-                            && (counts[i] == 0u32)
-                            && (counts[i.wrapping_add(1)] != 0u32)
-                        {
-                            counts[i] = 1u32;
-                        }
+            if zeros < 6 {
+                for i in 1..length.wrapping_sub(1) {
+                    if counts[i - 1] != 0 && counts[i] == 0 && counts[i + 1] != 0 {
+                        counts[i] = 1;
                     }
-                    i = i.wrapping_add(1);
                 }
             }
         }
@@ -287,24 +267,20 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
     {
         let mut symbol: u32 = counts[0];
         let mut step: usize = 0usize;
-        i = 0usize;
-        while i <= length {
-            {
-                if i == length || counts[i] != symbol {
-                    if symbol == 0u32 && (step >= 5usize) || symbol != 0u32 && (step >= 7usize) {
-                        for k in 0usize..step {
-                            good_for_rle[i.wrapping_sub(k).wrapping_sub(1)] = 1u8;
-                        }
+        for i in 0..=length {
+            if i == length || counts[i] != symbol {
+                if symbol == 0u32 && (step >= 5usize) || symbol != 0u32 && (step >= 7usize) {
+                    for k in 0usize..step {
+                        good_for_rle[i.wrapping_sub(k).wrapping_sub(1)] = 1u8;
                     }
-                    step = 1;
-                    if i != length {
-                        symbol = counts[i];
-                    }
-                } else {
-                    step = step.wrapping_add(1);
                 }
+                step = 1;
+                if i != length {
+                    symbol = counts[i];
+                }
+            } else {
+                step = step.wrapping_add(1);
             }
-            i = i.wrapping_add(1);
         }
     }
     stride = 0usize;
@@ -313,63 +289,59 @@ pub fn BrotliOptimizeHuffmanCountsForRle(
         .wrapping_div(3)
         .wrapping_add(420) as usize;
     sum = 0usize;
-    i = 0usize;
-    while i <= length {
+    for i in 0..=length {
+        if i == length
+            || good_for_rle[i] != 0
+            || i != 0usize && (good_for_rle[i.wrapping_sub(1)] != 0)
+            || ((256u32).wrapping_mul(counts[i]) as usize)
+                .wrapping_sub(limit)
+                .wrapping_add(streak_limit)
+                >= (2usize).wrapping_mul(streak_limit)
         {
-            if i == length
-                || good_for_rle[i] != 0
-                || i != 0usize && (good_for_rle[i.wrapping_sub(1)] != 0)
-                || ((256u32).wrapping_mul(counts[i]) as usize)
-                    .wrapping_sub(limit)
-                    .wrapping_add(streak_limit)
-                    >= (2usize).wrapping_mul(streak_limit)
-            {
-                if stride >= 4usize || stride >= 3usize && (sum == 0usize) {
-                    let mut count: usize = sum
-                        .wrapping_add(stride.wrapping_div(2))
-                        .wrapping_div(stride);
-                    if count == 0usize {
-                        count = 1;
-                    }
-                    if sum == 0usize {
-                        count = 0usize;
-                    }
-                    for k in 0usize..stride {
-                        counts[i.wrapping_sub(k).wrapping_sub(1)] = count as u32;
-                    }
+            if stride >= 4usize || stride >= 3usize && (sum == 0usize) {
+                let mut count: usize = sum
+                    .wrapping_add(stride.wrapping_div(2))
+                    .wrapping_div(stride);
+                if count == 0usize {
+                    count = 1;
                 }
-                stride = 0usize;
-                sum = 0usize;
-                if i < length.wrapping_sub(2) {
-                    limit = (256u32)
-                        .wrapping_mul(
-                            (counts[i])
-                                .wrapping_add(counts[i.wrapping_add(1)])
-                                .wrapping_add(counts[i.wrapping_add(2)]),
-                        )
-                        .wrapping_div(3)
-                        .wrapping_add(420) as usize;
-                } else if i < length {
-                    limit = (256u32).wrapping_mul(counts[i]) as usize;
-                } else {
-                    limit = 0usize;
+                if sum == 0usize {
+                    count = 0usize;
+                }
+                for k in 0usize..stride {
+                    counts[i.wrapping_sub(k).wrapping_sub(1)] = count as u32;
                 }
             }
-            stride = stride.wrapping_add(1);
-            if i != length {
-                sum = sum.wrapping_add(counts[i] as usize);
-                if stride >= 4usize {
-                    limit = (256usize)
-                        .wrapping_mul(sum)
-                        .wrapping_add(stride.wrapping_div(2))
-                        .wrapping_div(stride);
-                }
-                if stride == 4usize {
-                    limit = limit.wrapping_add(120);
-                }
+            stride = 0usize;
+            sum = 0usize;
+            if i < length.wrapping_sub(2) {
+                limit = (256u32)
+                    .wrapping_mul(
+                        (counts[i])
+                            .wrapping_add(counts[i.wrapping_add(1)])
+                            .wrapping_add(counts[i.wrapping_add(2)]),
+                    )
+                    .wrapping_div(3)
+                    .wrapping_add(420) as usize;
+            } else if i < length {
+                limit = (256u32).wrapping_mul(counts[i]) as usize;
+            } else {
+                limit = 0usize;
             }
         }
-        i = i.wrapping_add(1);
+        stride = stride.wrapping_add(1);
+        if i != length {
+            sum = sum.wrapping_add(counts[i] as usize);
+            if stride >= 4usize {
+                limit = (256usize)
+                    .wrapping_mul(sum)
+                    .wrapping_add(stride.wrapping_div(2))
+                    .wrapping_div(stride);
+            }
+            if stride == 4usize {
+                limit = limit.wrapping_add(120);
+            }
+        }
     }
 }
 
@@ -596,7 +568,6 @@ pub fn BrotliConvertBitDepthsToSymbols(depth: &[u8], len: usize, bits: &mut [u16
 
     let mut bl_count: [u16; MAX_HUFFMAN_BITS] = [0; MAX_HUFFMAN_BITS];
     let mut next_code: [u16; MAX_HUFFMAN_BITS] = [0; MAX_HUFFMAN_BITS];
-    let mut i: usize;
     let mut code: i32 = 0i32;
     for i in 0usize..len {
         let _rhs = 1;
@@ -605,13 +576,9 @@ pub fn BrotliConvertBitDepthsToSymbols(depth: &[u8], len: usize, bits: &mut [u16
     }
     bl_count[0] = 0u16;
     next_code[0] = 0u16;
-    i = 1;
-    while i < MAX_HUFFMAN_BITS {
-        {
-            code = (code + bl_count[i.wrapping_sub(1)] as i32) << 1;
-            next_code[i] = code as u16;
-        }
-        i = i.wrapping_add(1);
+    for i in 1..MAX_HUFFMAN_BITS {
+        code = (code + bl_count[i - 1] as i32) << 1;
+        next_code[i] = code as u16;
     }
     for i in 0usize..len {
         if depth[i] != 0 {

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -461,23 +461,19 @@ pub fn BrotliFindAllStaticDictionaryMatches(
                     minlen = max(minlen, l.wrapping_sub(9));
                 }
                 let maxlen: usize = min(matchlen, l.wrapping_sub(2));
-                len = minlen;
-                while len <= maxlen {
-                    {
-                        //eprint!("Ddding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
-                        AddMatch(
-                            id.wrapping_add(
-                                (kOmitLastNTransforms[l.wrapping_sub(len)] as usize)
-                                    .wrapping_mul(n),
-                            ),
-                            len,
-                            l,
-                            matches,
-                        );
-                        has_found_match = 1i32;
-                    }
-                    len = len.wrapping_add(1);
+                for len in minlen..=maxlen {
+                    //eprint!("Ddding match {} {} {} {}\n", w.len(), w.transform(), w.idx(), len);
+                    AddMatch(
+                        id.wrapping_add(
+                            (kOmitLastNTransforms[l.wrapping_sub(len)] as usize).wrapping_mul(n),
+                        ),
+                        len,
+                        l,
+                        matches,
+                    );
+                    has_found_match = 1i32;
                 }
+
                 if matchlen < l || l.wrapping_add(6) >= max_length {
                     continue;
                 }


### PR DESCRIPTION
Manually fix several for loops

I used this replacement, and then went through each and reasoned if wrapping can ever happen (mostly it cannot, e.g. -1 is ok if for loop starts at 1)

When reviewing, make sure to use "ignore blanks" because lots of code was only de-indented.

```diff
@@
expression idx, start, end;
@@
-   idx = start;
-   while idx < end
+   for idx in start..end
    {
        {
        ...
        }
-        idx = idx.wrapping_add(1);
    }
    
@@
expression idx, start, end;
@@
-   idx = start;
-   while idx <= end
+   for idx in start..=end
    {
        {
        ...
        }
-        idx = idx.wrapping_add(1);
    }
```