### PR TITLE
Add conditional cfg(test) to modules

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -575,9 +575,10 @@ impl BroCatli {
     }
 }
 
+#[cfg(test)]
 mod test {
-    #[cfg(test)]
     use super::BroCatli;
+
     #[test]
     fn test_deserialization() {
         let broccoli = BroCatli {

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -1,5 +1,5 @@
-#![cfg(feature = "std")]
 #![cfg(test)]
+#![cfg(feature = "std")]
 
 use alloc_stdlib::StandardAlloc;
 

--- a/src/enc/interface.rs
+++ b/src/enc/interface.rs
@@ -761,6 +761,7 @@ pub fn u8_to_speed(data: u8) -> u16 {
         (1u16 << log_val) | (rem >> 3)
     }
 }
+
 #[cfg(test)]
 mod test {
     use super::{speed_to_u8, u8_to_speed};

--- a/src/enc/static_dict.rs
+++ b/src/enc/static_dict.rs
@@ -234,102 +234,6 @@ pub fn ComplexFindMatchLengthWithLimit(mut s1: &[u8], mut s2: &[u8], mut limit: 
     matched + (limit & 7usize) // made it through the loop
 }
 
-mod test {
-    #[allow(unused)]
-    fn construct_situation(seed: &[u8], mut output: &mut [u8], limit: usize, matchfor: usize) {
-        output[..].clone_from_slice(seed);
-        if matchfor >= limit {
-            return;
-        }
-        output[matchfor] = output[matchfor].wrapping_add((matchfor as u8 % 253u8).wrapping_add(1));
-    }
-    #[test]
-    fn test_find_match_length() {
-        let mut a = [91u8; 600000];
-        let mut b = [0u8; 600000];
-        for i in 1..a.len() {
-            a[i] = (a[i - 1] % 19u8).wrapping_add(17);
-        }
-        construct_situation(&a[..], &mut b[..], a.len(), 0);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 0);
-        construct_situation(&a[..], &mut b[..], a.len(), 1);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 1);
-        construct_situation(&a[..], &mut b[..], a.len(), 10);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 10);
-        construct_situation(&a[..], &mut b[..], a.len(), 9);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 9);
-        construct_situation(&a[..], &mut b[..], a.len(), 7);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 7);
-        construct_situation(&a[..], &mut b[..], a.len(), 8);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 8);
-        construct_situation(&a[..], &mut b[..], a.len(), 48);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 48);
-        construct_situation(&a[..], &mut b[..], a.len(), 49);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 49);
-        construct_situation(&a[..], &mut b[..], a.len(), 63);
-        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 63);
-        construct_situation(&a[..], &mut b[..], a.len(), 222);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            222
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 1590);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            1590
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 12590);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            12590
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 52592);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            52592
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 152592);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            152592
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 252591);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            252591
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 131072);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            131072
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 131073);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            131073
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 131072 + 64 + 32 + 16 + 8);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            131072 + 64 + 32 + 16 + 8
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 272144 + 64 + 32 + 16 + 8 + 1);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            272144 + 64 + 32 + 16 + 8 + 1
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), 2 * 272144 + 64 + 32 + 16 + 8);
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            2 * 272144 + 64 + 32 + 16 + 8
-        );
-        construct_situation(&a[..], &mut b[..], a.len(), a.len());
-        assert_eq!(
-            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
-            a.len()
-        );
-    }
-}
 #[allow(unused)]
 pub fn slowFindMatchLengthWithLimit(s1: &[u8], s2: &[u8], limit: usize) -> usize {
     for (index, it) in s1[..limit].iter().zip(s2[..limit].iter()).enumerate() {
@@ -1397,4 +1301,102 @@ pub fn BrotliFindAllStaticDictionaryMatches(
         }
     }
     has_found_match
+}
+
+#[cfg(test)]
+mod test {
+    #[allow(unused)]
+    fn construct_situation(seed: &[u8], mut output: &mut [u8], limit: usize, matchfor: usize) {
+        output[..].clone_from_slice(seed);
+        if matchfor >= limit {
+            return;
+        }
+        output[matchfor] = output[matchfor].wrapping_add((matchfor as u8 % 253u8).wrapping_add(1));
+    }
+    #[test]
+    fn test_find_match_length() {
+        let mut a = [91u8; 600000];
+        let mut b = [0u8; 600000];
+        for i in 1..a.len() {
+            a[i] = (a[i - 1] % 19u8).wrapping_add(17);
+        }
+        construct_situation(&a[..], &mut b[..], a.len(), 0);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 0);
+        construct_situation(&a[..], &mut b[..], a.len(), 1);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 1);
+        construct_situation(&a[..], &mut b[..], a.len(), 10);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 10);
+        construct_situation(&a[..], &mut b[..], a.len(), 9);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 9);
+        construct_situation(&a[..], &mut b[..], a.len(), 7);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 7);
+        construct_situation(&a[..], &mut b[..], a.len(), 8);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 8);
+        construct_situation(&a[..], &mut b[..], a.len(), 48);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 48);
+        construct_situation(&a[..], &mut b[..], a.len(), 49);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 49);
+        construct_situation(&a[..], &mut b[..], a.len(), 63);
+        assert_eq!(super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()), 63);
+        construct_situation(&a[..], &mut b[..], a.len(), 222);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            222
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 1590);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            1590
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 12590);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            12590
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 52592);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            52592
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 152592);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            152592
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 252591);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            252591
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 131072);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            131072
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 131073);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            131073
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 131072 + 64 + 32 + 16 + 8);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            131072 + 64 + 32 + 16 + 8
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 272144 + 64 + 32 + 16 + 8 + 1);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            272144 + 64 + 32 + 16 + 8 + 1
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), 2 * 272144 + 64 + 32 + 16 + 8);
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            2 * 272144 + 64 + 32 + 16 + 8
+        );
+        construct_situation(&a[..], &mut b[..], a.len(), a.len());
+        assert_eq!(
+            super::FindMatchLengthWithLimit(&a[..], &b[..], a.len()),
+            a.len()
+        );
+    }
 }

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -1,11 +1,12 @@
 #![cfg(not(feature = "safe"))]
+mod test;
+
+use alloc::SliceWrapper;
+use core::cmp::min;
 #[cfg(feature = "std")]
 use std::io::Write;
 #[cfg(feature = "std")]
-use std::{io, panic, thread};
-mod test;
-use alloc::SliceWrapper;
-use core::cmp::min;
+use std::panic;
 
 use brotli_decompressor::ffi::alloc_util::SubclassableAllocator;
 use brotli_decompressor::ffi::interface::{
@@ -426,13 +427,13 @@ pub unsafe extern "C" fn BrotliEncoderCompressWorkPool(
 #[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
 fn catch_panic_wstate<F: FnOnce() -> *mut BrotliEncoderWorkPool + panic::UnwindSafe>(
     f: F,
-) -> thread::Result<*mut BrotliEncoderWorkPool> {
+) -> std::thread::Result<*mut BrotliEncoderWorkPool> {
     panic::catch_unwind(f)
 }
 
 #[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
 fn error_print<Err: core::fmt::Debug>(err: Err) {
-    let _ign = writeln!(&mut io::stderr(), "Internal Error {:?}", err);
+    let _ign = writeln!(&mut std::io::stderr(), "Internal Error {:?}", err);
 }
 
 #[cfg(any(not(feature = "std"), feature = "pass-through-ffi-panics"))]


### PR DESCRIPTION
Some modules were missing conditional test-only compilation.  In a few files, move `mod test {...}` to the end of the file (per convention)