### PR TITLE
Simplify mem cell alloc usage

### DIFF
--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -135,7 +135,7 @@ pub fn compress_validate<InputType: Read, OutputType: Write>(
     num_threads: usize,
 ) -> Result<(), io::Error> {
     let mut m8 = HeapAllocator::default();
-    let buffer = <HeapAllocator as Allocator<u8>>::alloc_cell(&mut m8, buffer_size);
+    let buffer = m8.alloc_cell(buffer_size);
     // FIXME: could reuse the dictionary to seed the compressor, but that violates the abstraction right now
     // also dictionaries are not very popular since they are mostly an internal concept, given their deprecation in
     // the standard brotli spec

--- a/src/enc/backward_references/benchmark.rs
+++ b/src/enc/backward_references/benchmark.rs
@@ -29,16 +29,11 @@ fn make_generic_hasher() -> AdvHasher<H5Sub, StandardAlloc> {
     let block_size = 1u64 << params_hasher.block_bits;
     let bucket_size = 1u64 << params_hasher.bucket_bits;
     let mut alloc = StandardAlloc::default();
-    let buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    let num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
 
     AdvHasher::<H5Sub, StandardAlloc> {
-        buckets: buckets,
+        buckets: alloc.alloc_cell((bucket_size * block_size) as usize),
         h9_opts: H9Opts::new(&params_hasher),
-        num: num,
+        num: alloc.alloc_cell(bucket_size as usize),
         GetHasherCommon: Struct1 {
             params: params_hasher,
             is_prepared_: 1,
@@ -65,16 +60,11 @@ fn make_specialized_hasher() -> AdvHasher<HQ7Sub, StandardAlloc> {
     let block_size = 1u64 << params_hasher.block_bits;
     let bucket_size = 1u64 << params_hasher.bucket_bits;
     let mut alloc = StandardAlloc::default();
-    let buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    let num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
 
     AdvHasher::<HQ7Sub, StandardAlloc> {
-        buckets: buckets,
+        buckets: alloc.alloc_cell((bucket_size * block_size) as usize),
         h9_opts: H9Opts::new(&params_hasher),
-        num: num,
+        num: alloc.alloc_cell(bucket_size as usize),
         GetHasherCommon: Struct1 {
             params: params_hasher,
             is_prepared_: 1,

--- a/src/enc/backward_references/hash_to_binary_tree.rs
+++ b/src/enc/backward_references/hash_to_binary_tree.rs
@@ -8,6 +8,7 @@ use super::{
     kHashMul32, AnyHasher, BrotliEncoderParams, CloneWithAlloc, H9Opts, HasherSearchResult,
     HowPrepared, Struct1,
 };
+use crate::enc::combined_alloc::allocate;
 use crate::enc::static_dict::{
     BrotliDictionary, FindMatchLengthWithLimit, BROTLI_UNALIGNED_LOAD32,
 };
@@ -206,7 +207,7 @@ where
             common: self.common.clone(),
             buckets_: Buckets::new_uninit(m),
             invalid_pos_: self.invalid_pos_,
-            forest: <Alloc as Allocator<u32>>::alloc_cell(m, self.forest.len()),
+            forest: allocate::<u32, _>(m, self.forest.len()),
             _params: core::marker::PhantomData::<Params>,
         };
         ret.buckets_

--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -12,6 +12,7 @@ use super::{
     kDistanceCacheIndex, kDistanceCacheOffset, kHashMul32, kInvalidMatch, AnyHasher,
     BrotliEncoderParams,
 };
+use crate::enc::combined_alloc::{alloc_if, alloc_or_default};
 use crate::enc::command::{
     BrotliDistanceParams, CombineLengthCodes, Command, GetCopyLengthCode, GetInsertLengthCode,
     PrefixEncodeCopyDistance,
@@ -209,16 +210,14 @@ impl<AllocF: Allocator<floatX>> ZopfliCostModel<AllocF> {
             num_bytes_: num_bytes,
             cost_cmd_: [0.0; 704],
             min_cost_cmd_: 0.0,
-            literal_costs_: if num_bytes.wrapping_add(2) > 0usize {
-                m.alloc_cell(num_bytes.wrapping_add(2))
-            } else {
-                AllocF::AllocatedMemory::default()
-            },
-            cost_dist_: if dist.alphabet_size > 0u32 {
-                m.alloc_cell(num_bytes.wrapping_add(dist.alphabet_size as usize))
-            } else {
-                AllocF::AllocatedMemory::default()
-            },
+            // FIXME: makes little sense to test if N+2 > 0 -- always true unless wrapping. Perhaps use allocate() instead?
+            literal_costs_: alloc_or_default::<floatX, _>(m, num_bytes + 2),
+            // FIXME: possible bug because allocation size is different from the condition
+            cost_dist_: alloc_if::<floatX, _>(
+                dist.alphabet_size > 0,
+                m,
+                num_bytes + dist.alphabet_size as usize,
+            ),
             distance_histogram_size: min(dist.alphabet_size, 544),
         }
     }
@@ -988,12 +987,8 @@ pub fn BrotliCreateZopfliBackwardReferences<
     Buckets: PartialEq<Buckets>,
 {
     let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16);
-    let mut nodes: <Alloc as Allocator<ZopfliNode>>::AllocatedMemory;
-    nodes = if num_bytes.wrapping_add(1) > 0usize {
-        <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
-    } else {
-        <Alloc as Allocator<ZopfliNode>>::AllocatedMemory::default()
-    };
+    // FIXME: makes little sense to test if N+1 > 0 -- always true unless wrapping. Perhaps use allocate() instead?
+    let mut nodes = alloc_or_default::<ZopfliNode, _>(alloc, num_bytes + 1);
     if !(0i32 == 0) {
         return;
     }
@@ -1244,11 +1239,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     Buckets: PartialEq<Buckets>,
 {
     let max_backward_limit: usize = (1usize << params.lgwin).wrapping_sub(16);
-    let mut num_matches: <Alloc as Allocator<u32>>::AllocatedMemory = if num_bytes > 0usize {
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, num_bytes)
-    } else {
-        <Alloc as Allocator<u32>>::AllocatedMemory::default()
-    };
+    let mut num_matches = alloc_or_default::<u32, _>(alloc, num_bytes);
     let mut matches_size: usize = (4usize).wrapping_mul(num_bytes);
     let store_end: usize = if num_bytes >= STORE_LOOKAHEAD_H_10 {
         position
@@ -1264,12 +1255,7 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
     let mut orig_dist_cache = [0i32; 4];
 
     let mut model: ZopfliCostModel<Alloc>;
-    let mut nodes: <Alloc as Allocator<ZopfliNode>>::AllocatedMemory;
-    let mut matches: <Alloc as Allocator<u64>>::AllocatedMemory = if matches_size > 0usize {
-        <Alloc as Allocator<u64>>::alloc_cell(alloc, matches_size)
-    } else {
-        <Alloc as Allocator<u64>>::AllocatedMemory::default()
-    };
+    let mut matches = alloc_or_default::<u64, _>(alloc, matches_size);
     let gap: usize = 0usize;
     let shadow_matches: usize = 0usize;
     i = 0usize;
@@ -1287,15 +1273,10 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
                     } else {
                         matches_size
                     };
-                    let mut new_array: <Alloc as Allocator<u64>>::AllocatedMemory;
                     while new_size < cur_match_pos.wrapping_add(128).wrapping_add(shadow_matches) {
                         new_size = new_size.wrapping_mul(2);
                     }
-                    new_array = if new_size > 0usize {
-                        <Alloc as Allocator<u64>>::alloc_cell(alloc, new_size)
-                    } else {
-                        <Alloc as Allocator<u64>>::AllocatedMemory::default()
-                    };
+                    let mut new_array = alloc_or_default::<u64, _>(alloc, new_size);
                     if matches_size != 0 {
                         for (dst, src) in new_array
                             .slice_mut()
@@ -1380,11 +1361,8 @@ pub fn BrotliCreateHqZopfliBackwardReferences<
         *i = *j;
     }
     let orig_num_commands: usize = *num_commands;
-    nodes = if num_bytes.wrapping_add(1) > 0usize {
-        <Alloc as Allocator<ZopfliNode>>::alloc_cell(alloc, num_bytes.wrapping_add(1))
-    } else {
-        <Alloc as Allocator<ZopfliNode>>::AllocatedMemory::default()
-    };
+    // FIXME: makes little sense to test if N+1 > 0 -- always true unless wrapping. Perhaps use allocate() instead?
+    let mut nodes = alloc_or_default::<ZopfliNode, _>(alloc, num_bytes + 1);
     if !(0i32 == 0) {
         return;
     }

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -16,6 +16,7 @@ use super::static_dict::{
     BROTLI_UNALIGNED_LOAD32, BROTLI_UNALIGNED_LOAD64,
 };
 use super::util::{floatX, Log2FloorNonZero};
+use crate::enc::combined_alloc::allocate;
 
 static kBrotliMinWindowBits: i32 = 10;
 static kBrotliMaxWindowBits: i32 = 24;
@@ -1955,8 +1956,8 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
     fn clone_with_alloc(&self, m: &mut Alloc) -> Self {
         let mut ret = BasicHasher::<H2Sub<Alloc>> {
             GetHasherCommon: self.GetHasherCommon.clone(),
-            buckets_: H2Sub::<Alloc> {
-                buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
+            buckets_: H2Sub {
+                buckets_: allocate::<u32, _>(m, self.buckets_.buckets_.len()),
             },
             h9_opts: self.h9_opts,
         };
@@ -1974,7 +1975,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
         let mut ret = BasicHasher::<H3Sub<Alloc>> {
             GetHasherCommon: self.GetHasherCommon.clone(),
             buckets_: H3Sub::<Alloc> {
-                buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
+                buckets_: allocate::<u32, _>(m, self.buckets_.buckets_.len()),
             },
             h9_opts: self.h9_opts,
         };
@@ -1992,7 +1993,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
         let mut ret = BasicHasher::<H4Sub<Alloc>> {
             GetHasherCommon: self.GetHasherCommon.clone(),
             buckets_: H4Sub::<Alloc> {
-                buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.buckets_.len()),
+                buckets_: allocate::<u32, _>(m, self.buckets_.buckets_.len()),
             },
             h9_opts: self.h9_opts,
         };
@@ -2010,7 +2011,7 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
         let mut ret = BasicHasher::<H54Sub<Alloc>> {
             GetHasherCommon: self.GetHasherCommon.clone(),
             buckets_: H54Sub::<Alloc> {
-                buckets_: <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.len()),
+                buckets_: allocate::<u32, _>(m, self.buckets_.len()),
             },
             h9_opts: self.h9_opts,
         };
@@ -2023,9 +2024,9 @@ impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc>
 }
 impl<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>> CloneWithAlloc<Alloc> for H9<Alloc> {
     fn clone_with_alloc(&self, m: &mut Alloc) -> Self {
-        let mut num = <Alloc as Allocator<u16>>::alloc_cell(m, self.num_.len());
+        let mut num = allocate::<u16, _>(m, self.num_.len());
         num.slice_mut().clone_from_slice(self.num_.slice());
-        let mut buckets = <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets_.len());
+        let mut buckets = allocate::<u32, _>(m, self.buckets_.len());
         buckets.slice_mut().clone_from_slice(self.buckets_.slice());
         H9::<Alloc> {
             num_: num,
@@ -2041,9 +2042,9 @@ impl<
     > CloneWithAlloc<Alloc> for AdvHasher<Special, Alloc>
 {
     fn clone_with_alloc(&self, m: &mut Alloc) -> Self {
-        let mut num = <Alloc as Allocator<u16>>::alloc_cell(m, self.num.len());
+        let mut num = allocate::<u16, _>(m, self.num.len());
         num.slice_mut().clone_from_slice(self.num.slice());
-        let mut buckets = <Alloc as Allocator<u32>>::alloc_cell(m, self.buckets.len());
+        let mut buckets = allocate::<u32, _>(m, self.buckets.len());
         buckets.slice_mut().clone_from_slice(self.buckets.slice());
         AdvHasher::<Special, Alloc> {
             GetHasherCommon: self.GetHasherCommon.clone(),

--- a/src/enc/backward_references/test.rs
+++ b/src/enc/backward_references/test.rs
@@ -6,6 +6,7 @@ use alloc_stdlib::StandardAlloc;
 use super::{
     AdvHasher, AnyHasher, BrotliHasherParams, CloneWithAlloc, H5Sub, H9Opts, HQ7Sub, Struct1,
 };
+use crate::enc::combined_alloc::allocate;
 use crate::enc::{Allocator, SliceWrapper};
 
 static RANDOM_THEN_UNICODE: &[u8] = include_bytes!("../../../testdata/random_then_unicode"); //&[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55];
@@ -24,11 +25,8 @@ fn test_bulk_store_range() {
     let block_size = 1u64 << params_hasher.block_bits;
     let bucket_size = 1u64 << params_hasher.bucket_bits;
     let mut alloc = StandardAlloc::default();
-    let mut buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    let mut num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    let mut buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    let mut num = alloc.alloc_cell(bucket_size as usize);
 
     let mut hasher_a = AdvHasher::<H5Sub, StandardAlloc> {
         buckets,
@@ -47,11 +45,8 @@ fn test_bulk_store_range() {
             block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
-    buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    num = alloc.alloc_cell(bucket_size as usize);
     let mut hasher_b = hasher_a.clone_with_alloc(&mut alloc);
     assert!(hasher_a == hasher_b);
     let mut hasher_e = hasher_a.clone_with_alloc(&mut alloc);
@@ -126,11 +121,8 @@ fn test_bulk_store_range_off_spec() {
     let block_size = 1u64 << params_hasher.block_bits;
     let bucket_size = 1u64 << params_hasher.bucket_bits;
     let mut alloc = StandardAlloc::default();
-    let mut buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    let mut num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    let mut buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    let mut num = alloc.alloc_cell(bucket_size as usize);
 
     let mut hasher_a = AdvHasher::<H5Sub, StandardAlloc> {
         buckets,
@@ -149,11 +141,8 @@ fn test_bulk_store_range_off_spec() {
             block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
-    buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    num = alloc.alloc_cell(bucket_size as usize);
     let mut hasher_b = hasher_a.clone_with_alloc(&mut alloc);
     assert!(hasher_a == hasher_b);
     let mut hasher_c = AdvHasher::<HQ7Sub, StandardAlloc> {
@@ -214,11 +203,8 @@ fn test_bulk_store_range_pow2() {
     let block_size = 1u64 << params_hasher.block_bits;
     let bucket_size = 1u64 << params_hasher.bucket_bits;
     let mut alloc = StandardAlloc::default();
-    let mut buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    let mut num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    let mut buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    let mut num = alloc.alloc_cell(bucket_size as usize);
 
     let mut hasher_a = AdvHasher::<H5Sub, StandardAlloc> {
         buckets,
@@ -237,11 +223,8 @@ fn test_bulk_store_range_pow2() {
             block_mask_: block_size.wrapping_sub(1) as u32,
         },
     };
-    buckets = <StandardAlloc as Allocator<u32>>::alloc_cell(
-        &mut alloc,
-        (bucket_size * block_size) as usize,
-    );
-    num = <StandardAlloc as Allocator<u16>>::alloc_cell(&mut alloc, bucket_size as usize);
+    buckets = allocate::<u32, _>(&mut alloc, (bucket_size * block_size) as usize);
+    num = alloc.alloc_cell(bucket_size as usize);
     let mut hasher_b = hasher_a.clone_with_alloc(&mut alloc);
     assert!(hasher_a == hasher_b);
     let mut hasher_e = hasher_a.clone_with_alloc(&mut alloc);

--- a/src/enc/block_split.rs
+++ b/src/enc/block_split.rs
@@ -2,6 +2,7 @@
 
 use super::super::alloc;
 use super::super::alloc::{Allocator, SliceWrapper};
+use crate::enc::combined_alloc::alloc_default;
 
 pub struct BlockSplit<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> {
     pub num_types: usize,
@@ -15,8 +16,8 @@ impl<Alloc: alloc::Allocator<u8> + alloc::Allocator<u32>> Default for BlockSplit
         Self {
             num_types: 0,
             num_blocks: 0,
-            types: <Alloc as Allocator<u8>>::AllocatedMemory::default(),
-            lengths: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
+            types: alloc_default::<u8, Alloc>(),
+            lengths: alloc_default::<u32, Alloc>(),
         }
     }
 }

--- a/src/enc/brotli_bit_stream.rs
+++ b/src/enc/brotli_bit_stream.rs
@@ -36,6 +36,7 @@ use super::static_dict::kNumDistanceCacheEntries;
 use super::util::floatX;
 use super::{find_stride, interface, prior_eval, stride_eval};
 use crate::enc::backward_references::BrotliEncoderParams;
+use crate::enc::combined_alloc::{alloc_default, alloc_or_default, allocate};
 use crate::VERSION;
 
 pub struct PrefixCodeRange {
@@ -121,8 +122,7 @@ impl<'a, Alloc: BrotliAlloc> CommandQueue<'a, Alloc> {
     ) -> CommandQueue<'a, Alloc> {
         // assume no more than 1/16 of the stream is block_types which may chop up literals
         // also there's the first btypel and a potential wrap around the ring buffer
-        let queue =
-            <Alloc as Allocator<StaticCommand>>::alloc_cell(alloc, num_commands * 17 / 16 + 4);
+        let queue = allocate::<StaticCommand, _>(alloc, num_commands * 17 / 16 + 4);
         CommandQueue {
             mc: alloc,
             queue, // always need a spare command in case the ring buffer splits a literal into two
@@ -190,10 +190,7 @@ impl<'a, Alloc: BrotliAlloc> CommandQueue<'a, Alloc> {
 impl<'a, Alloc: BrotliAlloc> interface::CommandProcessor<'a> for CommandQueue<'a, Alloc> {
     fn push(&mut self, val: interface::Command<InputReference<'a>>) {
         if self.full() {
-            let mut tmp = <Alloc as Allocator<StaticCommand>>::alloc_cell(
-                self.mc,
-                self.queue.slice().len() * 2,
-            );
+            let mut tmp = allocate::<StaticCommand, _>(self.mc, self.queue.slice().len() * 2);
             tmp.slice_mut()
                 .split_at_mut(self.queue.slice().len())
                 .0
@@ -557,7 +554,7 @@ fn LogMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
             orig_offset: input0.len(),
         },
     );
-    let mut best_strides = <Alloc as Allocator<u8>>::AllocatedMemory::default();
+    let mut best_strides = alloc_default::<u8, Alloc>();
     if params.stride_detection_quality > 2 {
         let mut stride_selector =
             stride_eval::StrideEval::<Alloc>::new(alloc, input, &prediction_mode, params);
@@ -572,7 +569,7 @@ fn LogMetaBlock<'a, Alloc: BrotliAlloc, Cb>(
             context_type,
         );
         let ntypes = stride_selector.num_types();
-        best_strides = <Alloc as Allocator<u8>>::alloc_cell(stride_selector.alloc(), ntypes);
+        best_strides = allocate::<u8, _>(stride_selector.alloc(), ntypes);
         stride_selector.choose_stride(best_strides.slice_mut());
     }
     let mut context_map_entropy = ContextMapEntropy::<Alloc>::new(
@@ -999,12 +996,10 @@ pub fn BrotliBuildAndStoreHuffmanTreeFast<AllocHT: alloc::Allocator<HuffmanTree>
         *depth_elem = 0; // memset
     }
     {
+        // FIXME: computation in u64, followed by allocation which might be less than u64
         let max_tree_size: u64 = (2u64).wrapping_mul(length).wrapping_add(1);
-        let mut tree = if max_tree_size != 0 {
-            m.alloc_cell(max_tree_size as usize)
-        } else {
-            AllocHT::AllocatedMemory::default() // null
-        };
+        // FIXME: makes little sense to test if N+1 > 0 -- always true unless wrapping. Perhaps use allocate() instead?
+        let mut tree = alloc_or_default::<HuffmanTree, _>(m, max_tree_size as usize);
         let mut count_limit: u32;
         if !(0i32 == 0) {
             return;
@@ -1209,19 +1204,18 @@ impl<
 {
     fn default() -> Self {
         Self {
-            literal_split: BlockSplit::<Alloc>::new(),
-            command_split: BlockSplit::<Alloc>::new(),
-            distance_split: BlockSplit::<Alloc>::new(),
-            literal_context_map: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
+            literal_split: BlockSplit::default(),
+            command_split: BlockSplit::default(),
+            distance_split: BlockSplit::default(),
+            literal_context_map: alloc_default::<u32, Alloc>(),
             literal_context_map_size: 0,
-            distance_context_map: <Alloc as Allocator<u32>>::AllocatedMemory::default(),
+            distance_context_map: alloc_default::<u32, Alloc>(),
             distance_context_map_size: 0,
-            literal_histograms: <Alloc as Allocator<HistogramLiteral>>::AllocatedMemory::default(),
+            literal_histograms: alloc_default::<HistogramLiteral, Alloc>(),
             literal_histograms_size: 0,
-            command_histograms: <Alloc as Allocator<HistogramCommand>>::AllocatedMemory::default(),
+            command_histograms: alloc_default::<HistogramCommand, Alloc>(),
             command_histograms_size: 0,
-            distance_histograms: <Alloc as Allocator<HistogramDistance>>::AllocatedMemory::default(
-            ),
+            distance_histograms: alloc_default::<HistogramDistance, Alloc>(),
             distance_histograms_size: 0,
         }
     }
@@ -1396,8 +1390,8 @@ impl<'a, Alloc: Allocator<u8> + Allocator<u16>> BlockEncoder<'a, Alloc> {
             block_ix_: 0,
             block_len_: block_len,
             entropy_ix_: 0,
-            depths_: <Alloc as Allocator<u8>>::AllocatedMemory::default(),
-            bits_: <Alloc as Allocator<u16>>::AllocatedMemory::default(),
+            depths_: alloc_default::<u8, Alloc>(),
+            bits_: alloc_default::<u16, Alloc>(),
         }
     }
 }
@@ -1847,11 +1841,7 @@ fn EncodeContextMap<AllocU32: alloc::Allocator<u32>>(
     if num_clusters == 1 {
         return;
     }
-    rle_symbols = if context_map_size != 0 {
-        m.alloc_cell(context_map_size)
-    } else {
-        AllocU32::AllocatedMemory::default()
-    };
+    rle_symbols = alloc_or_default::<u32, _>(m, context_map_size);
     MoveToFrontTransform(context_map, context_map_size, rle_symbols.slice_mut());
     RunLengthCodeZeros(
         context_map_size,
@@ -1921,16 +1911,8 @@ impl<Alloc: Allocator<u8> + Allocator<u16>> BlockEncoder<'_, Alloc> {
         storage: &mut [u8],
     ) {
         let table_size: usize = histograms_size.wrapping_mul(self.histogram_length_);
-        self.depths_ = if table_size != 0 {
-            <Alloc as Allocator<u8>>::alloc_cell(m, table_size)
-        } else {
-            <Alloc as Allocator<u8>>::AllocatedMemory::default()
-        };
-        self.bits_ = if table_size != 0 {
-            <Alloc as Allocator<u16>>::alloc_cell(m, table_size)
-        } else {
-            <Alloc as Allocator<u16>>::AllocatedMemory::default()
-        };
+        self.depths_ = alloc_or_default::<u8, _>(m, table_size);
+        self.bits_ = alloc_or_default::<u16, _>(m, table_size);
         {
             for i in 0usize..histograms_size {
                 let ix: usize = i.wrapping_mul(self.histogram_length_);
@@ -2137,7 +2119,6 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
     let mut pos: usize = start_pos;
     let num_distance_symbols = params.dist.alphabet_size;
     let mut num_effective_distance_symbols = num_distance_symbols as usize;
-    let mut tree: <Alloc as Allocator<HuffmanTree>>::AllocatedMemory;
     let _literal_context_lut = BROTLI_CONTEXT_LUT(literal_context_mode);
     let mut literal_enc: BlockEncoder<Alloc>;
     let mut command_enc: BlockEncoder<Alloc>;
@@ -2148,11 +2129,7 @@ pub fn BrotliStoreMetaBlock<Alloc: BrotliAlloc, Cb>(
         num_effective_distance_symbols = BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS;
     }
     StoreCompressedMetaBlockHeader(is_last, length, storage_ix, storage);
-    tree = if 2i32 * 704i32 + 1i32 != 0 {
-        <Alloc as Allocator<HuffmanTree>>::alloc_cell(alloc, (2i32 * 704i32 + 1i32) as usize)
-    } else {
-        <Alloc as Allocator<HuffmanTree>>::AllocatedMemory::default()
-    };
+    let mut tree = allocate::<HuffmanTree, _>(alloc, 2 * 704 + 1);
     literal_enc = BlockEncoder::new(
         BROTLI_NUM_LITERAL_SYMBOLS,
         mb.literal_split.num_types,

--- a/src/enc/cluster.rs
+++ b/src/enc/cluster.rs
@@ -10,6 +10,7 @@ use super::histogram::{
     CostAccessors, HistogramAddHistogram, HistogramClear, HistogramSelfAddHistogram,
 };
 use super::util::FastLog2;
+use crate::enc::combined_alloc::{alloc_or_default, allocate};
 
 #[derive(Clone, Copy)]
 pub struct HistogramPair {
@@ -324,11 +325,7 @@ pub fn BrotliHistogramReindex<
     length: usize,
 ) -> usize {
     static kInvalidIndex: u32 = !(0u32);
-    let mut new_index = if length != 0 {
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, length)
-    } else {
-        <Alloc as Allocator<u32>>::AllocatedMemory::default()
-    };
+    let mut new_index = alloc_or_default::<u32, _>(alloc, length);
     let mut next_index: u32;
     let mut tmp: <Alloc as Allocator<HistogramType>>::AllocatedMemory;
     for i in 0usize..length {
@@ -341,11 +338,7 @@ pub fn BrotliHistogramReindex<
             next_index = next_index.wrapping_add(1);
         }
     }
-    tmp = if next_index != 0 {
-        <Alloc as Allocator<HistogramType>>::alloc_cell(alloc, next_index as usize)
-    } else {
-        <Alloc as Allocator<HistogramType>>::AllocatedMemory::default()
-    };
+    tmp = alloc_or_default::<HistogramType, _>(alloc, next_index as usize);
     next_index = 0u32;
     for i in 0usize..length {
         if new_index.slice()[(symbols[i] as usize)] == next_index {
@@ -379,23 +372,14 @@ pub fn BrotliClusterHistograms<
     out_size: &mut usize,
     histogram_symbols: &mut [u32],
 ) {
-    let mut cluster_size = if in_size != 0 {
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, in_size)
-    } else {
-        <Alloc as Allocator<u32>>::AllocatedMemory::default()
-    };
-    let mut clusters = if in_size != 0 {
-        <Alloc as Allocator<u32>>::alloc_cell(alloc, in_size)
-    } else {
-        <Alloc as Allocator<u32>>::AllocatedMemory::default()
-    };
+    let mut cluster_size = alloc_or_default::<u32, Alloc>(alloc, in_size);
+    let mut clusters = alloc_or_default::<u32, Alloc>(alloc, in_size);
     let mut num_clusters: usize = 0usize;
     let max_input_histograms: usize = 64usize;
     let pairs_capacity: usize = max_input_histograms
         .wrapping_mul(max_input_histograms)
         .wrapping_div(2);
-    let mut pairs =
-        <Alloc as Allocator<HistogramPair>>::alloc_cell(alloc, pairs_capacity.wrapping_add(1));
+    let mut pairs = allocate::<HistogramPair, _>(alloc, pairs_capacity.wrapping_add(1));
     let mut i: usize;
     for i in 0usize..in_size {
         cluster_size.slice_mut()[i] = 1u32;
@@ -445,11 +429,7 @@ pub fn BrotliClusterHistograms<
                 while _new_size < max_num_pairs.wrapping_add(1) {
                     _new_size = _new_size.wrapping_mul(2);
                 }
-                new_array = if _new_size != 0 {
-                    <Alloc as Allocator<HistogramPair>>::alloc_cell(alloc, _new_size)
-                } else {
-                    <Alloc as Allocator<HistogramPair>>::AllocatedMemory::default()
-                };
+                new_array = alloc_or_default::<HistogramPair, _>(alloc, _new_size);
                 new_array.slice_mut()[..pairs_capacity]
                     .clone_from_slice(&pairs.slice()[..pairs_capacity]);
                 <Alloc as Allocator<HistogramPair>>::free_cell(

--- a/src/enc/combined_alloc.rs
+++ b/src/enc/combined_alloc.rs
@@ -519,3 +519,34 @@ implement_allocator!(
     AllocZopfliNode::AllocatedMemory,
     alloc_zn
 );
+
+/// Helper function to allocate memory with the given allocator (may crash if the `len` is 0).
+pub(crate) fn allocate<T, A: Allocator<T>>(alloc: &mut A, len: usize) -> A::AllocatedMemory {
+    A::alloc_cell(alloc, len)
+}
+
+/// Helper function to create an empty allocator object
+pub(crate) fn alloc_default<T, A: Allocator<T>>() -> A::AllocatedMemory {
+    A::AllocatedMemory::default()
+}
+
+/// Helper function to allocate memory or return a default value if the condition is false
+pub(crate) fn alloc_if<T, A: Allocator<T>>(
+    condition: bool,
+    alloc: &mut A,
+    len: usize,
+) -> A::AllocatedMemory {
+    if condition {
+        allocate(alloc, len)
+    } else {
+        alloc_default::<T, A>()
+    }
+}
+
+/// Helper function to allocate memory or return a default value when the size is 0.
+pub(crate) fn alloc_or_default<T, A: Allocator<T>>(
+    alloc: &mut A,
+    len: usize,
+) -> A::AllocatedMemory {
+    alloc_if(len > 0, alloc, len)
+}

--- a/src/enc/context_map_entropy.rs
+++ b/src/enc/context_map_entropy.rs
@@ -7,6 +7,7 @@ pub use super::ir_interpret::{push_base, Context, IRInterpreter};
 use super::util::{floatX, FastLog2u16};
 use super::weights::{Weights, BLEND_FIXED_POINT_PRECISION};
 use super::{find_stride, interface};
+use crate::enc::combined_alloc::alloc_if;
 
 const DEFAULT_CM_SPEED_INDEX: usize = 8;
 const NUM_SPEEDS_TO_TRY: usize = 16;
@@ -306,16 +307,8 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
             block_type: 0,
             cur_stride: 1,
             local_byte_offset: 0,
-            cm_priors: if cdf_detect {
-                <Alloc as Allocator<u16>>::alloc_cell(m16, CONTEXT_MAP_PRIOR_SIZE)
-            } else {
-                <Alloc as Allocator<u16>>::AllocatedMemory::default()
-            },
-            stride_priors: if cdf_detect {
-                <Alloc as Allocator<u16>>::alloc_cell(m16, STRIDE_PRIOR_SIZE)
-            } else {
-                <Alloc as Allocator<u16>>::AllocatedMemory::default()
-            },
+            cm_priors: alloc_if::<u16, _>(cdf_detect, m16, CONTEXT_MAP_PRIOR_SIZE),
+            stride_priors: alloc_if::<u16, _>(cdf_detect, m16, STRIDE_PRIOR_SIZE),
             _stride_pyramid_leaves: stride,
             weight: [
                 [Weights::new(); NUM_SPEEDS_TO_TRY],

--- a/src/enc/find_stride.rs
+++ b/src/enc/find_stride.rs
@@ -6,6 +6,7 @@ use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::input_pair::{InputPair, InputReference};
 use super::interface;
 use super::util::FastLog2;
+use crate::enc::combined_alloc::alloc_if;
 // float32 doesn't have enough resolution for blocks of data more than 3.5 megs
 pub type floatY = f64;
 // the cost of storing a particular population of data including the approx
@@ -35,6 +36,7 @@ pub struct EntropyBucketPopulation<AllocU32: alloc::Allocator<u32>> {
     pub bucket_populations: AllocU32::AllocatedMemory,
     pub cached_bit_entropy: floatY,
 }
+
 impl<AllocU32: alloc::Allocator<u32>> EntropyBucketPopulation<AllocU32> {
     pub fn new(m32: &mut AllocU32) -> Self {
         let size = 256 * 256;
@@ -236,63 +238,63 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyPyramid<AllocU32> {
     pub fn disabled_placeholder(_m32: &mut AllocU32) -> Self {
         EntropyPyramid::<AllocU32> {
             pop: [
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
                     bucket_populations: AllocU32::AllocatedMemory::default(),
                 },
@@ -674,69 +676,37 @@ impl<AllocU32: alloc::Allocator<u32>> EntropyTally<AllocU32> {
         let max_stride = max_stride_arg.unwrap_or(NUM_STRIDES as u8);
         EntropyTally::<AllocU32> {
             pop: [
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 0 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 0, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 1 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 1, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 2 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 2, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 3 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 3, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 4 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 4, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 5 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 5, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 6 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 6, m32, size),
                 },
-                EntropyBucketPopulation::<AllocU32> {
+                EntropyBucketPopulation {
                     cached_bit_entropy: 0.0,
-                    bucket_populations: if 7 < max_stride {
-                        m32.alloc_cell(size)
-                    } else {
-                        AllocU32::AllocatedMemory::default()
-                    },
+                    bucket_populations: alloc_if(max_stride > 7, m32, size),
                 },
             ],
         }

--- a/src/enc/reader.rs
+++ b/src/enc/reader.rs
@@ -17,6 +17,7 @@ use super::encode::{
     BrotliEncoderStateStruct,
 };
 use super::interface;
+use crate::enc::combined_alloc::allocate;
 
 #[cfg(feature = "std")]
 pub struct CompressorReaderCustomAlloc<R: Read, BufferType: SliceWrapperMut<u8>, Alloc: BrotliAlloc>(
@@ -73,7 +74,7 @@ pub struct CompressorReader<R: Read>(
 impl<R: Read> CompressorReader<R> {
     pub fn new(r: R, buffer_size: usize, q: u32, lgwin: u32) -> Self {
         let mut alloc = StandardAlloc::default();
-        let buffer = <StandardAlloc as Allocator<u8>>::alloc_cell(
+        let buffer = allocate::<u8, _>(
             &mut alloc,
             if buffer_size == 0 { 4096 } else { buffer_size },
         );

--- a/src/enc/stride_eval.rs
+++ b/src/enc/stride_eval.rs
@@ -8,6 +8,7 @@ use super::interface;
 use super::ir_interpret::{push_base, IRInterpreter};
 use super::prior_eval::DEFAULT_SPEED;
 use super::util::{floatX, FastLog2u16};
+use crate::enc::combined_alloc::{alloc_default, allocate};
 const NIBBLE_PRIOR_SIZE: usize = 16;
 pub const STRIDE_PRIOR_SIZE: usize = 256 * 256 * NIBBLE_PRIOR_SIZE * 2;
 
@@ -129,31 +130,31 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
             stride_speed[1] = stride_speed[0];
         }
         let score = if do_alloc {
-            <Alloc as Allocator<floatX>>::alloc_cell(alloc, 8 * 4) // FIXME make this bigger than just 4
+            allocate::<floatX, _>(alloc, 8 * 4) // FIXME make this bigger than just 4
         } else {
-            <Alloc as Allocator<floatX>>::AllocatedMemory::default()
+            alloc_default::<floatX, Alloc>()
         };
         let stride_priors = if do_alloc {
             [
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
-                <Alloc as Allocator<u16>>::alloc_cell(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
+                allocate::<u16, _>(alloc, STRIDE_PRIOR_SIZE),
             ]
         } else {
             [
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
-                <Alloc as Allocator<u16>>::AllocatedMemory::default(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
+                alloc_default::<u16, Alloc>(),
             ]
         };
         let mut ret = StrideEval::<Alloc> {
@@ -268,7 +269,7 @@ impl<'a, Alloc: alloc::Allocator<u16> + alloc::Allocator<u32> + alloc::Allocator
         self.cur_score_epoch += 1;
         if self.cur_score_epoch * 8 + 7 >= self.score.slice().len() {
             let new_len = self.score.slice().len() * 2;
-            let mut new_score = <Alloc as Allocator<floatX>>::alloc_cell(self.alloc, new_len);
+            let mut new_score = allocate::<floatX, _>(self.alloc, new_len);
             for (src, dst) in self.score.slice().iter().zip(
                 new_score
                     .slice_mut()

--- a/src/enc/writer.rs
+++ b/src/enc/writer.rs
@@ -17,6 +17,7 @@ use super::encode::{
     BrotliEncoderStateStruct,
 };
 use super::interface;
+use crate::enc::combined_alloc::allocate;
 
 #[cfg(feature = "std")]
 pub struct CompressorWriterCustomAlloc<
@@ -81,7 +82,7 @@ pub struct CompressorWriter<W: Write>(
 impl<W: Write> CompressorWriter<W> {
     pub fn new(w: W, buffer_size: usize, q: u32, lgwin: u32) -> Self {
         let mut alloc = StandardAlloc::default();
-        let buffer = <StandardAlloc as Allocator<u8>>::alloc_cell(
+        let buffer = allocate::<u8, _>(
             &mut alloc,
             if buffer_size == 0 { 4096 } else { buffer_size },
         );


### PR DESCRIPTION
Introduce several helper memory allocation functions to reduce boilerplate code.  This will help in the future to further simplify allocation, esp when alloc module becomes part of stdlib.  The helper functions allow far simpler usage with a generic type as the first param.

I began with this replacement:

```
\<([a-zA-Z0-9_]+) as Allocator\<([a-zA-Z0-9_]+)\>\>\:\:AllocatedMemory\:\:default\(\s*\)
```
with
```
alloc_default::<$2, $1>()
```

In a few cases, I was able to use `alloc.alloc_cell(...)` directly (compiler was able to figure out which type to use automatically).

Afterward, found all conditional allocations and replaced them with `alloc_if(condition, ...)`, and fixed the imports