### PR TITLE
Switch to `use crate::` for local decl

### DIFF
--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -1,16 +1,17 @@
 #![allow(dead_code)]
 
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
+use core;
 use core::cmp::min;
-
-use enc::static_dict::{BrotliDictionary, FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32};
-use enc::util::floatX;
-use {alloc, core};
 
 use super::{
     kHashMul32, AnyHasher, BrotliEncoderParams, CloneWithAlloc, H9Opts, HasherSearchResult,
     HowPrepared, Struct1,
 };
+use crate::enc::static_dict::{
+    BrotliDictionary, FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32,
+};
+use crate::enc::util::floatX;
 
 pub const kInfinity: floatX = 1.7e38 as floatX;
 

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -4,19 +4,6 @@ use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use core;
 use core::cmp::{max, min};
 
-use enc::command::{
-    BrotliDistanceParams, CombineLengthCodes, Command, GetCopyLengthCode, GetInsertLengthCode,
-    PrefixEncodeCopyDistance,
-};
-use enc::constants::{kCopyExtra, kInsExtra};
-use enc::encode;
-use enc::literal_cost::BrotliEstimateBitCostsForLiterals;
-use enc::static_dict::{
-    BrotliDictionary, BrotliFindAllStaticDictionaryMatches, FindMatchLengthWithLimit,
-    BROTLI_UNALIGNED_LOAD32,
-};
-use enc::util::{floatX, FastLog2, FastLog2f64};
-
 use super::hash_to_binary_tree::{
     kInfinity, Allocable, BackwardMatch, BackwardMatchMut, H10Params, StoreAndFindMatchesH10,
     Union1, ZopfliNode, H10,
@@ -25,6 +12,18 @@ use super::{
     kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kInvalidMatch, AnyHasher,
     BrotliEncoderParams,
 };
+use crate::enc::command::{
+    BrotliDistanceParams, CombineLengthCodes, Command, GetCopyLengthCode, GetInsertLengthCode,
+    PrefixEncodeCopyDistance,
+};
+use crate::enc::constants::{kCopyExtra, kInsExtra};
+use crate::enc::encode;
+use crate::enc::literal_cost::BrotliEstimateBitCostsForLiterals;
+use crate::enc::static_dict::{
+    BrotliDictionary, BrotliFindAllStaticDictionaryMatches, FindMatchLengthWithLimit,
+    BROTLI_UNALIGNED_LOAD32,
+};
+use crate::enc::util::{floatX, FastLog2, FastLog2f64};
 
 const BROTLI_WINDOW_GAP: usize = 16;
 const BROTLI_MAX_STATIC_DICTIONARY_MATCH_LEN: usize = 37;

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -2,11 +2,11 @@
 #![cfg(test)]
 
 use alloc_stdlib::StandardAlloc;
-use enc::{Allocator, SliceWrapper};
 
 use super::{
     AdvHasher, AnyHasher, BrotliHasherParams, CloneWithAlloc, H5Sub, H9Opts, HQ7Sub, Struct1,
 };
+use crate::enc::{Allocator, SliceWrapper};
 
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
 

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -6,9 +6,6 @@ use core::cmp::{max, min};
 #[cfg(feature = "std")]
 use std::io::Write;
 
-use enc::backward_references::BrotliEncoderParams;
-use VERSION;
-
 use super::super::alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 use super::super::dictionary::{
     kBrotliDictionary, kBrotliDictionaryOffsetsByLength, kBrotliDictionarySizeBitsByLength,
@@ -38,6 +35,8 @@ use super::interface::StaticCommand;
 use super::static_dict::kNumDistanceCacheEntries;
 use super::util::floatX;
 use super::{find_stride, interface, prior_eval, stride_eval};
+use crate::enc::backward_references::BrotliEncoderParams;
+use crate::VERSION;
 
 pub struct PrefixCodeRange {
     pub offset: u32,
@@ -2956,7 +2955,7 @@ pub fn BrotliWriteMetadataMetaBlock(
 
 #[cfg(test)]
 mod test {
-    use enc::brotli_bit_stream::{encode_base_128, MAX_SIZE_ENCODING};
+    use crate::enc::brotli_bit_stream::{encode_base_128, MAX_SIZE_ENCODING};
 
     #[test]
     fn test_encode_base_128() {

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -539,7 +539,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
     fn literal_context_map(&self) -> &[u8] {
         self.context_map.literal_context_map.slice()
     }
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> crate::interface::LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     fn update_cost(

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -4,8 +4,6 @@ use alloc::Allocator;
 use core;
 use core::cmp::{max, min};
 
-use enc::input_pair::InputReferenceMut;
-
 use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::backward_references::{
@@ -41,6 +39,7 @@ pub use super::parameters::BrotliEncoderParameter;
 use super::static_dict::{kNumDistanceCacheEntries, BrotliGetDictionary};
 use super::utf8_util::BrotliIsMostlyUTF8;
 use super::util::Log2FloorNonZero;
+use crate::enc::input_pair::InputReferenceMut;
 
 //fn BrotliCreateHqZopfliBackwardReferences(m: &mut [MemoryManager],
 //                                          dictionary: &[BrotliDictionary],

--- a/src/enc/ir_interpret.rs
+++ b/src/enc/ir_interpret.rs
@@ -11,7 +11,7 @@ pub trait IRInterpreter {
     fn block_type(&self) -> u8;
     fn literal_data_at_offset(&self, index: usize) -> u8;
     fn literal_context_map(&self) -> &[u8];
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble;
+    fn prediction_mode(&self) -> crate::interface::LiteralPredictionModeNibble;
     fn update_cost(
         &mut self,
         stride_prior: [u8; 8],

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -53,7 +53,6 @@ pub use alloc_stdlib::StandardAlloc;
 use brotli_decompressor::{CustomRead, CustomWrite};
 #[cfg(feature = "std")]
 pub use brotli_decompressor::{IntoIoReader, IoReaderWrapper, IoWriterWrapper};
-use enc::encode::BrotliEncoderStateStruct;
 pub use interface::{InputPair, InputReference, InputReferenceMut};
 
 pub use self::backward_references::{
@@ -76,6 +75,7 @@ pub use self::util::floatX;
 pub use self::vectorization::{v256, v256i, Mem256f};
 #[cfg(feature = "std")]
 pub use self::worker_pool::{compress_worker_pool, new_work_pool, WorkerPool};
+use crate::enc::encode::BrotliEncoderStateStruct;
 
 #[cfg(feature = "simd")]
 pub type s16 = core::simd::i16x16;

--- a/src/enc/multithreading.rs
+++ b/src/enc/multithreading.rs
@@ -8,13 +8,13 @@ use std;
 use std::sync::RwLock;
 use std::thread::JoinHandle;
 
-use enc::backward_references::UnionHasher;
-use enc::threading::{
+use crate::enc::backward_references::UnionHasher;
+use crate::enc::threading::{
     AnyBoxConstructor, BatchSpawnable, BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti,
     CompressionThreadResult, InternalOwned, InternalSendAlloc, Joinable, Owned, OwnedRetriever,
     PoisonedThreadError, SendAlloc,
 };
-use enc::{BrotliAlloc, BrotliEncoderParams};
+use crate::enc::{BrotliAlloc, BrotliEncoderParams};
 
 pub struct MultiThreadedJoinable<T: Send + 'static, U: Send + 'static>(
     JoinHandle<T>,

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -856,7 +856,7 @@ impl<'a, Alloc: alloc::Allocator<s16> + alloc::Allocator<u32> + alloc::Allocator
         self.context_map.literal_context_map.slice()
     }
     #[inline]
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> crate::interface::LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     #[inline]

--- a/src/enc/singlethreading.rs
+++ b/src/enc/singlethreading.rs
@@ -4,14 +4,13 @@ use core::mem;
 #[cfg(feature = "std")]
 use std;
 
-use enc::threading::{
+use super::backward_references::UnionHasher;
+use crate::enc::threading::{
     BatchSpawnable, BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti,
     CompressionThreadResult, InternalOwned, InternalSendAlloc, Joinable, Owned, OwnedRetriever,
     PoisonedThreadError, SendAlloc,
 };
-use enc::{BrotliAlloc, BrotliEncoderParams};
-
-use super::backward_references::UnionHasher;
+use crate::enc::{BrotliAlloc, BrotliEncoderParams};
 
 pub struct SingleThreadedJoinable<T: Send + 'static, U: Send + 'static> {
     result: Result<T, U>,

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -293,7 +293,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
     fn literal_context_map(&self) -> &[u8] {
         self.context_map.literal_context_map.slice()
     }
-    fn prediction_mode(&self) -> ::interface::LiteralPredictionModeNibble {
+    fn prediction_mode(&self) -> crate::interface::LiteralPredictionModeNibble {
         self.context_map.literal_prediction_mode()
     }
     fn update_cost(

--- a/src/enc/test.rs
+++ b/src/enc/test.rs
@@ -19,7 +19,6 @@ use core::cmp::min;
 use core::ops;
 
 use brotli_decompressor::HuffmanCode;
-use enc::encode::BrotliEncoderStateStruct;
 
 use super::super::alloc::{
     bzero, AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator,
@@ -33,6 +32,7 @@ use super::entropy_encode::HuffmanTree;
 use super::histogram::{ContextType, HistogramCommand, HistogramDistance, HistogramLiteral};
 use super::pdf::PDF;
 use super::{interface, s16, v8, StaticCommand, ZopfliNode};
+use crate::enc::encode::BrotliEncoderStateStruct;
 
 declare_stack_allocator_struct!(MemPool, 128, stack);
 declare_stack_allocator_struct!(CallocatedFreelist4096, 128, calloc);

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -5,15 +5,14 @@ use core::{any, mem};
 #[cfg(feature = "std")]
 use std;
 
-use concat::{BroCatli, BroCatliResult};
-use enc::encode::BrotliEncoderStateStruct;
-
 use super::backward_references::{AnyHasher, BrotliEncoderParams, CloneWithAlloc, UnionHasher};
 use super::encode::{
     BrotliEncoderDestroyInstance, BrotliEncoderMaxCompressedSize, BrotliEncoderOperation,
     HasherSetup, SanitizeParams,
 };
 use super::BrotliAlloc;
+use crate::concat::{BroCatli, BroCatliResult};
+use crate::enc::encode::BrotliEncoderStateStruct;
 
 pub type PoisonedThreadError = ();
 

--- a/src/enc/vectorization.rs
+++ b/src/enc/vectorization.rs
@@ -1,8 +1,8 @@
 #![allow(unknown_lints)]
 #![allow(unused_macros)]
 
-use enc::util::FastLog2;
-use enc::{s8, v8};
+use crate::enc::util::FastLog2;
+use crate::enc::{s8, v8};
 pub type Mem256f = v8;
 pub type Mem256i = s8;
 pub type v256 = v8;

--- a/src/enc/worker_pool.rs
+++ b/src/enc/worker_pool.rs
@@ -7,13 +7,13 @@ use std;
 use std::sync::RwLock;
 use std::sync::{Arc, Condvar, Mutex};
 
-use enc::backward_references::UnionHasher;
-use enc::fixed_queue::{FixedQueue, MAX_THREADS};
-use enc::threading::{
+use crate::enc::backward_references::UnionHasher;
+use crate::enc::fixed_queue::{FixedQueue, MAX_THREADS};
+use crate::enc::threading::{
     BatchSpawnableLite, BrotliEncoderThreadError, CompressMulti, CompressionThreadResult,
     InternalOwned, InternalSendAlloc, Joinable, Owned, SendAlloc,
 };
-use enc::{BrotliAlloc, BrotliEncoderParams};
+use crate::enc::{BrotliAlloc, BrotliEncoderParams};
 
 struct JobReply<T: Send + 'static> {
     result: T,

--- a/src/ffi/alloc_util.rs
+++ b/src/ffi/alloc_util.rs
@@ -1,7 +1,8 @@
 use alloc::{Allocator, SliceWrapper, SliceWrapperMut};
 
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
-use enc::BrotliAlloc;
+
+use crate::enc::BrotliAlloc;
 
 pub struct BrotliSubclassableAllocator(SubclassableAllocator);
 

--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -2,8 +2,9 @@ use core;
 
 pub use brotli_decompressor::ffi::interface::c_void;
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
-use concat::BroCatli;
-pub use concat::BroCatliResult;
+
+use crate::concat::BroCatli;
+pub use crate::concat::BroCatliResult;
 pub type BroccoliResult = BroCatliResult;
 // a tool to concatenate brotli files together
 

--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -13,9 +13,9 @@ use brotli_decompressor::ffi::interface::{
 use brotli_decompressor::ffi::{
     alloc_util, slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut,
 };
-use enc::encode::BrotliEncoderStateStruct;
 
 use super::alloc_util::BrotliSubclassableAllocator;
+use crate::enc::encode::BrotliEncoderStateStruct;
 
 #[repr(C)]
 pub enum BrotliEncoderOperation {

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -12,15 +12,15 @@ use brotli_decompressor::ffi::interface::{
     brotli_alloc_func, brotli_free_func, c_void, CAllocator,
 };
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
-use enc::backward_references::{BrotliEncoderParams, UnionHasher};
-use enc::encode::{
-    set_parameter, BrotliEncoderOperation, BrotliEncoderParameter, BrotliEncoderStateStruct,
-};
-use enc::threading::{Owned, SendAlloc};
 use {brotli_decompressor, core, enc};
 
 use super::alloc_util::BrotliSubclassableAllocator;
 use super::compressor;
+use crate::enc::backward_references::{BrotliEncoderParams, UnionHasher};
+use crate::enc::encode::{
+    set_parameter, BrotliEncoderOperation, BrotliEncoderParameter, BrotliEncoderStateStruct,
+};
+use crate::enc::threading::{Owned, SendAlloc};
 
 pub const MAX_THREADS: usize = 16;
 

--- a/src/ffi/multicompress/test.rs
+++ b/src/ffi/multicompress/test.rs
@@ -3,9 +3,8 @@
 
 use core;
 
-use enc::encode::BrotliEncoderParameter;
-
 use super::*;
+use crate::enc::encode::BrotliEncoderParameter;
 
 #[test]
 fn test_compress_workpool() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,19 +50,19 @@ pub use brotli_decompressor::{
     dictionary, reader, transform, writer, BrotliDecompressCustomIo,
     BrotliDecompressCustomIoCustomDict, BrotliDecompressStream, BrotliResult, BrotliState,
 };
-pub use enc::input_pair::{InputPair, InputReference, InputReferenceMut};
-pub use enc::interface::SliceOffset;
-#[cfg(feature = "std")]
-pub use enc::reader::CompressorReader;
-pub use enc::reader::CompressorReaderCustomIo;
-#[cfg(feature = "std")]
-pub use enc::writer::CompressorWriter;
-pub use enc::writer::CompressorWriterCustomIo;
-pub use enc::{interface, BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};
-#[cfg(feature = "std")]
-pub use enc::{BrotliCompress, BrotliCompressCustomAlloc};
 
 pub use self::enc::combined_alloc::CombiningAllocator;
+pub use crate::enc::input_pair::{InputPair, InputReference, InputReferenceMut};
+pub use crate::enc::interface::SliceOffset;
+#[cfg(feature = "std")]
+pub use crate::enc::reader::CompressorReader;
+pub use crate::enc::reader::CompressorReaderCustomIo;
+#[cfg(feature = "std")]
+pub use crate::enc::writer::CompressorWriter;
+pub use crate::enc::writer::CompressorWriterCustomIo;
+pub use crate::enc::{interface, BrotliCompressCustomIo, BrotliCompressCustomIoCustomDict};
+#[cfg(feature = "std")]
+pub use crate::enc::{BrotliCompress, BrotliCompressCustomAlloc};
 
 pub const VERSION: u8 = 1;
 


### PR DESCRIPTION
The `use foo` is no longer allowed when `foo` is part of the current crate. This has been the standard ever since 2018 edition.  `use crate::foo` is a preferred method.

* Use search/replace to replace:
  * `use enc::` -> `use crate::enc::`
  * `use concat::` -> `use crate::concat::`
  * `use VERSION` -> `use crate::VERSION`
  * ` ::interface` to ` crate::interface` (both strings start with a space)
* Run `just fmt2` to reorg use statements to new groups.