### PR TITLE
Fix CI bug with best_speed_log

### DIFF
--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -246,7 +246,7 @@ fn best_speed_log(_name: &str, _data: &[SpeedAndMax; 2], _cost: &[floatX; 2]) {}
 fn best_speed_log(name: &str, data: &[SpeedAndMax; 2], cost: &[floatX; 2]) {
     for high in 0..2 {
         println!(
-            "{} Speed [ inc: {}, max: {}, algo: 0 ] cost: {}",
+            "{} Speed [ inc: {}, max: {}, algo: {} ] cost: {}",
             name,
             if high != 0 { "hi" } else { "lo" },
             data[high].0,


### PR DESCRIPTION
Apparently `best_speed_log` was never tested - it does not compile due to a missing format placeholder. I think this is what it meant, but feel free to fix it in other way (or delete entirely?)