### PR TITLE
Use proper `self` for Command and related

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -427,7 +427,7 @@ where
             );
             util::write_one(&tmp);
             for cmd in data.iter() {
-                util::write_one(&brotli::thaw_pair(cmd, &mb));
+                util::write_one(&cmd.thaw_pair(&mb));
             }
         };
     if params.log_meta_block {

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -9,8 +9,8 @@ use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use core;
 use core::cmp::{max, min};
 use enc::command::{
-    CombineLengthCodes, Command, CommandCopyLen, ComputeDistanceCode, GetCopyLengthCode,
-    GetInsertLengthCode, InitCommand, PrefixEncodeCopyDistance,
+    CombineLengthCodes, Command, ComputeDistanceCode, GetCopyLengthCode, GetInsertLengthCode,
+    PrefixEncodeCopyDistance,
 };
 use enc::constants::{kCopyExtra, kInsExtra};
 use enc::dictionary_hash::kStaticDictionaryHash;

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -12,8 +12,8 @@ use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use core;
 use core::cmp::{max, min};
 use enc::command::{
-    BrotliDistanceParams, CombineLengthCodes, Command, CommandCopyLen, ComputeDistanceCode,
-    GetCopyLengthCode, GetInsertLengthCode, InitCommand, PrefixEncodeCopyDistance,
+    BrotliDistanceParams, CombineLengthCodes, Command, ComputeDistanceCode, GetCopyLengthCode,
+    GetInsertLengthCode, PrefixEncodeCopyDistance,
 };
 use enc::constants::{kCopyExtra, kInsExtra};
 use enc::dictionary_hash::kStaticDictionaryHash;
@@ -137,8 +137,7 @@ pub fn BrotliZopfliCreateCommands(
                 let max_distance: usize = min(block_start.wrapping_add(pos), max_backward_limit);
                 let is_dictionary = distance > max_distance.wrapping_add(gap);
                 let dist_code: usize = next.distance_code() as usize;
-                InitCommand(
-                    &mut commands[i],
+                commands[i].init(
                     &params.dist,
                     insert_length,
                     copy_length,
@@ -1146,7 +1145,7 @@ impl<AllocF: Allocator<floatX>> ZopfliCostModel<AllocF> {
         while i < num_commands {
             {
                 let inslength: usize = (commands[i]).insert_len_ as usize;
-                let copylength: usize = CommandCopyLen(&commands[i]) as usize;
+                let copylength: usize = commands[i].copy_len() as usize;
                 let distcode: usize = (commands[i].dist_prefix_ as i32 & 0x03ff) as usize;
                 let cmdcode: usize = (commands[i]).cmd_prefix_ as usize;
                 {

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -5,7 +5,7 @@ pub mod hq;
 mod test;
 
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::command::{BrotliDistanceParams, Command, ComputeDistanceCode, InitCommand};
+use super::command::{BrotliDistanceParams, Command, ComputeDistanceCode};
 use super::dictionary_hash::kStaticDictionaryHash;
 use super::hash_to_binary_tree::{H10Buckets, H10DefaultParams, ZopfliNode, H10};
 use super::static_dict::BrotliDictionary;
@@ -2472,13 +2472,10 @@ fn CreateBackwardReferences<AH: AnyHasher>(
                     hasher.PrepareDistanceCache(dist_cache);
                 }
                 new_commands_count += 1;
-                InitCommand(
-                    {
-                        let (mut _old, new_commands) =
-                            core::mem::take(&mut commands).split_at_mut(1);
-                        commands = new_commands;
-                        &mut _old[0]
-                    },
+
+                let (old, new_commands) = core::mem::take(&mut commands).split_at_mut(1);
+                commands = new_commands;
+                old[0].init(
                     &params.dist,
                     insert_length,
                     sr.len,

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -124,10 +124,6 @@ fn CountLiterals(cmds: &[Command], num_commands: usize) -> usize {
     total_length
 }
 
-fn CommandCopyLen(xself: &Command) -> u32 {
-    xself.copy_len_ & 0x01ff_ffff
-}
-
 fn CopyLiteralsToByteArray(
     cmds: &[Command],
     num_commands: usize,
@@ -155,7 +151,7 @@ fn CopyLiteralsToByteArray(
         }
         from_pos = from_pos
             .wrapping_add(insert_len)
-            .wrapping_add(CommandCopyLen(&cmds[i]) as usize)
+            .wrapping_add(cmds[i].copy_len() as usize)
             & mask;
     }
 }
@@ -972,7 +968,7 @@ pub fn BrotliSplitBlock<
         let mut j: usize = 0usize;
         for i in 0usize..num_commands {
             let cmd = &cmds[i];
-            if CommandCopyLen(cmd) != 0 && (cmd.cmd_prefix_ as i32 >= 128i32) {
+            if cmd.copy_len() != 0 && cmd.cmd_prefix_ >= 128 {
                 distance_prefixes.slice_mut()[j] = cmd.dist_prefix_ & 0x03ff;
                 j = j.wrapping_add(1);
             }

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -3,7 +3,7 @@
 use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::block_split::BlockSplit;
-use super::command::{Command, CommandCopyLen, CommandDistanceContext};
+use super::command::Command;
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
 use super::vectorization::Mem256i;
 use core;
@@ -533,14 +533,14 @@ pub fn BrotliBuildHistogramsWithContext<'a, Alloc: alloc::Allocator<u8> + alloc:
             }
             j = j.wrapping_sub(1);
         }
-        pos = pos.wrapping_add(CommandCopyLen(cmd) as usize);
-        if CommandCopyLen(cmd) != 0 {
+        pos = pos.wrapping_add(cmd.copy_len() as usize);
+        if cmd.copy_len() != 0 {
             prev_byte2 = ringbuffer[(pos.wrapping_sub(2) & mask)];
             prev_byte = ringbuffer[(pos.wrapping_sub(1) & mask)];
             if cmd.cmd_prefix_ as i32 >= 128i32 {
                 BlockSplitIteratorNext(&mut dist_it);
                 let context: usize =
-                    (dist_it.type_ << 2).wrapping_add(CommandDistanceContext(cmd) as usize);
+                    (dist_it.type_ << 2).wrapping_add(cmd.distance_context() as usize);
                 HistogramAddItem(
                     &mut copy_dist_histograms[(context as usize)],
                     cmd.dist_prefix_ as usize & 0x3ff,

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -479,8 +479,8 @@ impl<SliceType: SliceWrapper<u8> + Default> Command<SliceType> {
         F: FnMut(SliceType),
     {
         match self {
-            &mut Command::Literal(ref mut lit) => apply_func(core::mem::take(&mut lit.data)),
-            &mut Command::PredictionMode(ref mut pm) => {
+            Command::Literal(ref mut lit) => apply_func(core::mem::take(&mut lit.data)),
+            Command::PredictionMode(ref mut pm) => {
                 apply_func(core::mem::take(&mut pm.literal_context_map));
                 apply_func(core::mem::take(
                     &mut pm.predmode_speed_and_distance_context_map,
@@ -669,58 +669,54 @@ pub trait CommandProcessor<'a> {
     }
 }
 
-pub fn thaw_pair<'a, SliceType: Unfreezable + SliceWrapper<u8>>(
-    xself: &Command<SliceType>,
-    data: &InputPair<'a>,
-) -> Command<InputReference<'a>> {
-    match *xself {
-        Command::Literal(ref lit) => Command::Literal(LiteralCommand {
-            data: lit.data.thaw_pair(data).unwrap(),
-            prob: FeatureFlagSliceType::default(),
-            high_entropy: lit.high_entropy,
-        }),
-        Command::PredictionMode(ref pm) => Command::PredictionMode(PredictionModeContextMap {
-            literal_context_map: pm.literal_context_map.thaw_pair(data).unwrap(),
-            predmode_speed_and_distance_context_map: pm
-                .predmode_speed_and_distance_context_map
-                .thaw_pair(data)
-                .unwrap(),
-        }),
-        Command::Dict(ref d) => Command::Dict(*d),
-        Command::Copy(ref c) => Command::Copy(*c),
-        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
-        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
-        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
+impl<SliceType: Unfreezable + SliceWrapper<u8>> Command<SliceType> {
+    pub fn thaw_pair<'a>(&self, data: &InputPair<'a>) -> Command<InputReference<'a>> {
+        match self {
+            Command::Literal(ref lit) => Command::Literal(LiteralCommand {
+                data: lit.data.thaw_pair(data).unwrap(),
+                prob: FeatureFlagSliceType::default(),
+                high_entropy: lit.high_entropy,
+            }),
+            Command::PredictionMode(ref pm) => Command::PredictionMode(PredictionModeContextMap {
+                literal_context_map: pm.literal_context_map.thaw_pair(data).unwrap(),
+                predmode_speed_and_distance_context_map: pm
+                    .predmode_speed_and_distance_context_map
+                    .thaw_pair(data)
+                    .unwrap(),
+            }),
+            Command::Dict(ref d) => Command::Dict(*d),
+            Command::Copy(ref c) => Command::Copy(*c),
+            Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
+            Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
+            Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
+        }
     }
-}
 
-pub fn thaw<'a, SliceType: Unfreezable + SliceWrapper<u8>>(
-    xself: &Command<SliceType>,
-    data: &'a [u8],
-) -> Command<InputReference<'a>> {
-    match *xself {
-        Command::Literal(ref lit) => Command::Literal(LiteralCommand {
-            data: lit.data.thaw(data),
-            prob: FeatureFlagSliceType::default(),
-            high_entropy: lit.high_entropy,
-        }),
-        Command::PredictionMode(ref pm) => Command::PredictionMode(PredictionModeContextMap {
-            literal_context_map: pm.literal_context_map.thaw(data),
-            predmode_speed_and_distance_context_map: pm
-                .predmode_speed_and_distance_context_map
-                .thaw(data),
-        }),
-        Command::Dict(ref d) => Command::Dict(*d),
-        Command::Copy(ref c) => Command::Copy(*c),
-        Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
-        Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
-        Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
+    pub fn thaw<'a>(&self, data: &'a [u8]) -> Command<InputReference<'a>> {
+        match self {
+            Command::Literal(ref lit) => Command::Literal(LiteralCommand {
+                data: lit.data.thaw(data),
+                prob: FeatureFlagSliceType::default(),
+                high_entropy: lit.high_entropy,
+            }),
+            Command::PredictionMode(ref pm) => Command::PredictionMode(PredictionModeContextMap {
+                literal_context_map: pm.literal_context_map.thaw(data),
+                predmode_speed_and_distance_context_map: pm
+                    .predmode_speed_and_distance_context_map
+                    .thaw(data),
+            }),
+            Command::Dict(ref d) => Command::Dict(*d),
+            Command::Copy(ref c) => Command::Copy(*c),
+            Command::BlockSwitchCommand(ref c) => Command::BlockSwitchCommand(*c),
+            Command::BlockSwitchLiteral(ref c) => Command::BlockSwitchLiteral(*c),
+            Command::BlockSwitchDistance(ref c) => Command::BlockSwitchDistance(*c),
+        }
     }
 }
 
 impl<SliceType: SliceWrapper<u8> + Freezable> Command<SliceType> {
     pub fn freeze(&self) -> Command<SliceOffset> {
-        match *self {
+        match self {
             Command::Literal(ref lit) => Command::Literal(LiteralCommand {
                 data: lit.data.freeze(),
                 prob: FeatureFlagSliceType::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,6 @@ pub use enc::input_pair::InputPair;
 pub use enc::input_pair::InputReference;
 pub use enc::input_pair::InputReferenceMut;
 pub use enc::interface;
-pub use enc::interface::thaw;
-pub use enc::interface::thaw_pair;
 pub use enc::interface::SliceOffset;
 #[cfg(feature = "ffi-api")]
 pub mod ffi;


### PR DESCRIPTION
`CommandDistanceContext` was consolidated because it had identical code

Use `hide whitespace changes` when reviewing