### PR TITLE
Auto-format `use` statements

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -15,6 +15,9 @@ extern crate sha2;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc_no_stdlib;
+use core::cmp::{max, min};
+use core::ops;
+
 #[allow(unused_imports)]
 use alloc_no_stdlib::{
     bzero, AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator,
@@ -30,11 +33,8 @@ use brotli::enc::{
 use brotli::CustomRead;
 #[allow(unused_imports)]
 use brotli::HuffmanCode;
-use core::cmp::{max, min};
-use core::ops;
 mod validate;
 use std::env;
-
 use std::fs::File;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 

--- a/src/bin/catbrotli.rs
+++ b/src/bin/catbrotli.rs
@@ -1,10 +1,9 @@
 extern crate brotli;
 extern crate core;
-use std::env;
 use std::fs::File;
-use std::io;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::{env, io};
 
 use brotli::concat::{BroCatli, BroCatliResult};
 fn usage() {

--- a/src/bin/integration_tests.rs
+++ b/src/bin/integration_tests.rs
@@ -3,17 +3,6 @@
 #![allow(dead_code)]
 extern crate brotli_decompressor;
 extern crate core;
-#[allow(unused_imports)]
-use super::alloc_no_stdlib::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::brotli::BrotliResult;
-use super::brotli::BrotliState;
-#[cfg(feature = "std")]
-use super::brotli::{CompressorReader, CompressorWriter};
-#[cfg(feature = "std")]
-use super::brotli_decompressor::{Decompressor, DecompressorWriter};
-use super::HeapAllocator;
-use super::Rebox;
-use brotli::BrotliDecompressStream;
 use core::cmp::min;
 use std::io;
 #[cfg(feature = "std")]
@@ -21,6 +10,17 @@ use std::io::{Read, Write};
 use std::time::Duration;
 #[cfg(not(feature = "disable-timer"))]
 use std::time::SystemTime;
+
+use brotli::BrotliDecompressStream;
+
+#[allow(unused_imports)]
+use super::alloc_no_stdlib::{Allocator, SliceWrapper, SliceWrapperMut};
+use super::brotli::{BrotliResult, BrotliState};
+#[cfg(feature = "std")]
+use super::brotli::{CompressorReader, CompressorWriter};
+#[cfg(feature = "std")]
+use super::brotli_decompressor::{Decompressor, DecompressorWriter};
+use super::{HeapAllocator, Rebox};
 
 #[cfg(feature = "benchmark")]
 extern crate test;

--- a/src/bin/test_broccoli.rs
+++ b/src/bin/test_broccoli.rs
@@ -3,11 +3,13 @@
 #![allow(dead_code)]
 extern crate brotli_decompressor;
 extern crate core;
+use core::cmp::{max, min};
+
+use brotli_decompressor::{CustomRead, CustomWrite};
+
 use super::brotli::concat::{BroCatli, BroCatliResult};
 use super::brotli::enc::BrotliEncoderParams;
 use super::integration_tests::UnlimitedBuffer;
-use brotli_decompressor::{CustomRead, CustomWrite};
-use core::cmp::{max, min};
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
 static UKKONOOA: &[u8] = include_bytes!("../../testdata/ukkonooa");

--- a/src/bin/test_custom_dict.rs
+++ b/src/bin/test_custom_dict.rs
@@ -3,10 +3,11 @@
 #![allow(dead_code)]
 extern crate brotli_decompressor;
 extern crate core;
+use std::io::{Read, Write};
+
 use super::brotli::concat::{BroCatli, BroCatliResult};
 use super::brotli::enc::BrotliEncoderParams;
 use super::integration_tests::UnlimitedBuffer;
-use std::io::{Read, Write};
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
 use super::Rebox;

--- a/src/bin/test_threading.rs
+++ b/src/bin/test_threading.rs
@@ -3,15 +3,15 @@
 #![allow(dead_code)]
 extern crate brotli_decompressor;
 extern crate core;
+use brotli::enc::threading::{Owned, SendAlloc};
+use brotli_decompressor::{SliceWrapper, SliceWrapperMut};
+
 use super::brotli::enc::{
     compress_multi, compress_multi_no_threadpool, BrotliEncoderMaxCompressedSizeMulti,
     BrotliEncoderParams, UnionHasher,
 };
-use super::new_brotli_heap_alloc;
-use brotli::enc::threading::{Owned, SendAlloc};
-use brotli_decompressor::{SliceWrapper, SliceWrapperMut};
-
 use super::integration_tests::UnlimitedBuffer;
+use super::new_brotli_heap_alloc;
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../testdata/random_then_unicode");
 static ALICE: &[u8] = include_bytes!("../../testdata/alice29.txt");
 use super::Rebox;

--- a/src/bin/util.rs
+++ b/src/bin/util.rs
@@ -1,5 +1,7 @@
 use core::marker::PhantomData;
 use core::mem;
+use std::collections::BTreeMap;
+use std::fmt;
 use std::thread::JoinHandle;
 
 use alloc_no_stdlib::{Allocator, SliceWrapper};
@@ -13,8 +15,6 @@ use brotli::enc::threading::{
 use brotli::enc::BrotliAlloc;
 use brotli::interface;
 use brotli::transform::TransformDictionaryWord;
-use std::collections::BTreeMap;
-use std::fmt;
 
 struct HexSlice<'a>(&'a [u8]);
 

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -1,12 +1,14 @@
-use super::{HeapAllocator, IoWriterWrapper, Rebox};
+#[cfg(feature = "validation")]
+use core;
+use std::io::{self, Error, ErrorKind, Read, Write};
+
 use alloc_no_stdlib::{Allocator, SliceWrapper};
 use brotli::enc::BrotliEncoderParams;
 use brotli::{CustomWrite, DecompressorWriterCustomIo};
 #[cfg(feature = "validation")]
-use core;
-#[cfg(feature = "validation")]
 use sha2::{Digest, Sha256};
-use std::io::{self, Error, ErrorKind, Read, Write};
+
+use super::{HeapAllocator, IoWriterWrapper, Rebox};
 #[cfg(feature = "validation")]
 type Checksum = Sha256;
 

--- a/src/enc/backward_references/benchmark.rs
+++ b/src/enc/backward_references/benchmark.rs
@@ -1,8 +1,9 @@
 #![cfg(feature = "benchmark")]
 #![cfg(feature = "std")]
 extern crate test;
-use super::*;
 use alloc_stdlib::StandardAlloc;
+
+use super::*;
 static RANDOM_THEN_UNICODE: &'static [u8] = include_bytes!("../../../testdata/random_then_unicode");
 static FINALIZE_DATA: &'static [u8] = &[
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -1,13 +1,7 @@
 #![allow(dead_code, unused_imports)]
-use super::{
-    kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
-    kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams, CloneWithAlloc, H9Opts,
-    HasherSearchResult, HowPrepared, Struct1,
-};
-use alloc;
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
 use core::cmp::{max, min};
+
 use enc::command::{
     CombineLengthCodes, Command, ComputeDistanceCode, GetCopyLengthCode, GetInsertLengthCode,
     PrefixEncodeCopyDistance,
@@ -17,11 +11,16 @@ use enc::dictionary_hash::kStaticDictionaryHash;
 use enc::literal_cost::BrotliEstimateBitCostsForLiterals;
 use enc::static_dict::{
     kBrotliEncDictionary, BrotliDictionary, BrotliFindAllStaticDictionaryMatches,
-};
-use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use enc::util::{floatX, FastLog2, Log2FloorNonZero};
+use {alloc, core};
+
+use super::{
+    kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
+    kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams, CloneWithAlloc, H9Opts,
+    HasherSearchResult, HowPrepared, Struct1,
+};
 
 pub const kInfinity: floatX = 1.7e38 as floatX;
 #[derive(Clone, Copy, Debug)]

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -1,16 +1,7 @@
 #![allow(dead_code, unused_imports)]
-use super::hash_to_binary_tree::{
-    kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, StoreAndFindMatchesH10,
-    Union1, ZopfliNode, H10,
-};
-use super::{
-    kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
-    kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams,
-};
-use alloc;
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core;
 use core::cmp::{max, min};
+
 use enc::command::{
     BrotliDistanceParams, CombineLengthCodes, Command, ComputeDistanceCode, GetCopyLengthCode,
     GetInsertLengthCode, PrefixEncodeCopyDistance,
@@ -21,11 +12,19 @@ use enc::encode;
 use enc::literal_cost::BrotliEstimateBitCostsForLiterals;
 use enc::static_dict::{
     kBrotliEncDictionary, BrotliDictionary, BrotliFindAllStaticDictionaryMatches,
-};
-use enc::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use enc::util::{floatX, FastLog2, FastLog2f64, Log2FloorNonZero};
+use {alloc, core};
+
+use super::hash_to_binary_tree::{
+    kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, StoreAndFindMatchesH10,
+    Union1, ZopfliNode, H10,
+};
+use super::{
+    kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kHashMul64, kHashMul64Long,
+    kInvalidMatch, AnyHasher, BrotliEncoderParams, BrotliHasherParams,
+};
 
 const BROTLI_WINDOW_GAP: usize = 16;
 const BROTLI_MAX_STATIC_DICTIONARY_MATCH_LEN: usize = 37;

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -4,17 +4,17 @@ pub mod hash_to_binary_tree;
 pub mod hq;
 mod test;
 
+use core::cmp::{max, min};
+
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::command::{BrotliDistanceParams, Command, ComputeDistanceCode};
 use super::dictionary_hash::kStaticDictionaryHash;
 use super::hash_to_binary_tree::{H10Buckets, H10DefaultParams, ZopfliNode, H10};
-use super::static_dict::BrotliDictionary;
 use super::static_dict::{
-    FindMatchLengthWithLimit, FindMatchLengthWithLimitMin4, BROTLI_UNALIGNED_LOAD32,
-    BROTLI_UNALIGNED_LOAD64,
+    BrotliDictionary, FindMatchLengthWithLimit, FindMatchLengthWithLimitMin4,
+    BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use super::util::{floatX, Log2FloorNonZero};
-use core::cmp::{max, min};
 
 static kBrotliMinWindowBits: i32 = 10;
 static kBrotliMaxWindowBits: i32 = 24;

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "std")]
 #![cfg(test)]
+use alloc_stdlib::StandardAlloc;
+use enc::{Allocator, SliceWrapper};
+
 use super::{
     AdvHasher, AnyHasher, BrotliHasherParams, CloneWithAlloc, H5Sub, H9Opts, HQ7Sub, Struct1,
 };
-use alloc_stdlib::StandardAlloc;
-use enc::{Allocator, SliceWrapper};
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
 #[cfg(feature = "std")]
 #[test]

--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
-use super::super::alloc::SliceWrapper;
-use super::histogram::CostAccessors;
 use core::cmp::{max, min};
 
+use super::super::alloc::SliceWrapper;
+use super::histogram::CostAccessors;
 use super::util::{FastLog2, FastLog2u16};
 use super::vectorization::Mem256i;
 

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
-use super::super::alloc::Allocator;
-use super::super::alloc::SliceWrapper;
+use super::super::alloc::{Allocator, SliceWrapper};
 
 pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub num_types: usize,

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
-use super::backward_references::BrotliEncoderParams;
-use super::vectorization::{sum8i, v256, v256i, Mem256f};
+use core::cmp::{max, min};
+#[cfg(feature = "simd")]
+use core::simd::prelude::{SimdFloat, SimdPartialOrd};
 
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use super::backward_references::BrotliEncoderParams;
 use super::bit_cost::BrotliPopulationCost;
 use super::block_split::BlockSplit;
 use super::cluster::{BrotliHistogramBitCostDistance, BrotliHistogramCombine, HistogramPair};
@@ -12,9 +14,7 @@ use super::histogram::{
     HistogramClear, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
 use super::util::FastLog2;
-use core::cmp::{max, min};
-#[cfg(feature = "simd")]
-use core::simd::prelude::{SimdFloat, SimdPartialOrd};
+use super::vectorization::{sum8i, v256, v256i, Mem256f};
 
 static kMaxLiteralHistograms: usize = 100usize;
 

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -2,26 +2,21 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_macros)]
-use super::combined_alloc::BrotliAlloc;
-use super::prior_eval;
-use super::stride_eval;
-use super::util::floatX;
-use super::{s16, v8};
+use core::cmp::{max, min};
 #[cfg(feature = "std")]
 use std::io::Write;
+
+use enc::backward_references::BrotliEncoderParams;
 use VERSION;
 
-use super::block_split::BlockSplit;
-use super::input_pair::{InputPair, InputReference, InputReferenceMut};
-use enc::backward_references::BrotliEncoderParams;
-
-use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::super::core;
 use super::super::dictionary::{
     kBrotliDictionary, kBrotliDictionaryOffsetsByLength, kBrotliDictionarySizeBitsByLength,
 };
 use super::super::transform::TransformDictionaryWord;
+use super::super::{alloc, core};
+use super::block_split::BlockSplit;
+use super::combined_alloc::BrotliAlloc;
 use super::command::{Command, GetCopyLengthCode, GetInsertLengthCode};
 use super::constants::{
     kCodeLengthBits, kCodeLengthDepth, kCopyBase, kCopyExtra, kInsBase, kInsExtra,
@@ -35,16 +30,16 @@ use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, BrotliSetDepth,
     BrotliWriteHuffmanTree, HuffmanComparator, HuffmanTree, SortHuffmanTreeItems,
 };
-use super::find_stride;
 use super::histogram::{
     ContextType, HistogramAddItem, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
-use super::interface;
+use super::input_pair::{InputPair, InputReference, InputReferenceMut};
 use super::interface::{CommandProcessor, StaticCommand};
 use super::pdf::PDF;
 use super::static_dict::kNumDistanceCacheEntries;
+use super::util::floatX;
 use super::vectorization::Mem256f;
-use core::cmp::{max, min};
+use super::{find_stride, interface, prior_eval, s16, stride_eval, v8};
 pub struct PrefixCodeRange {
     pub offset: u32,
     pub nbits: u32,

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core::cmp::min;
+
 use super::bit_cost::BrotliPopulationCost;
 use super::histogram::{
     CostAccessors, HistogramAddHistogram, HistogramClear, HistogramSelfAddHistogram,
 };
 use super::util::FastLog2;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use core::cmp::min;
 #[derive(Clone, Copy)]
 pub struct HistogramPair {
     pub idx1: u32,

--- a/src/enc/combined_alloc.rs
+++ b/src/enc/combined_alloc.rs
@@ -1,17 +1,16 @@
-use super::cluster::HistogramPair;
-use super::command::Command;
-use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
-use super::interface::StaticCommand;
-use super::s16;
-use super::util::floatX;
-use super::v8;
-use super::PDF;
 pub use alloc::Allocator;
 
-use super::entropy_encode::HuffmanTree;
-use super::hash_to_binary_tree::ZopfliNode;
 #[cfg(feature = "std")]
 use alloc_stdlib::StandardAlloc;
+
+use super::cluster::HistogramPair;
+use super::command::Command;
+use super::entropy_encode::HuffmanTree;
+use super::hash_to_binary_tree::ZopfliNode;
+use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
+use super::interface::StaticCommand;
+use super::util::floatX;
+use super::{s16, v8, PDF};
 /*
 struct CombiningAllocator<T1, T2, AllocT1:Allocator<T1>, AllocT2:Allocator<T2>>(AllocT1, AllocT2);
 

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
+use core::cmp::min;
+
 use super::backward_references::kHashMul32;
 //use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-
 use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
 //caution: lots of the functions look structurally the same as two_pass,
 // but have subtle index differences
@@ -17,7 +18,6 @@ use super::static_dict::{
     FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use super::util::{FastLog2, Log2FloorNonZero};
-use core::cmp::min;
 
 //static kHashMul32: u32 = 0x1e35a7bdu32;
 

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+use core::cmp::min;
+
 use super::backward_references::kHashMul32;
 use super::bit_cost::BitsEntropy;
 use super::brotli_bit_stream::{BrotliBuildAndStoreHuffmanTreeFast, BrotliStoreHuffmanTree};
@@ -10,7 +12,6 @@ use super::static_dict::{
     BROTLI_UNALIGNED_STORE64,
 };
 use super::util::Log2FloorNonZero;
-use core::cmp::min;
 static kCompressFragmentTwoPassBlockSize: usize = (1i32 << 17) as usize;
 
 // returns number of commands inserted

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -1,10 +1,9 @@
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::find_stride;
 use super::input_pair::{InputPair, InputReference, InputReferenceMut};
-use super::interface;
 pub use super::ir_interpret::{push_base, Context, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::weights::{Weights, BLEND_FIXED_POINT_PRECISION};
+use super::{find_stride, interface};
 
 const DEFAULT_CM_SPEED_INDEX: usize = 8;
 const NUM_SPEEDS_TO_TRY: usize = 16;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -1,4 +1,10 @@
 #![allow(dead_code)]
+use alloc::Allocator;
+use core::cmp::{max, min};
+
+use enc::input_pair::InputReferenceMut;
+
+use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::backward_references::{
     AdvHashSpecialization, AdvHasher, AnyHasher, BasicHasher, BrotliCreateBackwardReferences,
     BrotliEncoderMode, BrotliEncoderParams, BrotliHasherParams, H2Sub, H3Sub, H4Sub, H54Sub, H5Sub,
@@ -16,35 +22,30 @@ use super::brotli_bit_stream::{
     MetaBlockSplit, RecoderState,
 };
 use super::combined_alloc::BrotliAlloc;
+use super::command::{BrotliDistanceParams, Command, GetLengthCode};
+use super::compress_fragment::BrotliCompressFragmentFast;
+use super::compress_fragment_two_pass::{BrotliCompressFragmentTwoPass, BrotliWriteBits};
 use super::constants::{
     BROTLI_CONTEXT, BROTLI_CONTEXT_LUT, BROTLI_MAX_NDIRECT, BROTLI_MAX_NPOSTFIX,
     BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS, BROTLI_WINDOW_GAP,
 };
-use super::hash_to_binary_tree::InitializeH10;
-use super::interface;
-pub use super::parameters::BrotliEncoderParameter;
-use alloc::Allocator;
-
-use super::super::alloc::{SliceWrapper, SliceWrapperMut};
-use super::command::{BrotliDistanceParams, Command, GetLengthCode};
-use super::compress_fragment::BrotliCompressFragmentFast;
-use super::compress_fragment_two_pass::{BrotliCompressFragmentTwoPass, BrotliWriteBits};
 #[allow(unused_imports)]
 use super::entropy_encode::{
     BrotliConvertBitDepthsToSymbols, BrotliCreateHuffmanTree, HuffmanTree,
 };
+use super::hash_to_binary_tree::InitializeH10;
 use super::histogram::{
     ContextType, CostAccessors, HistogramCommand, HistogramDistance, HistogramLiteral,
 };
+use super::interface;
 use super::metablock::{
     BrotliBuildMetaBlock, BrotliBuildMetaBlockGreedy, BrotliInitDistanceParams,
     BrotliOptimizeHistograms,
 };
+pub use super::parameters::BrotliEncoderParameter;
 use super::static_dict::{kNumDistanceCacheEntries, BrotliGetDictionary};
 use super::utf8_util::BrotliIsMostlyUTF8;
 use super::util::Log2FloorNonZero;
-use core::cmp::{max, min};
-use enc::input_pair::InputReferenceMut;
 //fn BrotliCreateHqZopfliBackwardReferences(m: &mut [MemoryManager],
 //                                          dictionary: &[BrotliDictionary],
 //                                          num_bytes: usize,

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -1,10 +1,10 @@
+use core::cmp::{max, min};
+use core::ops::{Index, IndexMut, Range};
+
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::input_pair::{InputPair, InputReference};
 use super::interface;
 use super::util::FastLog2;
-use core::cmp::{max, min};
-
-use core::ops::{Index, IndexMut, Range};
 // float32 doesn't have enough resolution for blocks of data more than 3.5 megs
 pub type floatY = f64;
 // the cost of storing a particular population of data including the approx

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
+use core::cmp::min;
+
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::block_split::BlockSplit;
 use super::command::Command;
 use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
 use super::vectorization::Mem256i;
-use core::cmp::min;
 static kBrotliMinWindowBits: i32 = 10i32;
 
 static kBrotliMaxWindowBits: i32 = 24i32;

--- a/src/enc/input_pair.rs
+++ b/src/enc/input_pair.rs
@@ -1,7 +1,7 @@
-use super::super::alloc::SliceWrapper;
-use super::super::alloc::SliceWrapperMut;
-use super::interface::Freezable;
 use core::cmp::min;
+
+use super::super::alloc::{SliceWrapper, SliceWrapperMut};
+use super::interface::Freezable;
 #[derive(Copy, Clone, Default, Debug)]
 pub struct InputReference<'a> {
     pub data: &'a [u8],

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -1,8 +1,9 @@
-use super::histogram;
-pub use super::input_pair::{InputPair, InputReference, InputReferenceMut};
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 #[allow(unused_imports)] // right now just used in feature flag
 use core;
+
+use super::histogram;
+pub use super::input_pair::{InputPair, InputReference, InputReferenceMut};
 #[derive(Debug, Copy, Clone, Default)]
 pub struct BlockSwitch(pub u8);
 // Commands that can instantiate as a no-op should implement this.
@@ -761,8 +762,7 @@ pub fn u8_to_speed(data: u8) -> u16 {
 }
 #[cfg(test)]
 mod test {
-    use super::speed_to_u8;
-    use super::u8_to_speed;
+    use super::{speed_to_u8, u8_to_speed};
     fn tst_u8_to_speed(data: u16) {
         assert_eq!(u8_to_speed(speed_to_u8(data)), data);
     }

--- a/src/enc/literal_cost.rs
+++ b/src/enc/literal_cost.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
+use core::cmp::min;
+
 use super::utf8_util::BrotliIsMostlyUTF8;
 use super::util::FastLog2f64;
-use core::cmp::min;
 
 static kMinUTF8Ratio: super::util::floatX = 0.75 as super::util::floatX;
 

--- a/src/enc/metablock.rs
+++ b/src/enc/metablock.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+use core::cmp::{max, min};
+
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::backward_references::BrotliEncoderParams;
 use super::bit_cost::{BitsEntropy, BrotliPopulationCost};
@@ -19,7 +21,6 @@ use super::histogram::{
     HistogramAddHistogram, HistogramAddItem, HistogramClear, HistogramCommand, HistogramDistance,
     HistogramLiteral,
 };
-use core::cmp::{max, min};
 
 pub fn BrotliInitDistanceParams(params: &mut BrotliEncoderParams, npostfix: u32, ndirect: u32) {
     let dist_params = &mut params.dist;

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -19,8 +19,7 @@ pub mod static_dict;
 pub mod static_dict_lut;
 pub mod utf8_util;
 pub mod util;
-pub use self::backward_references::hash_to_binary_tree;
-pub use self::backward_references::hq as backward_references_hq;
+pub use self::backward_references::{hash_to_binary_tree, hq as backward_references_hq};
 pub mod block_splitter;
 pub mod compress_fragment;
 pub mod compress_fragment_two_pass;
@@ -58,6 +57,20 @@ pub type s8 = compat::Compat32x8;
 mod parameters;
 mod test;
 mod weights;
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Read, Write};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::{CustomRead, CustomWrite};
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
+use enc::encode::BrotliEncoderStateStruct;
+pub use interface::{InputPair, InputReference, InputReferenceMut};
+
 pub use self::backward_references::{BrotliEncoderParams, UnionHasher};
 use self::encode::{BrotliEncoderDestroyInstance, BrotliEncoderOperation};
 pub use self::encode::{
@@ -66,28 +79,13 @@ pub use self::encode::{
 pub use self::hash_to_binary_tree::ZopfliNode;
 pub use self::interface::StaticCommand;
 pub use self::pdf::PDF;
-pub use self::util::floatX;
-pub use self::vectorization::{v256, v256i, Mem256f};
-use brotli_decompressor::{CustomRead, CustomWrite};
-pub use interface::{InputPair, InputReference, InputReferenceMut};
-
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-#[cfg(feature = "std")]
-use std::io;
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Read, Write};
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-use enc::encode::BrotliEncoderStateStruct;
-
 #[cfg(not(feature = "std"))]
 pub use self::singlethreading::{compress_worker_pool, new_work_pool, WorkerPool};
 pub use self::threading::{
     BatchSpawnableLite, BrotliEncoderThreadError, CompressionThreadResult, Owned, SendAlloc,
 };
+pub use self::util::floatX;
+pub use self::vectorization::{v256, v256i, Mem256f};
 #[cfg(feature = "std")]
 pub use self::worker_pool::{compress_worker_pool, new_work_pool, WorkerPool};
 #[cfg(feature = "std")]

--- a/src/enc/multithreading.rs
+++ b/src/enc/multithreading.rs
@@ -2,19 +2,17 @@
 use alloc::{Allocator, SliceWrapper};
 use core::marker::PhantomData;
 use core::mem;
+// in-place thread create
+use std::sync::RwLock;
+use std::thread::JoinHandle;
+
 use enc::backward_references::UnionHasher;
 use enc::threading::{
     AnyBoxConstructor, BatchSpawnable, BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti,
     CompressionThreadResult, InternalOwned, InternalSendAlloc, Joinable, Owned, OwnedRetriever,
     PoisonedThreadError, SendAlloc,
 };
-use enc::BrotliAlloc;
-use enc::BrotliEncoderParams;
-use std::thread::JoinHandle;
-
-// in-place thread create
-
-use std::sync::RwLock;
+use enc::{BrotliAlloc, BrotliEncoderParams};
 
 pub struct MultiThreadedJoinable<T: Send + 'static, U: Send + 'static>(
     JoinHandle<T>,

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -1,14 +1,13 @@
-use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use super::backward_references::BrotliEncoderParams;
-use super::find_stride;
-use super::input_pair::{InputPair, InputReference, InputReferenceMut};
-use super::interface;
-use super::ir_interpret::{push_base, IRInterpreter};
-use super::util::{floatX, FastLog2u16};
-use super::{s16, v8};
 use core::cmp::min;
 #[cfg(feature = "simd")]
 use core::simd::prelude::SimdPartialOrd;
+
+use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use super::backward_references::BrotliEncoderParams;
+use super::input_pair::{InputPair, InputReference, InputReferenceMut};
+use super::ir_interpret::{push_base, IRInterpreter};
+use super::util::{floatX, FastLog2u16};
+use super::{find_stride, interface, s16, v8};
 
 // the high nibble, followed by the low nibbles
 pub const CONTEXT_MAP_PRIOR_SIZE: usize = 256 * 17;

--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -1,5 +1,17 @@
 #![cfg_attr(not(feature = "std"), allow(unused_imports))]
 
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Read};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::CustomRead;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
+
 use super::backward_references::BrotliEncoderParams;
 use super::combined_alloc::BrotliAlloc;
 use super::encode::{
@@ -7,19 +19,6 @@ use super::encode::{
     BrotliEncoderStateStruct,
 };
 use super::interface;
-use brotli_decompressor::CustomRead;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Read};
 
 #[cfg(feature = "std")]
 pub struct CompressorReaderCustomAlloc<R: Read, BufferType: SliceWrapperMut<u8>, Alloc: BrotliAlloc>(

--- a/src/enc/singlethreading.rs
+++ b/src/enc/singlethreading.rs
@@ -1,14 +1,15 @@
-use super::backward_references::UnionHasher;
 use alloc::{Allocator, SliceWrapper};
 use core::marker::PhantomData;
 use core::mem;
+
 use enc::threading::{
     BatchSpawnable, BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti,
     CompressionThreadResult, InternalOwned, InternalSendAlloc, Joinable, Owned, OwnedRetriever,
     PoisonedThreadError, SendAlloc,
 };
-use enc::BrotliAlloc;
-use enc::BrotliEncoderParams;
+use enc::{BrotliAlloc, BrotliEncoderParams};
+
+use super::backward_references::UnionHasher;
 
 pub struct SingleThreadedJoinable<T: Send + 'static, U: Send + 'static> {
     result: Result<T, U>,

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -1,7 +1,8 @@
 #![cfg(test)]
-use super::{s16, v8};
 use core;
 use core::cmp::min;
+
+use super::{s16, v8};
 extern crate alloc_no_stdlib;
 extern crate brotli_decompressor;
 use super::super::alloc::{
@@ -10,8 +11,7 @@ use super::super::alloc::{
 use super::cluster::HistogramPair;
 use super::encode::{BrotliEncoderOperation, BrotliEncoderParameter};
 use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
-use super::StaticCommand;
-use super::ZopfliNode;
+use super::{StaticCommand, ZopfliNode};
 
 extern "C" {
     fn calloc(n_elem: usize, el_size: usize) -> *mut u8;
@@ -19,15 +19,17 @@ extern "C" {
 extern "C" {
     fn free(ptr: *mut u8);
 }
+use core::ops;
+
+use brotli_decompressor::HuffmanCode;
+use enc::encode::BrotliEncoderStateStruct;
+
 pub use super::super::{BrotliDecompressStream, BrotliResult, BrotliState};
 use super::combined_alloc::CombiningAllocator;
 use super::command::Command;
 use super::entropy_encode::HuffmanTree;
 use super::interface;
 use super::pdf::PDF;
-use brotli_decompressor::HuffmanCode;
-use core::ops;
-use enc::encode::BrotliEncoderStateStruct;
 
 declare_stack_allocator_struct!(MemPool, 128, stack);
 declare_stack_allocator_struct!(CallocatedFreelist4096, 128, calloc);

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -1,16 +1,17 @@
+use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core::marker::PhantomData;
+use core::ops::Range;
+use core::{any, mem};
+
+use concat::{BroCatli, BroCatliResult};
+use enc::encode::BrotliEncoderStateStruct;
+
 use super::backward_references::{AnyHasher, BrotliEncoderParams, CloneWithAlloc, UnionHasher};
 use super::encode::{
     BrotliEncoderDestroyInstance, BrotliEncoderMaxCompressedSize, BrotliEncoderOperation,
     HasherSetup, SanitizeParams,
 };
 use super::BrotliAlloc;
-use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
-use concat::{BroCatli, BroCatliResult};
-use core::any;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::Range;
-use enc::encode::BrotliEncoderStateStruct;
 
 pub type PoisonedThreadError = ();
 

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -1,19 +1,17 @@
 #![cfg(feature = "std")]
-use core::mem;
-
 use alloc::{Allocator, SliceWrapper};
+use core::mem;
+// in-place thread create
+use std::sync::RwLock;
+use std::sync::{Arc, Condvar, Mutex};
+
 use enc::backward_references::UnionHasher;
 use enc::fixed_queue::{FixedQueue, MAX_THREADS};
 use enc::threading::{
     BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti, CompressionThreadResult,
     InternalOwned, InternalSendAlloc, Joinable, Owned, SendAlloc,
 };
-use enc::BrotliAlloc;
-use enc::BrotliEncoderParams;
-use std::sync::{Arc, Condvar, Mutex};
-// in-place thread create
-
-use std::sync::RwLock;
+use enc::{BrotliAlloc, BrotliEncoderParams};
 
 struct JobReply<T: Send + 'static> {
     result: T,

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -1,4 +1,16 @@
 #![cfg_attr(not(feature = "std"), allow(unused_imports))]
+pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::io::{Error, ErrorKind, Write};
+
+#[cfg(feature = "std")]
+pub use alloc_stdlib::StandardAlloc;
+use brotli_decompressor::CustomWrite;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::{IntoIoWriter, IoWriterWrapper};
+
 use super::backward_references::BrotliEncoderParams;
 use super::combined_alloc::BrotliAlloc;
 use super::encode::{
@@ -6,18 +18,6 @@ use super::encode::{
     BrotliEncoderStateStruct,
 };
 use super::interface;
-pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
-#[cfg(feature = "std")]
-pub use alloc_stdlib::StandardAlloc;
-use brotli_decompressor::CustomWrite;
-#[cfg(feature = "std")]
-pub use brotli_decompressor::{IntoIoWriter, IoWriterWrapper};
-
-#[cfg(feature = "std")]
-use std::io;
-
-#[cfg(feature = "std")]
-use std::io::{Error, ErrorKind, Write};
 
 #[cfg(feature = "std")]
 pub struct CompressorWriterCustomAlloc<

--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -1,8 +1,9 @@
+use core;
+
 pub use brotli_decompressor::ffi::interface::c_void;
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
 use concat::BroCatli;
 pub use concat::BroCatliResult;
-use core;
 pub type BroccoliResult = BroCatliResult;
 // a tool to concatenate brotli files together
 

--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -1,19 +1,21 @@
 #![cfg(not(feature = "safe"))]
 
+use core;
 #[cfg(feature = "std")]
 use std::io::Write;
 #[cfg(feature = "std")]
 use std::{io, panic, thread};
 
-use super::alloc_util::BrotliSubclassableAllocator;
-use brotli_decompressor::ffi::alloc_util;
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
 use brotli_decompressor::ffi::interface::{
     brotli_alloc_func, brotli_free_func, c_void, CAllocator,
 };
-use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
-use core;
+use brotli_decompressor::ffi::{
+    alloc_util, slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut,
+};
 use enc::encode::BrotliEncoderStateStruct;
+
+use super::alloc_util::BrotliSubclassableAllocator;
 
 #[repr(C)]
 pub enum BrotliEncoderOperation {

--- a/src/ffi/decompressor.rs
+++ b/src/ffi/decompressor.rs
@@ -1,6 +1,5 @@
-pub use brotli_decompressor::ffi;
 pub use brotli_decompressor::ffi::interface::{brotli_alloc_func, brotli_free_func, c_void};
-pub use brotli_decompressor::{BrotliDecoderReturnInfo, HuffmanCode};
+pub use brotli_decompressor::{ffi, BrotliDecoderReturnInfo, HuffmanCode};
 
 pub unsafe extern "C" fn CBrotliDecoderCreateInstance(
     alloc_func: brotli_alloc_func,

--- a/src/ffi/multicompress/test.rs
+++ b/src/ffi/multicompress/test.rs
@@ -1,8 +1,10 @@
 #![cfg(test)]
 #![cfg(feature = "std")]
-use super::*;
 use core;
+
 use enc::encode::BrotliEncoderParameter;
+
+use super::*;
 #[test]
 fn test_compress_workpool() {
     let input = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,29 +27,19 @@ pub use alloc_stdlib::HeapAlloc;
 pub mod enc;
 pub use self::enc::combined_alloc::CombiningAllocator;
 pub mod concat;
-pub use brotli_decompressor::dictionary;
-pub use brotli_decompressor::reader;
+pub use brotli_decompressor::io_wrappers::{CustomRead, CustomWrite};
+#[cfg(feature = "std")]
+pub use brotli_decompressor::io_wrappers::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
 #[cfg(feature = "std")]
 pub use brotli_decompressor::reader::Decompressor;
 pub use brotli_decompressor::reader::DecompressorCustomIo;
-pub use brotli_decompressor::transform;
 pub use brotli_decompressor::transform::TransformDictionaryWord;
-pub use brotli_decompressor::writer;
-pub use brotli_decompressor::BrotliState;
-pub use brotli_decompressor::HuffmanCode; // so we can make custom allocator for decompression
-
-pub use brotli_decompressor::writer::DecompressorWriterCustomIo;
-
 #[cfg(feature = "std")]
 pub use brotli_decompressor::writer::DecompressorWriter;
-
-pub use brotli_decompressor::io_wrappers::{CustomRead, CustomWrite};
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::io_wrappers::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-pub use enc::input_pair::InputPair;
-pub use enc::input_pair::InputReference;
-pub use enc::input_pair::InputReferenceMut;
+pub use brotli_decompressor::writer::DecompressorWriterCustomIo;
+pub use brotli_decompressor::HuffmanCode; // so we can make custom allocator for decompression
+pub use brotli_decompressor::{dictionary, reader, transform, writer, BrotliState};
+pub use enc::input_pair::{InputPair, InputReference, InputReferenceMut};
 pub use enc::interface;
 pub use enc::interface::SliceOffset;
 #[cfg(feature = "ffi-api")]
@@ -64,27 +54,22 @@ pub mod ffi;
 //                               mut total_out: &mut usize,
 //                               mut s: &mut BrotliState<AllocU8, AllocU32, AllocHC>);
 
-pub use brotli_decompressor::{BrotliDecompressStream, BrotliResult};
 #[cfg(feature = "std")]
-pub use enc::{BrotliCompress, BrotliCompressCustomAlloc};
-pub use enc::{BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};
-
+pub use brotli_decompressor::copy_from_to;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::BrotliDecompress;
+#[cfg(feature = "std")]
+pub use brotli_decompressor::BrotliDecompressCustomAlloc;
+pub use brotli_decompressor::{
+    BrotliDecompressCustomIo, BrotliDecompressCustomIoCustomDict, BrotliDecompressStream,
+    BrotliResult,
+};
 #[cfg(feature = "std")]
 pub use enc::reader::CompressorReader;
 pub use enc::reader::CompressorReaderCustomIo;
-
 #[cfg(feature = "std")]
 pub use enc::writer::CompressorWriter;
 pub use enc::writer::CompressorWriterCustomIo;
-
 #[cfg(feature = "std")]
-pub use brotli_decompressor::BrotliDecompress;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::BrotliDecompressCustomAlloc;
-
-pub use brotli_decompressor::BrotliDecompressCustomIo;
-pub use brotli_decompressor::BrotliDecompressCustomIoCustomDict;
-
-#[cfg(feature = "std")]
-pub use brotli_decompressor::copy_from_to;
+pub use enc::{BrotliCompress, BrotliCompressCustomAlloc};
+pub use enc::{BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};


### PR DESCRIPTION
Use `nightly` fmt to auto-reformat all the use statements.  I will create a follow-up PR to do some manual additional cleanups. I did not want to include manual cleanups in the same PR as the initial automatic ones.

Groups `use` statements into 3 standard groups: std library, 3rd party crates, and brotli crate itself -- `StdExternalCrate` mode.

Note that the nightly fmt is required for this. It will not affect the regular `cargo fmt` CI check because regular one ignores `use` sections (the formatting has not been fully stabilized).

```
cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
cd c && cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
```

Note that the above steps can also be done with `just`:  `just fmt2`