### PR TITLE
Use proper `self` for HuffmanTree, and rm init

### DIFF
--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -35,8 +35,7 @@ use super::constants::{
 use super::context_map_entropy::{speed_to_tuple, ContextMapEntropy, SpeedAndMax};
 use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, BrotliSetDepth,
-    BrotliWriteHuffmanTree, HuffmanComparator, HuffmanTree, InitHuffmanTree, NewHuffmanTree,
-    SortHuffmanTreeItems,
+    BrotliWriteHuffmanTree, HuffmanComparator, HuffmanTree, SortHuffmanTreeItems,
 };
 use super::find_stride;
 use super::histogram::{
@@ -1038,21 +1037,13 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                 l = length;
                 while l != 0 {
                     l = l.wrapping_sub(1);
-                    if histogram[(l as usize)] != 0 {
-                        if histogram[(l as usize)] >= count_limit {
-                            InitHuffmanTree(
-                                &mut tree.slice_mut()[(node_index as usize)],
-                                histogram[(l as usize)],
-                                -1i16,
-                                l as i16,
-                            );
+                    if histogram[l as usize] != 0 {
+                        if histogram[l as usize] >= count_limit {
+                            tree.slice_mut()[node_index as usize] =
+                                HuffmanTree::new(histogram[l as usize], -1, l as i16);
                         } else {
-                            InitHuffmanTree(
-                                &mut tree.slice_mut()[(node_index as usize)],
-                                count_limit,
-                                -1i16,
-                                l as i16,
-                            );
+                            tree.slice_mut()[node_index as usize] =
+                                HuffmanTree::new(count_limit, -1, l as i16);
                         }
                         node_index = node_index.wrapping_add(1);
                     }
@@ -1064,7 +1055,7 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
                     let mut j: i32 = n + 1i32;
                     let mut k: i32;
                     SortHuffmanTreeItems(tree.slice_mut(), n as usize, SimpleSortHuffmanTree {});
-                    let sentinel: HuffmanTree = NewHuffmanTree(!(0u32), -1i16, -1i16);
+                    let sentinel = HuffmanTree::new(u32::MAX, -1, -1);
                     tree.slice_mut()[(node_index.wrapping_add(1) as usize)] = sentinel;
                     tree.slice_mut()[(node_index as usize)] = sentinel;
                     node_index = node_index.wrapping_add(2);

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -12,7 +12,7 @@ use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHu
 use super::super::alloc;
 use super::compress_fragment_two_pass::{memcpy, BrotliStoreMetaBlockHeader, BrotliWriteBits};
 use super::entropy_encode::{
-    BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree, NewHuffmanTree,
+    BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree,
 };
 use super::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
@@ -584,7 +584,7 @@ fn BuildAndStoreCommandPrefixCode(
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
-    let mut tree: [HuffmanTree; 129] = [NewHuffmanTree(0, 0, 0); 129];
+    let mut tree = [HuffmanTree::new(0, 0, 0); 129];
     let mut cmd_depth: [u8; 704] = [0u8; 704];
 
     let mut cmd_bits: [u16; 64] = [0; 64];

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -5,7 +5,7 @@ use super::super::alloc;
 use super::bit_cost::BitsEntropy;
 use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 use super::entropy_encode::{
-    BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree, NewHuffmanTree,
+    BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree,
 };
 use super::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
@@ -466,7 +466,7 @@ fn BuildAndStoreCommandPrefixCode(
     storage_ix: &mut usize,
     storage: &mut [u8],
 ) {
-    let mut tree: [HuffmanTree; 129] = [NewHuffmanTree(0, 0, 0); 129];
+    let mut tree = [HuffmanTree::new(0, 0, 0); 129];
     let mut cmd_depth: [u8; 704] = [0; 704];
     let mut cmd_bits: [u16; 64] = [0; 64];
     BrotliCreateHuffmanTree(histogram, 64usize, 15i32, &mut tree[..], depth);

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -15,15 +15,14 @@ pub struct HuffmanTree {
     pub index_right_or_value_: i16,
 }
 
-pub fn NewHuffmanTree(count: u32, left: i16, right: i16) -> HuffmanTree {
-    HuffmanTree {
-        total_count_: count,
-        index_left_: left,
-        index_right_or_value_: right,
+impl HuffmanTree {
+    pub fn new(count: u32, left: i16, right: i16) -> Self {
+        Self {
+            total_count_: count,
+            index_left_: left,
+            index_right_or_value_: right,
+        }
     }
-}
-pub fn InitHuffmanTree(xself: &mut HuffmanTree, count: u32, left: i16, right: i16) {
-    *xself = NewHuffmanTree(count, left, right);
 }
 
 pub fn BrotliSetDepth(p0: i32, pool: &mut [HuffmanTree], depth: &mut [u8], max_depth: i32) -> bool {
@@ -152,14 +151,8 @@ pub fn BrotliCreateHuffmanTree(
     tree: &mut [HuffmanTree],
     depth: &mut [u8],
 ) {
-    let mut count_limit: u32;
-    let mut sentinel: HuffmanTree = HuffmanTree {
-        total_count_: 0,
-        index_left_: 0,
-        index_right_or_value_: 0,
-    };
-    InitHuffmanTree(&mut sentinel, !(0u32), -1i16, -1i16);
-    count_limit = 1u32;
+    let sentinel = HuffmanTree::new(u32::MAX, -1, -1);
+    let mut count_limit = 1u32;
     'break1: loop {
         {
             let mut n: usize = 0usize;
@@ -171,7 +164,7 @@ pub fn BrotliCreateHuffmanTree(
                 i = i.wrapping_sub(1);
                 if data[i] != 0 {
                     let count: u32 = brotli_max_uint32_t(data[i], count_limit);
-                    InitHuffmanTree(&mut tree[n], count, -1i16, i as i16);
+                    tree[n] = HuffmanTree::new(count, -1, i as i16);
                     n = n.wrapping_add(1);
                 }
             }


### PR DESCRIPTION
`HuffmanTree` is used as a copyable struct, and it seems there is never a need for `init` version of it (can simply be assigned where needed), so removed that.

Use `hide whitespace changes` when reviewing