### PR TITLE
Make hex numbers more readable

### DIFF
--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -16,21 +16,14 @@ use super::static_dict::{
 use super::util::{floatX, Log2FloorNonZero};
 use core::cmp::{max, min};
 
-static kBrotliMinWindowBits: i32 = 10i32;
-
-static kBrotliMaxWindowBits: i32 = 24i32;
-
-pub static kInvalidMatch: u32 = 0xfffffffu32;
-
-static kCutoffTransformsCount: u32 = 10u32;
-
-static kCutoffTransforms: u64 = 0x71b520au64 << 32 | 0xda2d3200u32 as (u64);
-
-pub static kHashMul32: u32 = 0x1e35a7bdu32;
-
-pub static kHashMul64: u64 = 0x1e35a7bdu64 << 32 | 0x1e35a7bdu64;
-
-pub static kHashMul64Long: u64 = 0x1fe35a7bu32 as (u64) << 32 | 0xd3579bd3u32 as (u64);
+static kBrotliMinWindowBits: i32 = 10;
+static kBrotliMaxWindowBits: i32 = 24;
+pub static kInvalidMatch: u32 = 0x0fff_ffff;
+static kCutoffTransformsCount: u32 = 10;
+static kCutoffTransforms: u64 = 0x071b_520a_da2d_3200;
+pub static kHashMul32: u32 = 0x1e35_a7bd;
+pub static kHashMul64: u64 = 0x1e35_a7bd_1e35_a7bd;
+pub static kHashMul64Long: u64 = 0x1fe3_5a7b_d357_9bd3;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[repr(C)]
@@ -946,8 +939,8 @@ impl AdvHashSpecialization for HQ5Sub {
     }
     #[inline(always)]
     fn get_hash_mask(&self) -> u64 {
-        //return 0xffffffffffffffffu64;
-        0xffffffffu64 // make it 32 bit
+        //return 0xffff_ffff_ffff_ffff;
+        0xffff_ffff // make it 32 bit
     }
     #[inline(always)]
     fn get_k_hash_mul(&self) -> u64 {
@@ -993,8 +986,8 @@ impl AdvHashSpecialization for HQ7Sub {
     }
     #[inline(always)]
     fn get_hash_mask(&self) -> u64 {
-        //return 0xffffffffffffffffu64;
-        0xffffffffu64 // make it 32 bit
+        //return 0xffff_ffff_ffff_ffff;
+        0xffff_ffff // make it 32 bit
     }
     #[inline(always)]
     fn get_k_hash_mul(&self) -> u64 {
@@ -1041,8 +1034,8 @@ impl AdvHashSpecialization for H5Sub {
         self.block_mask_
     }
     fn get_hash_mask(&self) -> u64 {
-        //return 0xffffffffffffffffu64;
-        0xffffffffu64 // make it 32 bit
+        //return 0xffff_ffff_ffff_ffff;
+        0xffff_ffff // make it 32 bit
     }
     fn get_k_hash_mul(&self) -> u64 {
         kHashMul32 as u64
@@ -1115,7 +1108,8 @@ impl AdvHashSpecialization for H6Sub {
 }
 
 fn BackwardReferencePenaltyUsingLastDistance(distance_short_code: usize) -> u64 {
-    (39u64).wrapping_add((0x1ca10u64 >> (distance_short_code & 0xeusize) & 0xeu64))
+    // FIXME?: double bitwise AND with the same value?
+    (39u64).wrapping_add((0x0001_ca10_u64 >> (distance_short_code & 0x0e) & 0x0e))
 }
 
 impl<
@@ -1146,7 +1140,7 @@ impl<
             let chunk_count = (ix_end - ix_start) / 4;
             for chunk_id in 0..chunk_count {
                 let i = (ix_start + chunk_id * 4) & mask;
-                let ffffffff = 0xffffffff;
+                let ffffffff = 0xffff_ffff;
                 let word = u64::from(data[i])
                     | (u64::from(data[i + 1]) << 8)
                     | (u64::from(data[i + 2]) << 16)
@@ -1229,7 +1223,7 @@ impl<
                 );
                 for quad_index in 0..(REG_SIZE >> 2) {
                     let i = quad_index << 2;
-                    let ffffffff = 0xffffffff;
+                    let ffffffff = 0xffff_ffff;
                     let word = u64::from(data64[i])
                         | (u64::from(data64[i + 1]) << 8)
                         | (u64::from(data64[i + 2]) << 16)
@@ -1311,7 +1305,7 @@ impl<
                     .clone_from_slice(data.split_at(ix_offset).1.split_at(REG_SIZE + lookahead4).0);
                 for quad_index in 0..(REG_SIZE >> 2) {
                     let i = quad_index << 2;
-                    let ffffffff = 0xffffffff;
+                    let ffffffff = 0xffff_ffff;
                     let word = u64::from(data64[i])
                         | (u64::from(data64[i + 1]) << 8)
                         | (u64::from(data64[i + 2]) << 16)
@@ -1505,13 +1499,13 @@ impl<
             | (u64::from(data[li + 7]) << 56);
         let hi = (ix + 8) & mask;
         let hword = u64::from(data[hi]) | (u64::from(data[hi + 1]) << 8);
-        let mixed0 = ((((lword & 0xffffffff) * self.specialization.get_k_hash_mul())
+        let mixed0 = ((((lword & 0xffff_ffff) * self.specialization.get_k_hash_mul())
             & self.specialization.get_hash_mask())
             >> shift) as usize;
-        let mixed1 = (((((lword >> 16) & 0xffffffff) * self.specialization.get_k_hash_mul())
+        let mixed1 = (((((lword >> 16) & 0xffff_ffff) * self.specialization.get_k_hash_mul())
             & self.specialization.get_hash_mask())
             >> shift) as usize;
-        let mixed2 = (((((lword >> 32) & 0xffffffff) * self.specialization.get_k_hash_mul())
+        let mixed2 = (((((lword >> 32) & 0xffff_ffff) * self.specialization.get_k_hash_mul())
             & self.specialization.get_hash_mask())
             >> shift) as usize;
         let mixed3 = ((((((hword & 0xffff) << 16) | ((lword >> 48) & 0xffff))

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -168,25 +168,25 @@ fn test_bulk_store_range_off_spec() {
     assert!(hasher_d == hasher_c);
     hasher_a.BulkStoreRange(
         RANDOM_THEN_UNICODE,
-        0xfff,
+        0x0fff,
         15,
         RANDOM_THEN_UNICODE.len() - 8,
     );
     hasher_c.BulkStoreRange(
         RANDOM_THEN_UNICODE,
-        0xfff,
+        0x0fff,
         15,
         RANDOM_THEN_UNICODE.len() - 8,
     );
     hasher_c.BulkStoreRange(
         RANDOM_THEN_UNICODE,
-        0xfff,
+        0x0fff,
         RANDOM_THEN_UNICODE.len(),
         RANDOM_THEN_UNICODE.len() - 8,
     ); // noop
     for i in 15..RANDOM_THEN_UNICODE.len() - 8 {
-        hasher_b.Store(RANDOM_THEN_UNICODE, 0xfff, i);
-        hasher_d.Store(RANDOM_THEN_UNICODE, 0xfff, i);
+        hasher_b.Store(RANDOM_THEN_UNICODE, 0x0fff, i);
+        hasher_d.Store(RANDOM_THEN_UNICODE, 0x0fff, i);
     }
     assert_eq!(hasher_a.buckets.slice(), hasher_c.buckets.slice());
     assert_eq!(hasher_b.buckets.slice(), hasher_d.buckets.slice());

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -125,7 +125,7 @@ fn CountLiterals(cmds: &[Command], num_commands: usize) -> usize {
 }
 
 fn CommandCopyLen(xself: &Command) -> u32 {
-    xself.copy_len_ & 0x1ffffffu32
+    xself.copy_len_ & 0x01ff_ffff
 }
 
 fn CopyLiteralsToByteArray(
@@ -973,7 +973,7 @@ pub fn BrotliSplitBlock<
         for i in 0usize..num_commands {
             let cmd = &cmds[i];
             if CommandCopyLen(cmd) != 0 && (cmd.cmd_prefix_ as i32 >= 128i32) {
-                distance_prefixes.slice_mut()[j] = cmd.dist_prefix_ & 0x3ff;
+                distance_prefixes.slice_mut()[j] = cmd.dist_prefix_ & 0x03ff;
                 j = j.wrapping_add(1);
             }
         }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -962,12 +962,7 @@ pub fn BrotliStoreHuffmanTree(
 }
 
 fn StoreStaticCodeLengthCode(storage_ix: &mut usize, storage: &mut [u8]) {
-    BrotliWriteBits(
-        40,
-        0xffu32 as (u64) << 32 | 0x55555554u32 as (u64),
-        storage_ix,
-        storage,
-    );
+    BrotliWriteBits(40, 0xff_5555_5554, storage_ix, storage);
 }
 
 pub struct SimpleSortHuffmanTree {}
@@ -1998,7 +1993,7 @@ impl Command {
     fn copy_len_code(&self) -> u32 {
         let modifier = self.copy_len_ >> 25;
         let delta: i32 = ((modifier | ((modifier & 0x40) << 1)) as u8) as i8 as i32;
-        ((self.copy_len_ & 0x1ffffff) as i32 + delta) as u32
+        ((self.copy_len_ & 0x01ff_ffff) as i32 + delta) as u32
     }
 }
 
@@ -2095,7 +2090,7 @@ impl<Alloc: Allocator<u8> + Allocator<u16>> BlockEncoder<'_, Alloc> {
 }
 
 fn CommandCopyLen(xself: &Command) -> u32 {
-    xself.copy_len_ & 0x1ffffffu32
+    xself.copy_len_ & 0x01ff_ffff
 }
 
 fn CommandDistanceContext(xself: &Command) -> u32 {
@@ -2325,7 +2320,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
             prev_byte2 = input[(pos.wrapping_sub(2) & mask)];
             prev_byte = input[(pos.wrapping_sub(1) & mask)];
             if cmd.cmd_prefix_ as i32 >= 128i32 {
-                let dist_code: usize = cmd.dist_prefix_ as usize & 0x3ff;
+                let dist_code: usize = cmd.dist_prefix_ as usize & 0x03ff;
                 let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10; //FIXME: from command
                 let distextra: u64 = cmd.dist_extra_ as (u64);
                 if mb.distance_context_map_size == 0usize {
@@ -2378,7 +2373,7 @@ fn BuildHistograms(
         }
         pos = pos.wrapping_add(CommandCopyLen(&cmd) as usize);
         if CommandCopyLen(&cmd) != 0 && (cmd.cmd_prefix_ as i32 >= 128i32) {
-            HistogramAddItem(dist_histo, cmd.dist_prefix_ as usize & 0x3ff);
+            HistogramAddItem(dist_histo, cmd.dist_prefix_ as usize & 0x03ff);
         }
     }
 }
@@ -2425,7 +2420,7 @@ fn StoreDataWithHuffmanCodes(
         }
         pos = pos.wrapping_add(CommandCopyLen(&cmd) as usize);
         if CommandCopyLen(&cmd) != 0 && (cmd.cmd_prefix_ as i32 >= 128i32) {
-            let dist_code: usize = cmd.dist_prefix_ as usize & 0x3ff;
+            let dist_code: usize = cmd.dist_prefix_ as usize & 0x03ff;
             let distnumextra: u32 = u32::from(cmd.dist_prefix_) >> 10;
             let distextra: u32 = cmd.dist_extra_;
             BrotliWriteBits(
@@ -2559,17 +2554,12 @@ pub fn BrotliStoreMetaBlockTrivial<Alloc: BrotliAlloc, Cb>(
 }
 
 fn StoreStaticCommandHuffmanTree(storage_ix: &mut usize, storage: &mut [u8]) {
-    BrotliWriteBits(
-        56,
-        0x926244u32 as (u64) << 32 | 0x16307003,
-        storage_ix,
-        storage,
-    );
-    BrotliWriteBits(3, 0x0u64, storage_ix, storage);
+    BrotliWriteBits(56, 0x0092_6244_1630_7003, storage_ix, storage);
+    BrotliWriteBits(3, 0, storage_ix, storage);
 }
 
 fn StoreStaticDistanceHuffmanTree(storage_ix: &mut usize, storage: &mut [u8]) {
-    BrotliWriteBits(28, 0x369dc03u64, storage_ix, storage);
+    BrotliWriteBits(28, 0x0369_dc03, storage_ix, storage);
 }
 
 struct BlockSplitRef<'a> {

--- a/src/enc/command.rs
+++ b/src/enc/command.rs
@@ -21,7 +21,7 @@ pub struct Command {
 }
 
 pub fn CommandCopyLen(xself: &Command) -> u32 {
-    xself.copy_len_ & 0x1ffffffu32
+    xself.copy_len_ & 0x01ff_ffff
 }
 
 pub fn CommandDistanceContext(xself: &Command) -> u32 {
@@ -45,9 +45,9 @@ pub fn ComputeDistanceCode(distance: usize, max_distance: usize, dist_cache: &[i
         } else if distance == dist_cache[1] as usize {
             return 1;
         } else if offset0 < 7usize {
-            return (0x9750468i32 >> (4usize).wrapping_mul(offset0) & 0xfi32) as usize;
+            return (0x0975_0468_i32 >> (4usize).wrapping_mul(offset0) & 0xfi32) as usize;
         } else if offset1 < 7usize {
-            return (0xfdb1acei32 >> (4usize).wrapping_mul(offset1) & 0xfi32) as usize;
+            return (0x0fdb_1ace_i32 >> (4usize).wrapping_mul(offset1) & 0xfi32) as usize;
         } else if distance == dist_cache[2] as usize {
             return 2usize;
         } else if distance == dist_cache[3] as usize {

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -359,8 +359,8 @@ pub const BROTLI_LARGE_MAX_WBITS: u32 = 30;
 
 pub const BROTLI_MAX_DISTANCE_BITS: u32 = 24;
 pub const BROTLI_MAX_WINDOW_BITS: usize = BROTLI_MAX_DISTANCE_BITS as usize;
-pub const BROTLI_MAX_DISTANCE: usize = 0x3FFFFFC;
-pub const BROTLI_MAX_ALLOWED_DISTANCE: usize = 0x7FFFFFC;
+pub const BROTLI_MAX_DISTANCE: usize = 0x03ff_fffc;
+pub const BROTLI_MAX_ALLOWED_DISTANCE: usize = 0x07ff_fffc;
 pub const BROTLI_NUM_DISTANCE_SHORT_CODES: u32 = 16;
 pub fn BROTLI_DISTANCE_ALPHABET_SIZE(NPOSTFIX: u32, NDIRECT: u32, MAXNBITS: u32) -> u32 {
     BROTLI_NUM_DISTANCE_SHORT_CODES + (NDIRECT) + ((MAXNBITS) << ((NPOSTFIX) + 1))
@@ -417,7 +417,7 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
 
         let mask = self.ringbuffer_.mask_;
         let max_backward_distance: u64 = (1u64 << self.params.lgwin) - BROTLI_WINDOW_GAP as u64;
-        let last_copy_len = u64::from(last_command.copy_len_) & 0x1ffffff;
+        let last_copy_len = u64::from(last_command.copy_len_) & 0x01ff_ffff;
         let last_processed_pos: u64 = self.last_processed_pos_ - last_copy_len;
         let max_distance: u64 = if last_processed_pos < max_backward_distance {
             last_processed_pos
@@ -447,9 +447,9 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
             /* The copy length is at most the metablock size, and thus expressible. */
             GetLengthCode(
                 last_command.insert_len_ as usize,
-                ((last_command.copy_len_ & 0x1FFFFFF) as i32
+                ((last_command.copy_len_ & 0x01ff_ffff) as i32
                     + (last_command.copy_len_ >> 25) as i32) as usize,
-                ((last_command.dist_prefix_ & 0x3FF) == 0) as i32,
+                ((last_command.dist_prefix_ & 0x03ff) == 0) as i32,
                 &mut last_command.cmd_prefix_,
             );
         }
@@ -3100,7 +3100,7 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
 }
 
 pub fn BrotliEncoderVersion() -> u32 {
-    0x1000f01u32
+    0x0100_0f01
 }
 
 impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {

--- a/src/enc/entropy_encode.rs
+++ b/src/enc/entropy_encode.rs
@@ -430,7 +430,7 @@ fn BrotliWriteHuffmanTreeRepetitions(
         repetitions = repetitions.wrapping_sub(3);
         loop {
             tree[*tree_size] = 16u8;
-            extra_bits_data[*tree_size] = (repetitions & 0x3usize) as u8;
+            extra_bits_data[*tree_size] = (repetitions & 0x03) as u8;
             *tree_size = tree_size.wrapping_add(1);
             repetitions >>= 2i32;
             if repetitions == 0usize {

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -605,7 +605,7 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyPyramid<AllocU32> {
                     .split_at(input.len() >> 3)
                     .1,
                 scratch,
-                0xa,
+                0x0a,
                 Some(5..7),
                 Some(7..0xa),
             );

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -16,7 +16,7 @@ impl<'a> SliceWrapper<u8> for InputReference<'a> {
 
 impl<'a> Freezable for InputReference<'a> {
     fn freeze(&self) -> super::interface::SliceOffset {
-        debug_assert!(self.data.len() <= 0xffffffff);
+        debug_assert!(self.data.len() <= 0xffff_ffff);
         super::interface::SliceOffset(self.orig_offset, self.data.len() as u32)
     }
 }

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -572,7 +572,7 @@ pub trait Unfreezable {
 
 impl<'a> From<InputReference<'a>> for SliceOffset {
     fn from(f: InputReference<'a>) -> Self {
-        debug_assert!(f.data.len() <= 0xffffffff);
+        debug_assert!(f.data.len() <= 0xffff_ffff);
         SliceOffset(f.orig_offset, f.data.len() as u32)
     }
 }
@@ -759,7 +759,7 @@ pub fn u8_to_speed(data: u8) -> u16 {
         0
     } else {
         let log_val = (data >> 3) - 1;
-        let rem = (u16::from(data) & 0x7) << log_val;
+        let rem = (u16::from(data) & 0x07) << log_val;
         (1u16 << log_val) | (rem >> 3)
     }
 }

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -106,7 +106,7 @@ fn compute_huffman_table_index_for_context_map(
 
 pub fn Context(p1: u8, p2: u8, mode: ContextType) -> u8 {
     match mode {
-        ContextType::CONTEXT_LSB6 => (p1 as i32 & 0x3fi32) as u8,
+        ContextType::CONTEXT_LSB6 => p1 & 0x3f,
         ContextType::CONTEXT_MSB6 => (p1 as i32 >> 2) as u8,
         ContextType::CONTEXT_UTF8 => {
             (kUTF8ContextLookup[p1 as usize] as i32

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -122,7 +122,7 @@ fn ComputeDistanceCost(
                     &mut dist_extra,
                 );
             }
-            HistogramAddItem(&mut histo, (dist_prefix & 0x3FF) as usize);
+            HistogramAddItem(&mut histo, (dist_prefix & 0x03ff) as usize);
             extra_bits += (dist_prefix >> 10) as f64;
         }
     }

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -108,7 +108,7 @@ fn stride_lookup_lin(
     high_nibble: Option<u8>,
 ) -> usize {
     if let Some(nibble) = high_nibble {
-        1 + 2 * (actual_context | ((stride_byte as usize & 0xf) << 8) | ((nibble as usize) << 12))
+        1 + 2 * (actual_context | ((stride_byte as usize & 0x0f) << 8) | ((nibble as usize) << 12))
     } else {
         2 * (actual_context | ((stride_byte as usize) << 8))
     }

--- a/src/enc/static_dict_lut.rs
+++ b/src/enc/static_dict_lut.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
-pub static kInvalidMatch: u32 = 0xfffffff;
+pub static kInvalidMatch: u32 = 0x0fff_ffff;
 
 pub static kDictNumBits: i32 = 15;
 
-pub static kDictHashMul32: u32 = 0x1e35a7bd;
+pub static kDictHashMul32: u32 = 0x1e35_a7bd;
 pub static kStaticDictionaryBuckets: [u16; 32768] = [
     1, 0, 0, 0, 0, 0, 0, 0, 0, 3, 6, 0, 0, 0, 0, 0, 20, 0, 0, 0, 21, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0,
     23, 0, 0, 25, 0, 29, 0, 53, 0, 0, 0, 0, 0, 0, 55, 0, 0, 0, 0, 0, 0, 61, 76, 0, 0, 0, 94, 0, 0,

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -12,7 +12,7 @@ pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * NIBBLE_PRIOR_SIZE * 2;
 
 pub fn local_init_cdfs(cdfs: &mut [u16]) {
     for (index, item) in cdfs.iter_mut().enumerate() {
-        *item = 4 + 4 * (index as u16 & 0xf);
+        *item = 4 + 4 * (index as u16 & 0x0f);
     }
 }
 #[allow(unused_variables)]

--- a/src/enc/utf8_util.rs
+++ b/src/enc/utf8_util.rs
@@ -2,7 +2,7 @@
 static kMinUTF8Ratio: super::util::floatX = 0.75 as super::util::floatX;
 
 fn BrotliParseAsUTF8(symbol: &mut i32, input: &[u8], size: usize) -> usize {
-    if input[0] as i32 & 0x80i32 == 0i32 {
+    if input[0] & 0x80 == 0 {
         *symbol = input[0] as i32;
         if *symbol > 0i32 {
             return 1usize;

--- a/src/enc/weights.rs
+++ b/src/enc/weights.rs
@@ -81,7 +81,7 @@ fn fix_weights(weights: &mut [i32; 2]) {
 #[allow(dead_code)]
 #[inline(always)]
 fn normalize_weights(weights: &mut [i32; 2]) {
-    if ((weights[0] | weights[1]) & 0x7f000000) != 0 {
+    if ((weights[0] | weights[1]) & 0x7f00_0000) != 0 {
         fix_weights(weights);
     }
 }


### PR DESCRIPTION
When a hex number is used with bit operations, it tends to be less readable as it gets longer.  Hex numbers should have each 4 digits separated by a `_`, and separate from the type - so that we can easily see if the number group has 3 or 4 digits.

In some cases I also removed the type qualifier - as it is auto-detected and not needed.