### PR TITLE
Fix CI: avoid breaking semver

### DIFF
--- a/src/enc/bit_cost.rs
+++ b/src/enc/bit_cost.rs
@@ -1,5 +1,4 @@
 use alloc::SliceWrapperMut;
-
 use core::cmp::{max, min};
 
 use super::super::alloc::SliceWrapper;
@@ -8,11 +7,17 @@ use super::util::{FastLog2, FastLog2u16};
 use super::vectorization::Mem256i;
 use crate::enc::floatX;
 
-
 const BROTLI_REPEAT_ZERO_CODE_LENGTH: usize = 17;
 const BROTLI_CODE_LENGTH_CODES: usize = BROTLI_REPEAT_ZERO_CODE_LENGTH + 1;
 
-pub fn ShannonEntropy(mut population: &[u32], size: usize) -> (floatX, usize) {
+#[deprecated(note = "use shannon_entropy instead")]
+pub fn ShannonEntropy(population: &[u32], size: usize, total: &mut usize) -> floatX {
+    let (result, tot) = shannon_entropy(population, size);
+    *total = tot;
+    result
+}
+
+pub(crate) fn shannon_entropy(mut population: &[u32], size: usize) -> (floatX, usize) {
     let mut sum: usize = 0;
     let mut retval: floatX = 0.0;
 
@@ -36,7 +41,7 @@ pub fn ShannonEntropy(mut population: &[u32], size: usize) -> (floatX, usize) {
 
 #[inline(always)]
 pub fn BitsEntropy(population: &[u32], size: usize) -> floatX {
-    let (mut retval, sum) = ShannonEntropy(population, size);
+    let (mut retval, sum) = shannon_entropy(population, size);
     if retval < sum as floatX {
         retval = sum as floatX;
     }

--- a/src/enc/encode.rs
+++ b/src/enc/encode.rs
@@ -10,7 +10,7 @@ use super::backward_references::{
     H6Sub, HQ5Sub, HQ7Sub, HowPrepared, StoreLookaheadThenStore, Struct1, UnionHasher, H9,
     H9_BLOCK_BITS, H9_BLOCK_SIZE, H9_BUCKET_BITS, H9_NUM_LAST_DISTANCES_TO_CHECK,
 };
-use super::bit_cost::{BitsEntropy, ShannonEntropy};
+use super::bit_cost::{shannon_entropy, BitsEntropy};
 use super::brotli_bit_stream::{
     store_meta_block, store_meta_block_fast, store_meta_block_trivial,
     store_uncompressed_meta_block, BrotliWriteEmptyLastMetaBlock, BrotliWriteMetadataMetaBlock,
@@ -1741,12 +1741,12 @@ fn ChooseContextMap(
         }
         i = i.wrapping_add(1);
     }
-    entropy[1] = ShannonEntropy(&monogram_histo[..], 3).0;
+    entropy[1] = shannon_entropy(&monogram_histo[..], 3).0;
     entropy[2] =
-        ShannonEntropy(&two_prefix_histo[..], 3).0 + ShannonEntropy(&two_prefix_histo[3..], 3).0;
+        shannon_entropy(&two_prefix_histo[..], 3).0 + shannon_entropy(&two_prefix_histo[3..], 3).0;
     entropy[3] = 0.0;
     for i in 0usize..3usize {
-        entropy[3] += ShannonEntropy(&bigram_histo[(3usize).wrapping_mul(i)..], 3).0;
+        entropy[3] += shannon_entropy(&bigram_histo[(3usize).wrapping_mul(i)..], 3).0;
     }
     let total: usize = monogram_histo[0]
         .wrapping_add(monogram_histo[1])
@@ -1834,11 +1834,11 @@ fn ShouldUseComplexStaticContextMap(
             }
             start_pos += 4096;
         }
-        entropy[1] = ShannonEntropy(&combined_histo[..], 32).0;
+        entropy[1] = shannon_entropy(&combined_histo[..], 32).0;
         entropy[2] = 0.0;
         for i in 0..13 {
             assert!(i < 13);
-            entropy[2] += ShannonEntropy(&context_histo[i][..], 32).0;
+            entropy[2] += shannon_entropy(&context_histo[i][..], 32).0;
         }
         entropy[0] = 1.0 / (total as floatX);
         entropy[1] *= entropy[0];


### PR DESCRIPTION
`ShannonEntropy` is currently exposed publicly. In my last PR its signature changed. In order to avoid another major release, add a deprecated wrapper for it until we are ready to migrate to the new major version.

This allows us to make patch releases because no functionality has been changed yet.