### PR TITLE
Remove dead code blocks

### DIFF
--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -5,8 +5,8 @@ use core::cmp::{max, min};
 #[cfg(feature = "simd")]
 use core::simd::prelude::SimdPartialOrd;
 
-use super::util::{floatX, FastLog2, FastLog2u16};
-use super::vectorization::{cast_f32_to_i32, cast_i32_to_f32, log2i, sum8, v256, v256i, Mem256i};
+use super::util::{FastLog2, FastLog2u16};
+use super::vectorization::Mem256i;
 
 static kCopyBase: [u32; 24] = [
     2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 22, 30, 38, 54, 70, 102, 134, 198, 326, 582, 1094, 2118,
@@ -79,167 +79,33 @@ fn CostComputation<T: SliceWrapper<Mem256i>>(
     depth_histo: &mut [u32; BROTLI_CODE_LENGTH_CODES],
     nnz_data: &T,
     nnz: usize,
-    total_count: super::util::floatX,
+    _total_count: super::util::floatX,
     log2total: super::util::floatX,
 ) -> super::util::floatX {
     let mut bits: super::util::floatX = 0.0 as super::util::floatX;
-    if true {
-        let mut max_depth: usize = 1;
-        for i in 0..nnz {
-            // Compute -log2(P(symbol)) = -log2(count(symbol)/total_count) =
-            //                            = log2(total_count) - log2(count(symbol))
-            let element = nnz_data.slice()[i >> 3][i & 7];
-            let log2p = log2total - FastLog2u16(element as u16);
-            // Approximate the bit depth by round(-log2(P(symbol)))
-            let depth = min((log2p + 0.5) as u8, 15u8);
-            bits += element as super::util::floatX * log2p;
-            if (depth as usize > max_depth) {
-                max_depth = depth as usize;
-            }
-            depth_histo[depth as usize] += 1;
-        }
-
-        // Add the estimated encoding cost of the code length code histogram.
-        bits += (18 + 2 * max_depth) as super::util::floatX;
-        // Add the entropy of the code length code histogram.
-        bits += BitsEntropy(depth_histo, BROTLI_CODE_LENGTH_CODES);
-        //println_stderr!("{:?} {:?}", &depth_histo[..], bits);
-        return bits;
-    }
-    let rem = nnz & 7;
-    let nnz_srl_3 = nnz >> 3;
-    if true {
-        let mut vec_max_depth: [i32; 8] = [1; 8];
-        let mut depth_histo_vec = [[0i32; BROTLI_CODE_LENGTH_CODES]; 8];
-        for nnz_data_vec in nnz_data.slice().split_at(nnz_srl_3).0.iter() {
-            for i in 0..8 {
-                // Compute -log2(P(symbol)) = -log2(count(symbol)/total_count) =
-                //                            = log2(total_count) - log2(count(symbol))
-                let ele = nnz_data_vec[i];
-                let log2p = log2total - FastLog2u16(ele as u16);
-                // Approximate the bit depth by round(-log2(P(symbol)))
-                let depth = min((log2p + 0.5) as i32, 15) as i32;
-                bits += ele as super::util::floatX * log2p;
-                vec_max_depth[i] = max(vec_max_depth[i], depth);
-                depth_histo_vec[i][depth as usize] += 1;
-            }
-        }
-        let mut max_depth = vec_max_depth[7];
-        for i in 0..8 {
-            for j in 0..BROTLI_CODE_LENGTH_CODES {
-                depth_histo[j] += depth_histo_vec[i][j] as u32;
-            }
-            max_depth = max(vec_max_depth[i], max_depth);
-        }
-        if rem != 0 {
-            let last_vec = nnz_data.slice()[nnz_srl_3];
-            for i in 0..rem {
-                // remainder won't have last element for sure
-                let element = last_vec[i];
-                let log2p = log2total - FastLog2u16(element as u16);
-                // Approximate the bit depth by round(-log2(P(symbol)))
-                let depth = min((log2p + 0.5) as i32, 15);
-                bits += element as super::util::floatX * log2p;
-                max_depth = max(depth, max_depth);
-                depth_histo[depth as usize] += 1;
-            }
-        }
-        // Add the estimated encoding cost of the code length code histogram.
-        bits += (18 + 2 * max_depth) as super::util::floatX;
-        // Add the entropy of the code length code histogram.
-        bits += BitsEntropy(depth_histo, BROTLI_CODE_LENGTH_CODES);
-        //println_stderr!("{:?} {:?}", &depth_histo[..], bits);
-        return bits;
-    }
-    let pow2l: v256 = [
-        1.0/*0.7071067811865476*/ as floatX,
-        0.3535533905932738 as floatX,
-        0.1767766952966369 as floatX,
-        0.0883883476483184 as floatX,
-        0.0441941738241592 as floatX,
-        0.0220970869120796 as floatX,
-        0.0110485434560398 as floatX,
-        0.0055242717280199 as floatX,
-    ]
-    .into();
-    let pow2h: v256 = [
-        //FIXME: setr
-        0.0027621358640100 as floatX,
-        0.0013810679320050 as floatX,
-        0.0006905339660025 as floatX,
-        0.0003452669830012 as floatX,
-        0.0001726334915006 as floatX,
-        0.0000863167457503 as floatX,
-        0.0000431583728752 as floatX,
-        /*0.0000215791864376f*/ 0.0 as floatX,
-    ]
-    .into();
-    let ymm_tc = v256::splat(total_count as floatX);
-    let search_depthl = cast_f32_to_i32(pow2l * ymm_tc);
-    let search_depthh = cast_f32_to_i32(pow2h * ymm_tc);
-    let mut suml = v256i::splat(0);
-    let mut sumh = v256i::splat(0);
-    for nnz_data_vec in nnz_data.slice().split_at(nnz_srl_3).0.iter() {
-        for sub_data_item_index in 0..8 {
-            let count = v256i::splat(nnz_data_vec[sub_data_item_index]);
-            let cmpl: v256i = count.simd_gt(search_depthl).to_int();
-            let cmph: v256i = count.simd_gt(search_depthh).to_int();
-            suml = suml + cmpl;
-            sumh = sumh + cmph;
-        }
-    }
-    if rem != 0 {
-        let last_element = nnz_data.slice()[nnz >> 3];
-        for sub_index in 0..rem {
-            let count = v256i::splat(last_element[sub_index & 7]);
-            let cmpl: v256i = count.simd_gt(search_depthl).to_int();
-            let cmph: v256i = count.simd_gt(search_depthh).to_int();
-            suml = suml + cmpl;
-            sumh = sumh + cmph;
-        }
-    }
     let mut max_depth: usize = 1;
-    // Deal with depth_histo and max_depth
-    {
-        let cumulative_sum: [Mem256i; 2] = [suml, sumh];
-        let mut prev = cumulative_sum[0][0];
-        for j in 1..16 {
-            let cur = cumulative_sum[(j & 8) >> 3][j & 7];
-            let delta = cur - prev;
-            prev = cur;
-            let cur = &mut depth_histo[j];
-            *cur = (*cur as i32 + delta) as u32; // depth_histo[j] += delta
-            if delta != 0 {
-                max_depth = j;
-            }
+    for i in 0..nnz {
+        // Compute -log2(P(symbol)) = -log2(count(symbol)/total_count) =
+        //                            = log2(total_count) - log2(count(symbol))
+        let element = nnz_data.slice()[i >> 3][i & 7];
+        let log2p = log2total - FastLog2u16(element as u16);
+        // Approximate the bit depth by round(-log2(P(symbol)))
+        let depth = min((log2p + 0.5) as u8, 15u8);
+        bits += element as super::util::floatX * log2p;
+        if (depth as usize > max_depth) {
+            max_depth = depth as usize;
         }
-    }
-    let ymm_log2total = v256::splat(log2total);
-    let mut bits_cumulative = v256::splat(0.0 as floatX);
-    for nnz_data_item in nnz_data.slice().split_at(nnz_srl_3).0.iter() {
-        let counts = cast_i32_to_f32(*nnz_data_item);
-        let log_counts = log2i(*nnz_data_item);
-        let log2p = ymm_log2total - log_counts;
-        let tmp = counts * log2p;
-        bits_cumulative += tmp;
-    }
-    bits += sum8(bits_cumulative);
-    if rem != 0 {
-        let last_vec = nnz_data.slice()[nnz_srl_3];
-        for i in 0..rem {
-            let last_item = last_vec[i];
-            let log2p = log2total - FastLog2u16(last_item as u16);
-            bits += last_item as super::util::floatX * log2p;
-        }
+        depth_histo[depth as usize] += 1;
     }
 
     // Add the estimated encoding cost of the code length code histogram.
     bits += (18 + 2 * max_depth) as super::util::floatX;
     // Add the entropy of the code length code histogram.
     bits += BitsEntropy(depth_histo, BROTLI_CODE_LENGTH_CODES);
-    //println_stderr!("{:?} {:?}", depth_histo, bits);
+    //println_stderr!("{:?} {:?}", &depth_histo[..], bits);
     bits
 }
+
 use alloc::SliceWrapperMut;
 
 pub fn BrotliPopulationCost<HistogramType: SliceWrapper<u32> + CostAccessors>(

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -2395,57 +2395,21 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
         if self.num_commands_ != 0 && self.last_insert_len_ == 0 {
             self.extend_last_command(&mut bytes, &mut wrapped_last_processed_pos);
         }
-        if false {
-            // we are remapping 10 as quality=9.5 since Zopfli doesn't seem to offer much benefits here
-            panic!(
-                r####"
-    BrotliCreateZopfliBackwardReferences(m,
-                                         dictionary,
-                                         bytes as usize,
-                                         wrapped_last_processed_pos as usize,
-                                         data,
-                                         mask as usize,
-                                         &mut s.params,
-                                         s.hasher_,
-                                         s.dist_cache_.as_mut_ptr(),
-                                         &mut s.last_insert_len_,
-                                         &mut *s.commands_[((*s).num_commands_ as usize)..],
-                                         &mut s.num_commands_,
-                                         &mut s.num_literals_);"####
-            );
-        } else if false && self.params.quality == 11i32 {
-            panic!(
-                r####"BrotliCreateHqZopfliBackwardReferences(m,
-                                           dictionary,
-                                           bytes as usize,
-                                           wrapped_last_processed_pos as usize,
-                                           data,
-                                           mask as usize,
-                                           &mut s.params,
-                                           s.hasher_,
-                                           s.dist_cache_.as_mut_ptr(),
-                                           &mut s.last_insert_len_,
-                                           &mut *s.commands_[((*s).num_commands_ as usize)..],
-                                           &mut s.num_commands_,
-                                           &mut s.num_literals_);"####
-            );
-        } else {
-            BrotliCreateBackwardReferences(
-                &mut self.m8,
-                dictionary,
-                bytes as usize,
-                wrapped_last_processed_pos as usize,
-                &mut self.ringbuffer_.data_mo.slice_mut()[self.ringbuffer_.buffer_index..],
-                mask as usize,
-                &mut self.params,
-                &mut self.hasher_,
-                &mut self.dist_cache_,
-                &mut self.last_insert_len_,
-                &mut self.commands_.slice_mut()[self.num_commands_..],
-                &mut self.num_commands_,
-                &mut self.num_literals_,
-            );
-        }
+        BrotliCreateBackwardReferences(
+            &mut self.m8,
+            dictionary,
+            bytes as usize,
+            wrapped_last_processed_pos as usize,
+            &mut self.ringbuffer_.data_mo.slice_mut()[self.ringbuffer_.buffer_index..],
+            mask as usize,
+            &mut self.params,
+            &mut self.hasher_,
+            &mut self.dist_cache_,
+            &mut self.last_insert_len_,
+            &mut self.commands_.slice_mut()[self.num_commands_..],
+            &mut self.num_commands_,
+            &mut self.num_literals_,
+        );
         {
             let max_length: usize = MaxMetablockSize(&mut self.params);
             let max_literals: usize = max_length.wrapping_div(8);


### PR DESCRIPTION
Hide whitespace when viewing changes.

Several giant blocks of code are never used. If they are still needed, we should use conditional compilation, and add it to the CI to avoid bitrot.