### PR TITLE
Use bools instead of i32s (second part)

### DIFF
--- a/src/enc/backward_references/hq.rs
+++ b/src/enc/backward_references/hq.rs
@@ -13,7 +13,7 @@ use super::{
     BrotliEncoderParams,
 };
 use crate::enc::command::{
-    BrotliDistanceParams, CombineLengthCodes, Command, GetCopyLengthCode, GetInsertLengthCode,
+    combine_length_codes, BrotliDistanceParams, Command, GetCopyLengthCode, GetInsertLengthCode,
     PrefixEncodeCopyDistance,
 };
 use crate::enc::constants::{kCopyExtra, kInsExtra};
@@ -737,7 +737,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
             let dist_cost = base_cost + model.get_distance_cost(j);
             for l in best_len.wrapping_add(1)..=len {
                 let copycode: u16 = GetCopyLengthCode(l);
-                let cmdcode: u16 = CombineLengthCodes(inscode, copycode, (j == 0usize) as i32);
+                let cmdcode = combine_length_codes(inscode, copycode, j == 0);
                 let cost: floatX = (if cmdcode < 128 { base_cost } else { dist_cost })
                     + (GetCopyExtra(copycode) as floatX)
                     + model.get_command_cost(cmdcode);
@@ -790,7 +790,7 @@ fn UpdateNodes<AllocF: Allocator<floatX>>(
                         len
                     };
                     let copycode: u16 = GetCopyLengthCode(len_code);
-                    let cmdcode: u16 = CombineLengthCodes(inscode, copycode, 0i32);
+                    let cmdcode = combine_length_codes(inscode, copycode, false);
                     let cost: floatX = dist_cost
                         + GetCopyExtra(copycode) as (floatX)
                         + model.get_command_cost(cmdcode);

--- a/src/enc/backward_references/mod.rs
+++ b/src/enc/backward_references/mod.rs
@@ -68,6 +68,7 @@ pub struct BrotliEncoderParams {
     pub lgblock: i32,
     /// how big the source file is (or 0 if no hint is provided)
     pub size_hint: usize,
+    // FIXME: this should be bool
     /// avoid serializing out priors for literal sections in the favor of decode speed
     pub disable_literal_context_modeling: i32,
     pub hasher: BrotliHasherParams,
@@ -120,6 +121,7 @@ pub enum HowPrepared {
 #[derive(Clone, PartialEq)]
 pub struct Struct1 {
     pub params: BrotliHasherParams,
+    /// FIXME: this should be bool
     pub is_prepared_: i32,
     pub dict_num_lookups: usize,
     pub dict_num_matches: usize,

--- a/src/enc/compress_fragment.rs
+++ b/src/enc/compress_fragment.rs
@@ -651,11 +651,11 @@ fn BuildAndStoreCommandPrefixCode(
 }
 
 #[allow(unused_assignments)]
-fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
+fn compress_fragment_fast_impl<AllocHT: alloc::Allocator<HuffmanTree>>(
     m: &mut AllocHT,
     input_ptr: &[u8],
     mut input_size: usize,
-    is_last: i32,
+    is_last: bool,
     table: &mut [i32],
     table_bits: usize,
     cmd_depth: &mut [u8],
@@ -1050,7 +1050,7 @@ fn BrotliCompressFragmentFastImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
             break;
         }
     }
-    if is_last == 0 {
+    if !is_last {
         cmd_code[0] = 0;
         *cmd_code_numbits = 0;
         BuildAndStoreCommandPrefixCode(
@@ -1069,7 +1069,7 @@ macro_rules! compress_specialization {
             mht: &mut AllocHT,
             input: &[u8],
             input_size: usize,
-            is_last: i32,
+            is_last: bool,
             table: &mut [i32],
             cmd_depth: &mut [u8],
             cmd_bits: &mut [u16],
@@ -1078,7 +1078,7 @@ macro_rules! compress_specialization {
             storage_ix: &mut usize,
             storage: &mut [u8],
         ) {
-            BrotliCompressFragmentFastImpl(
+            compress_fragment_fast_impl(
                 mht,
                 input,
                 input_size,
@@ -1101,11 +1101,42 @@ compress_specialization!(11, BrotliCompressFragmentFastImpl11);
 compress_specialization!(13, BrotliCompressFragmentFastImpl13);
 compress_specialization!(15, BrotliCompressFragmentFastImpl15);
 
+#[deprecated(note = "use BrotliCompressFragmentFastImpl9 instead")]
 pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
     m: &mut AllocHT,
     input: &[u8],
     input_size: usize,
     is_last: i32,
+    table: &mut [i32],
+    table_size: usize,
+    cmd_depth: &mut [u8],
+    cmd_bits: &mut [u16],
+    cmd_code_numbits: &mut usize,
+    cmd_code: &mut [u8],
+    storage_ix: &mut usize,
+    storage: &mut [u8],
+) {
+    compress_fragment_fast(
+        m,
+        input,
+        input_size,
+        is_last != 0,
+        table,
+        table_size,
+        cmd_depth,
+        cmd_bits,
+        cmd_code_numbits,
+        cmd_code,
+        storage_ix,
+        storage,
+    )
+}
+
+pub(crate) fn compress_fragment_fast<AllocHT: alloc::Allocator<HuffmanTree>>(
+    m: &mut AllocHT,
+    input: &[u8],
+    input_size: usize,
+    is_last: bool,
     table: &mut [i32],
     table_size: usize,
     cmd_depth: &mut [u8],
@@ -1186,7 +1217,7 @@ pub fn BrotliCompressFragmentFast<AllocHT: alloc::Allocator<HuffmanTree>>(
     if storage_ix.wrapping_sub(initial_storage_ix) > (31usize).wrapping_add(input_size << 3) {
         EmitUncompressedMetaBlock(input, input_size, initial_storage_ix, storage_ix, storage);
     }
-    if is_last != 0 {
+    if is_last {
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         BrotliWriteBits(1usize, 1, storage_ix, storage);
         *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;

--- a/src/enc/compress_fragment_two_pass.rs
+++ b/src/enc/compress_fragment_two_pass.rs
@@ -645,13 +645,14 @@ fn EmitUncompressedMetaBlock(
     *storage_ix = storage_ix.wrapping_add(input_size << 3);
     storage[(*storage_ix >> 3)] = 0u8;
 }
+
 #[allow(unused_variables)]
 #[inline(always)]
-fn BrotliCompressFragmentTwoPassImpl<AllocHT: alloc::Allocator<HuffmanTree>>(
+fn compress_fragment_two_pass_impl<AllocHT: alloc::Allocator<HuffmanTree>>(
     m: &mut AllocHT,
     base_ip: &[u8],
     mut input_size: usize,
-    is_last: i32,
+    is_last: bool,
     command_buf: &mut [u32],
     literal_buf: &mut [u8],
     table: &mut [i32],
@@ -707,7 +708,7 @@ macro_rules! compress_specialization {
             mht: &mut AllocHT,
             input: &[u8],
             input_size: usize,
-            is_last: i32,
+            is_last: bool,
             command_buf: &mut [u32],
             literal_buf: &mut [u8],
             table: &mut [i32],
@@ -715,7 +716,7 @@ macro_rules! compress_specialization {
             storage: &mut [u8],
         ) {
             let min_match = if $table_bits < 15 { 4 } else { 6 };
-            BrotliCompressFragmentTwoPassImpl(
+            compress_fragment_two_pass_impl(
                 mht,
                 input,
                 input_size,
@@ -753,11 +754,38 @@ fn RewindBitPosition(new_storage_ix: usize, storage_ix: &mut usize, storage: &mu
     *storage_ix = new_storage_ix;
 }
 
+#[deprecated(note = "use compress_fragment_two_pass instead")]
 pub fn BrotliCompressFragmentTwoPass<AllocHT: alloc::Allocator<HuffmanTree>>(
     m: &mut AllocHT,
     input: &[u8],
     input_size: usize,
     is_last: i32,
+    command_buf: &mut [u32],
+    literal_buf: &mut [u8],
+    table: &mut [i32],
+    table_size: usize,
+    storage_ix: &mut usize,
+    storage: &mut [u8],
+) {
+    compress_fragment_two_pass(
+        m,
+        input,
+        input_size,
+        is_last != 0,
+        command_buf,
+        literal_buf,
+        table,
+        table_size,
+        storage_ix,
+        storage,
+    )
+}
+
+pub(crate) fn compress_fragment_two_pass<AllocHT: alloc::Allocator<HuffmanTree>>(
+    m: &mut AllocHT,
+    input: &[u8],
+    input_size: usize,
+    is_last: bool,
     command_buf: &mut [u32],
     literal_buf: &mut [u8],
     table: &mut [i32],
@@ -901,7 +929,7 @@ pub fn BrotliCompressFragmentTwoPass<AllocHT: alloc::Allocator<HuffmanTree>>(
         RewindBitPosition(initial_storage_ix, storage_ix, storage);
         EmitUncompressedMetaBlock(input, input_size, storage_ix, storage);
     }
-    if is_last != 0 {
+    if is_last {
         BrotliWriteBits(1, 1, storage_ix, storage);
         BrotliWriteBits(1, 1, storage_ix, storage);
         *storage_ix = storage_ix.wrapping_add(7u32 as usize) & !7u32 as usize;

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -14,14 +14,14 @@ use super::backward_references::{
 };
 use super::bit_cost::{BitsEntropy, ShannonEntropy};
 use super::brotli_bit_stream::{
-    BrotliStoreMetaBlock, BrotliStoreMetaBlockFast, BrotliStoreMetaBlockTrivial,
-    BrotliStoreUncompressedMetaBlock, BrotliWriteEmptyLastMetaBlock, BrotliWriteMetadataMetaBlock,
+    store_meta_block, store_meta_block_fast, store_meta_block_trivial,
+    store_uncompressed_meta_block, BrotliWriteEmptyLastMetaBlock, BrotliWriteMetadataMetaBlock,
     MetaBlockSplit, RecoderState,
 };
 use super::combined_alloc::BrotliAlloc;
-use super::command::{BrotliDistanceParams, Command, GetLengthCode};
-use super::compress_fragment::BrotliCompressFragmentFast;
-use super::compress_fragment_two_pass::{BrotliCompressFragmentTwoPass, BrotliWriteBits};
+use super::command::{get_length_code, BrotliDistanceParams, Command};
+use super::compress_fragment::compress_fragment_fast;
+use super::compress_fragment_two_pass::{compress_fragment_two_pass, BrotliWriteBits};
 use super::constants::{
     BROTLI_CONTEXT, BROTLI_CONTEXT_LUT, BROTLI_MAX_NDIRECT, BROTLI_MAX_NPOSTFIX,
     BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS, BROTLI_WINDOW_GAP,
@@ -380,11 +380,11 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
                 }
             }
             /* The copy length is at most the metablock size, and thus expressible. */
-            GetLengthCode(
+            get_length_code(
                 last_command.insert_len_ as usize,
                 ((last_command.copy_len_ & 0x01ff_ffff) as i32
                     + (last_command.copy_len_ >> 25) as i32) as usize,
-                ((last_command.dist_prefix_ & 0x03ff) == 0) as i32,
+                (last_command.dist_prefix_ & 0x03ff) == 0,
                 &mut last_command.cmd_prefix_,
             );
         }
@@ -1111,7 +1111,8 @@ fn GetHasherCommon<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
     t.GetHasherCommon()
 }
 
-pub fn HasherSetup<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
+#[deprecated(note = "Use hasher_setup instead")]
+pub fn HasherSetup<Alloc: Allocator<u16> + Allocator<u32>>(
     m16: &mut Alloc,
     handle: &mut UnionHasher<Alloc>,
     params: &mut BrotliEncoderParams,
@@ -1120,7 +1121,27 @@ pub fn HasherSetup<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
     input_size: usize,
     is_last: i32,
 ) {
-    let one_shot: i32 = (position == 0usize && (is_last != 0)) as i32;
+    hasher_setup(
+        m16,
+        handle,
+        params,
+        data,
+        position,
+        input_size,
+        is_last != 0,
+    )
+}
+
+pub(crate) fn hasher_setup<Alloc: Allocator<u16> + Allocator<u32>>(
+    m16: &mut Alloc,
+    handle: &mut UnionHasher<Alloc>,
+    params: &mut BrotliEncoderParams,
+    data: &[u8],
+    position: usize,
+    input_size: usize,
+    is_last: bool,
+) {
+    let one_shot = position == 0 && is_last;
     let is_uninit = match (handle) {
         &mut UnionHasher::Uninit => true,
         _ => false,
@@ -1135,7 +1156,7 @@ pub fn HasherSetup<Alloc: alloc::Allocator<u16> + alloc::Allocator<u32>>(
         HasherReset(handle); // this sets everything to zero, unlike in C
         handle.GetHasherCommon().is_prepared_ = 1;
     } else {
-        match handle.Prepare(one_shot != 0, input_size, data) {
+        match handle.Prepare(one_shot, input_size, data) {
             HowPrepared::ALREADY_PREPARED => {}
             HowPrepared::NEWLY_PREPARED => {
                 if position == 0usize {
@@ -1155,7 +1176,7 @@ fn HasherPrependCustomDictionary<Alloc: alloc::Allocator<u16> + alloc::Allocator
     size: usize,
     dict: &[u8],
 ) {
-    HasherSetup(m, handle, params, dict, 0usize, size, 0i32);
+    hasher_setup(m, handle, params, dict, 0usize, size, false);
     match handle {
         &mut UnionHasher::H2(ref mut hasher) => StoreLookaheadThenStore(hasher, size, dict),
         &mut UnionHasher::H3(ref mut hasher) => StoreLookaheadThenStore(hasher, size, dict),
@@ -1271,15 +1292,7 @@ fn InitOrStitchToPreviousBlock<Alloc: alloc::Allocator<u16> + alloc::Allocator<u
     input_size: usize,
     is_last: bool,
 ) {
-    HasherSetup(
-        m,
-        handle,
-        params,
-        data,
-        position,
-        input_size,
-        is_last as i32,
-    );
+    hasher_setup(m, handle, params, data, position, input_size, is_last);
     handle.StitchToPreviousBlock(input_size, position, data, mask);
 }
 
@@ -1949,9 +1962,9 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
     ) == 0
     {
         dist_cache[..4].clone_from_slice(&saved_dist_cache[..4]);
-        BrotliStoreUncompressedMetaBlock(
+        store_uncompressed_meta_block(
             alloc,
-            is_last as i32,
+            is_last,
             data,
             wrapped_last_flush_pos as usize,
             mask,
@@ -1980,14 +1993,14 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
                                 params.dist.distance_postfix_bits);
     }*/
     // why was this removed??
-    if params.quality <= 2i32 {
-        BrotliStoreMetaBlockFast(
+    if params.quality <= 2 {
+        store_meta_block_fast(
             alloc,
             data,
             wrapped_last_flush_pos as usize,
             bytes,
             mask,
-            is_last as i32,
+            is_last,
             params,
             saved_dist_cache,
             commands,
@@ -1997,14 +2010,14 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
             storage,
             cb,
         );
-    } else if params.quality < 4i32 {
-        BrotliStoreMetaBlockTrivial(
+    } else if params.quality < 4 {
+        store_meta_block_trivial(
             alloc,
             data,
             wrapped_last_flush_pos as usize,
             bytes,
             mask,
-            is_last as i32,
+            is_last,
             params,
             saved_dist_cache,
             commands,
@@ -2073,7 +2086,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
             }
             BrotliOptimizeHistograms(num_effective_dist_codes as usize, &mut mb);
         }
-        BrotliStoreMetaBlock(
+        store_meta_block(
             alloc,
             data,
             wrapped_last_flush_pos as usize,
@@ -2081,7 +2094,7 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
             mask,
             prev_byte,
             prev_byte2,
-            is_last as i32,
+            is_last,
             &block_params,
             literal_context_mode,
             saved_dist_cache,
@@ -2103,9 +2116,9 @@ fn WriteMetaBlockInternal<Alloc: BrotliAlloc, Cb>(
         storage[saved_byte_location] = last_bytes as u8;
         storage[saved_byte_location + 1] = (last_bytes >> 8) as u8;
         *storage_ix = last_bytes_bits as usize;
-        BrotliStoreUncompressedMetaBlock(
+        store_uncompressed_meta_block(
             alloc,
-            is_last as i32,
+            is_last,
             data,
             wrapped_last_flush_pos as usize,
             mask,
@@ -2239,9 +2252,9 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
             {
                 let data =
                     &mut self.ringbuffer_.data_mo.slice_mut()[self.ringbuffer_.buffer_index..];
-                BrotliStoreUncompressedMetaBlock(
+                store_uncompressed_meta_block(
                     &mut self.m8,
-                    0,
+                    false,
                     data,
                     self.last_flush_pos_ as usize,
                     mask as usize,
@@ -2310,11 +2323,11 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
                     GetHashTable!(self, self.params.quality, bytes as usize, &mut table_size);
 
                 if self.params.quality == 0i32 {
-                    BrotliCompressFragmentFast(
+                    compress_fragment_fast(
                         &mut self.m8,
                         &mut data[((wrapped_last_processed_pos & mask) as usize)..],
                         bytes as usize,
-                        is_last as i32,
+                        is_last,
                         table,
                         table_size,
                         &mut self.cmd_depths_[..],
@@ -2325,11 +2338,11 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
                         self.storage_.slice_mut(),
                     );
                 } else {
-                    BrotliCompressFragmentTwoPass(
+                    compress_fragment_two_pass(
                         &mut self.m8,
                         &mut data[((wrapped_last_processed_pos & mask) as usize)..],
                         bytes as usize,
-                        is_last as i32,
+                        is_last,
                         self.command_buf_.slice_mut(),
                         self.literal_buf_.slice_mut(),
                         table,
@@ -2746,11 +2759,11 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
                 let table: &mut [i32] =
                     GetHashTable!(self, self.params.quality, block_size, &mut table_size);
                 if self.params.quality == 0i32 {
-                    BrotliCompressFragmentFast(
+                    compress_fragment_fast(
                         &mut self.m8,
                         &(next_in_array)[*next_in_offset..],
                         block_size,
-                        is_last as i32,
+                        is_last,
                         table,
                         table_size,
                         &mut self.cmd_depths_[..],
@@ -2761,11 +2774,11 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
                         storage,
                     );
                 } else {
-                    BrotliCompressFragmentTwoPass(
+                    compress_fragment_two_pass(
                         &mut self.m8,
                         &(next_in_array)[*next_in_offset..],
                         block_size,
-                        is_last as i32,
+                        is_last,
                         command_buf.slice_mut(),
                         literal_buf.slice_mut(),
                         table,
@@ -3009,9 +3022,13 @@ impl<Alloc: BrotliAlloc> BrotliEncoderStateStruct<Alloc> {
         ),
     >(
         &'a mut self,
+        // FIXME: this should be bool
         is_last: i32,
+        // FIXME: this should be bool
         force_flush: i32,
+        // FIXME: this should probably be removed because the slice already contains the size
         out_size: &mut usize,
+        // FIXME: this should be part of the fn return value
         output: &'a mut &'a mut [u8],
         metablock_callback: &mut MetablockCallback,
     ) -> bool {

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -7,8 +7,8 @@ use std;
 
 use super::backward_references::{AnyHasher, BrotliEncoderParams, CloneWithAlloc, UnionHasher};
 use super::encode::{
-    BrotliEncoderDestroyInstance, BrotliEncoderMaxCompressedSize, BrotliEncoderOperation,
-    HasherSetup, SanitizeParams,
+    hasher_setup, BrotliEncoderDestroyInstance, BrotliEncoderMaxCompressedSize,
+    BrotliEncoderOperation, SanitizeParams,
 };
 use super::BrotliAlloc;
 use crate::concat::{BroCatli, BroCatliResult};
@@ -446,14 +446,14 @@ where
         let mut local_params = params.clone();
         SanitizeParams(&mut local_params);
         let mut hasher = UnionHasher::Uninit;
-        HasherSetup(
+        hasher_setup(
             alloc_per_thread[num_threads - 1].0.unwrap_input().0,
             &mut hasher,
             &mut local_params,
             &[],
             0,
             0,
-            0,
+            false,
         );
         for thread_index in 1..num_threads {
             let res = spawner_and_input.view(|input_and_params: &(SliceW, BrotliEncoderParams)| {


### PR DESCRIPTION
There are a few publicly visible functions that should also be using a `bool` type.  In order not to cause an API change, I created a crate-visible variants so that we can remove them in the next major release. In the meantime, users will see a deprecation warning IF they are using these functions (most likely they are not) - but if they are, they will let us know to keep them public.

Note a few extra `FIXME` -- these I think we should fix when making a breaking change, but not just yet because they are harder to do in a backward-compatible way