### PR TITLE
Remove unused values

### DIFF
--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -389,7 +389,6 @@ where
         let mut cur_id: u8 = block_id[byte_ix];
         while byte_ix > 0usize {
             let mask: u8 = (1u32 << (cur_id as i32 & 7i32)) as u8;
-            0i32;
             byte_ix -= 1;
             ix = ix.wrapping_sub(bitmaplen);
             if switch_signal[ix.wrapping_add((cur_id as i32 >> 3) as usize)] as i32 & mask as i32
@@ -417,7 +416,6 @@ fn RemapBlockIds(
         new_id[i] = kInvalidId;
     }
     for i in 0usize..length {
-        0i32;
         if new_id[(block_ids[i] as usize)] as i32 == kInvalidId as i32 {
             new_id[(block_ids[i] as usize)] = {
                 let _old = next_id;
@@ -428,9 +426,7 @@ fn RemapBlockIds(
     }
     for i in 0usize..length {
         block_ids[i] = new_id[(block_ids[i] as usize)] as u8;
-        0i32;
     }
-    0i32;
     next_id as usize
 }
 
@@ -507,7 +503,6 @@ fn ClusterBlocks<
         i = 0usize;
         while i < length {
             {
-                0i32;
                 {
                     let _rhs = 1;
                     let _lhs = &mut block_lengths.slice_mut()[block_idx];
@@ -521,7 +516,6 @@ fn ClusterBlocks<
             }
             i = i.wrapping_add(1);
         }
-        0i32;
     }
     i = 0usize;
     while i < num_blocks {
@@ -610,8 +604,6 @@ fn ClusterBlocks<
                     (num_clusters as u32).wrapping_add(remap[symbols[j] as usize]);
             }
             num_clusters = num_clusters.wrapping_add(num_new_clusters);
-            0i32;
-            0i32;
         }
         i = i.wrapping_add(64);
     }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -906,7 +906,7 @@ pub fn BrotliStoreHuffmanTree(
     let mut i: usize;
     let mut num_codes: i32 = 0i32;
     let mut code: usize = 0usize;
-    0i32;
+
     BrotliWriteHuffmanTree(
         depths,
         num,
@@ -1798,7 +1798,7 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
         }
         i = i.wrapping_add(1);
     }
-    0i32;
+
     i = 0usize;
     while i <= max_value as usize {
         {
@@ -1810,7 +1810,6 @@ fn MoveToFrontTransform(v_in: &[u32], v_size: usize, v_out: &mut [u32]) {
         let mtf_size: usize = max_value.wrapping_add(1) as usize;
         for i in 0usize..v_size {
             let index: usize = IndexOf(&mtf[..], mtf_size, v_in[i] as u8);
-            0i32;
             v_out[i] = index as u32;
             MoveToFront(&mut mtf[..], index);
         }
@@ -1866,7 +1865,6 @@ fn RunLengthCodeZeros(
     *out_size = 0usize;
     i = 0usize;
     while i < in_size {
-        0i32;
         if v[i] != 0u32 {
             v[*out_size] = (v[i]).wrapping_add(*max_run_length_prefix);
             i = i.wrapping_add(1);

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -1117,7 +1117,6 @@ pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
     let initial_storage_ix: usize = *storage_ix;
     let table_bits: usize = Log2FloorNonZero(table_size as u64) as usize;
     if input_size == 0usize {
-        0i32;
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -114,12 +114,8 @@ fn EmitCopyLenLastDistance(copylen: usize, commands: &mut &mut [u32]) -> usize {
     }
 }
 fn HashBytesAtOffset(v: u64, offset: i32, shift: usize, length: usize) -> u32 {
-    0i32;
-    0i32;
-    {
-        let h: u64 = (v >> (8i32 * offset) << ((8 - length) * 8)).wrapping_mul(kHashMul32 as (u64));
-        (h >> shift) as u32
-    }
+    let h: u64 = (v >> (8i32 * offset) << ((8 - length) * 8)).wrapping_mul(kHashMul32 as (u64));
+    (h >> shift) as u32
 }
 
 fn EmitCopyLen(copylen: usize, commands: &mut &mut [u32]) -> usize {
@@ -198,7 +194,6 @@ fn CreateCommands(
             let mut skip: u32 = 32u32;
             let mut next_ip: usize = ip_index;
             let mut candidate: usize = 0;
-            0i32;
             loop {
                 {
                     'break3: loop {
@@ -207,7 +202,6 @@ fn CreateCommands(
                             let bytes_between_hash_lookups: u32 = skip >> 5;
                             skip = skip.wrapping_add(1);
                             ip_index = next_ip;
-                            0i32;
                             next_ip = ip_index.wrapping_add(bytes_between_hash_lookups as usize);
                             if next_ip > ip_limit {
                                 goto_emit_remainder = 1i32;
@@ -216,7 +210,6 @@ fn CreateCommands(
                                 }
                             }
                             next_hash = Hash(&base_ip[next_ip..], shift, min_match);
-                            0i32;
                             candidate = ip_index.wrapping_sub(last_distance as usize);
                             if IsMatch(&base_ip[ip_index..], &base_ip[candidate..], min_match)
                                 && candidate < ip_index
@@ -227,8 +220,6 @@ fn CreateCommands(
                                 }
                             }
                             candidate = table[(hash as usize)] as usize;
-                            0i32;
-                            0i32;
                             table[(hash as usize)] = ip_index.wrapping_sub(0) as i32;
                         }
                         if IsMatch(&base_ip[ip_index..], &base_ip[candidate..], min_match) {
@@ -256,7 +247,6 @@ fn CreateCommands(
                 let distance: i32 = base.wrapping_sub(candidate) as i32;
                 let insert: i32 = base.wrapping_sub(next_emit) as i32;
                 ip_index = ip_index.wrapping_add(matched);
-                0i32;
                 *num_commands += EmitInsertLen(insert as u32, commands);
                 (*literals)[..(insert as usize)]
                     .clone_from_slice(&base_ip[next_emit..(next_emit + insert as usize)]);
@@ -327,7 +317,6 @@ fn CreateCommands(
                 ));
                 ip_index = ip_index.wrapping_add(matched);
                 last_distance = base_index.wrapping_sub(candidate) as i32;
-                0i32;
                 *num_commands += EmitCopyLen(matched, commands);
                 *num_commands += EmitDistance(last_distance as u32, commands);
                 next_emit = ip_index;
@@ -384,7 +373,6 @@ fn CreateCommands(
             }
         }
     }
-    0i32;
     if next_emit < ip_end {
         let insert: u32 = ip_end.wrapping_sub(next_emit) as u32;
         *num_commands += EmitInsertLen(insert, commands);
@@ -575,7 +563,6 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
     while i < num_commands {
         {
             let code: u32 = commands[i] & 0xffu32;
-            0i32;
             {
                 let _rhs = 1;
                 let _lhs = &mut cmd_histo[code as usize];
@@ -615,7 +602,6 @@ fn StoreCommands<AllocHT: alloc::Allocator<HuffmanTree>>(
         let cmd: u32 = commands[i];
         let code: u32 = cmd & 0xffu32;
         let extra: u32 = cmd >> 8;
-        0i32;
         BrotliWriteBits(
             cmd_depths[code as usize] as usize,
             cmd_bits[code as usize] as (u64),

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1824,7 +1824,6 @@ fn ChooseContextMap(
     let total: usize = monogram_histo[0]
         .wrapping_add(monogram_histo[1])
         .wrapping_add(monogram_histo[2]) as usize;
-    0i32;
     entropy[0] = 1.0 as super::util::floatX / total as (super::util::floatX);
     {
         let _rhs = entropy[0];
@@ -2894,8 +2893,6 @@ fn BrotliEncoderCompressStreamFast<Alloc: BrotliAlloc>(
             *available_in = available_in.wrapping_sub(block_size);
             if inplace != 0 {
                 let out_bytes: usize = storage_ix >> 3;
-                0i32;
-                0i32;
                 *next_out_offset += out_bytes;
                 *available_out = available_out.wrapping_sub(out_bytes);
                 s.total_out_ = s.total_out_.wrapping_add(out_bytes as u64);

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -30,7 +30,6 @@ pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_d
     let mut stack: [i32; 16] = [0; 16];
     let mut level: i32 = 0i32;
     let mut p: i32 = p0;
-    0i32;
     stack[0] = -1i32;
     loop {
         if (pool[(p as usize)]).index_left_ as i32 >= 0i32 {
@@ -443,7 +442,6 @@ fn BrotliWriteHuffmanTreeRepetitions(
     tree: &mut [u8],
     extra_bits_data: &mut [u8],
 ) {
-    0i32;
     if previous_value as i32 != value as i32 {
         tree[*tree_size] = value;
         extra_bits_data[*tree_size] = 0u8;


### PR DESCRIPTION
Ran `cargo clippy -- -A clippy::all -W clippy::no_effect` and fixed them.

Mostly removing statements like `0i32;`