### PR TITLE
Use proper `self` instead of `xself`

### DIFF
--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -376,12 +376,12 @@ impl<'a> BackwardMatchMut<'a> {
     pub fn set_length_and_code(&mut self, data: u32) {
         *self.0 = u64::from((*self.0) as u32) | (u64::from(data) << 32);
     }
-}
 
-#[inline(always)]
-pub fn InitBackwardMatch(xself: &mut BackwardMatchMut, dist: usize, len: usize) {
-    xself.set_distance(dist as u32);
-    xself.set_length_and_code((len << 5) as u32);
+    #[inline(always)]
+    pub fn init_backward_match(&mut self, dist: usize, len: usize) {
+        self.set_distance(dist as u32);
+        self.set_length_and_code((len << 5) as u32);
+    }
 }
 
 macro_rules! LeftChildIndexH10 {
@@ -472,11 +472,8 @@ where
                 ));
                 if matches_offset != matches.len() && (len > *best_len) {
                     *best_len = len;
-                    InitBackwardMatch(
-                        &mut BackwardMatchMut(&mut matches[matches_offset]),
-                        backward,
-                        len,
-                    );
+                    BackwardMatchMut(&mut matches[matches_offset])
+                        .init_backward_match(backward, len);
                     matches_offset += 1;
                 }
                 if len >= max_comp_len {

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_imports)]
 use super::hash_to_binary_tree::{
-    kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, InitBackwardMatch,
-    StoreAndFindMatchesH10, Union1, ZopfliNode, H10,
+    kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, StoreAndFindMatchesH10,
+    Union1, ZopfliNode, H10,
 };
 use super::{
     kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
@@ -395,11 +395,8 @@ where
                     );
                     if len > best_len {
                         best_len = len;
-                        InitBackwardMatch(
-                            &mut BackwardMatchMut(&mut matches[matches_offset]),
-                            backward,
-                            len,
-                        );
+                        BackwardMatchMut(&mut matches[matches_offset])
+                            .init_backward_match(backward, len);
                         matches_offset += 1;
                     }
                 }


### PR DESCRIPTION
There are a lot of hacky `xself` that should use `self`.  This PR currently has only one minor change, but I would like to change all/most of them in the similar manner. Note that the usage here is a bit strange - a struct is created only to be discarded right after.

Note that since this is a breaking change, we should also rename the methods to conform to Rust naming standards... although I am not sure these should even be public - seems like an implementation detail that should be hidden

Are there any reasons to preserve `xself`?