### PR TITLE
fixed simd (mask.to_int() renamed to mask.to_simd())

### DIFF
--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -72,7 +72,9 @@ fn update_cost_and_signal(
     {
         let mut ymm_cost = *cost_it;
         let costk_minus_min_cost = ymm_cost - ymm_min_cost;
-        let ymm_cmpge: v256i = costk_minus_min_cost.simd_ge(ymm_block_switch_cost).to_int();
+        let ymm_cmpge: v256i = costk_minus_min_cost
+            .simd_ge(ymm_block_switch_cost)
+            .to_simd();
         let ymm_bits = ymm_cmpge & ymm_and_mask;
         let result = sum8i(ymm_bits);
         //super::vectorization::sum8(ymm_bits) as u8;

--- a/src/enc/block_splitter.rs
+++ b/src/enc/block_splitter.rs
@@ -72,9 +72,7 @@ fn update_cost_and_signal(
     {
         let mut ymm_cost = *cost_it;
         let costk_minus_min_cost = ymm_cost - ymm_min_cost;
-        let ymm_cmpge: v256i = costk_minus_min_cost
-            .simd_ge(ymm_block_switch_cost)
-            .to_simd();
+        let ymm_cmpge: v256i = costk_minus_min_cost.simd_ge(ymm_block_switch_cost).to_int();
         let ymm_bits = ymm_cmpge & ymm_and_mask;
         let result = sum8i(ymm_bits);
         //super::vectorization::sum8(ymm_bits) as u8;

--- a/src/enc/compat.rs
+++ b/src/enc/compat.rs
@@ -10,7 +10,7 @@ impl Compat16x16 {
         Compat16x16([a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a])
     }
     #[inline(always)]
-    pub fn to_int(&self) -> Self {
+    pub fn to_simd(&self) -> Self {
         *self
     }
     #[inline(always)]
@@ -187,7 +187,7 @@ impl Compat32x8 {
             -((self[7] >= rhs[7]) as i32),
         ])
     }
-    pub fn to_int(&self) -> Self {
+    pub fn to_simd(&self) -> Self {
         *self
     }
 }

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -346,7 +346,9 @@ impl<'a> CDF<'a> {
         let mut cdf = *self.cdf;
         let increment_v = s16::splat(speed.0 as i16);
         let one_to_16 = s16::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-        let mask_v: s16 = one_to_16.simd_gt(s16::splat(i16::from(nibble_u8))).to_int();
+        let mask_v: s16 = one_to_16
+            .simd_gt(s16::splat(i16::from(nibble_u8)))
+            .to_simd();
         cdf = cdf + (increment_v & mask_v);
         if cdf[15] >= speed.1 as i16 {
             let cdf_bias = one_to_16;

--- a/src/enc/prior_eval.rs
+++ b/src/enc/prior_eval.rs
@@ -346,9 +346,7 @@ impl<'a> CDF<'a> {
         let mut cdf = *self.cdf;
         let increment_v = s16::splat(speed.0 as i16);
         let one_to_16 = s16::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-        let mask_v: s16 = one_to_16
-            .simd_gt(s16::splat(i16::from(nibble_u8)))
-            .to_simd();
+        let mask_v: s16 = one_to_16.simd_gt(s16::splat(i16::from(nibble_u8))).to_int();
         cdf = cdf + (increment_v & mask_v);
         if cdf[15] >= speed.1 as i16 {
             let cdf_bias = one_to_16;


### PR DESCRIPTION
Some functions in unstable portable simd have been renamed in the latest rust nightlies.
This includes `Mask::to_int` that should now be `Mask::to_simd`
This was used in two places.