### PR TITLE
fix ci semver compat, enable in branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main, master ]
+  push: { }  # Since the primary repo has no CI, every fork must do the CI work in every branch
+  #  push:
+  #    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
   release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["compression", "no-std"]
 readme = "README.md"
 autobins = false
 edition = "2015"
-rust-version = "1.56.0"
+rust-version = "1.59.0"
 
 [[bin]]
 doc = false

--- a/src/enc/mod.rs
+++ b/src/enc/mod.rs
@@ -43,6 +43,10 @@ mod weights;
 pub mod worker_pool;
 pub mod writer;
 
+// FIXME: Remove this in 7.0
+#[deprecated(note = "Leaving this here to avoid breaking 6.0 compatibility.")]
+pub mod fast_log {}
+
 pub use alloc::{AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator};
 #[cfg(feature = "std")]
 use std::io;


### PR DESCRIPTION
Fix CI once again - this time it will be tested in every branch too (so will work in the fork repos).  Also, there is a compilation issue requiring MSRV to be 1.59