### PR TITLE
Add an explicit include section to the `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ readme = "README.md"
 autobins = false
 edition = "2015"
 rust-version = "1.59.0"
+include = [
+  "/src/**/*.rs",
+  "/examples/**/*.rs",
+  "/Cargo.toml",
+  "/README.md",
+  "/LICENSE.MIT",
+]
 
 [[bin]]
 doc = false


### PR DESCRIPTION
This commit adds an explicit `package.include` section to the `Cargo.toml` file to only include relevant rust code into the final package. This decreases the size of the uploaded tar-ball from 1.3 Mb to ~700kb and it also decreases the number of included files from ~140 to ~70. Finally it removes any possibly unwanted binary data from the uploaded package, which follows security best-practices.

Fixes #220