### PR TITLE
Fix missing LICENSE.BSD-3-Clause in published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
   "/examples/**/*.rs",
   "/Cargo.toml",
   "/README.md",
+  "/LICENSE.BSD-3-Clause",
   "/LICENSE.MIT",
 ]
 


### PR DESCRIPTION
When the contents of the published crate were minimized in 4b059e6081386238c764d11140605a5514da30f5, the file `LICENSE.BSD-3-Clause` was omitted from the list of files to include.