### PR TITLE
Expose testdata folder to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = [
   "/README.md",
   "/LICENSE.BSD-3-Clause",
   "/LICENSE.MIT",
+  "/testdata/**",
 ]
 
 [[bin]]


### PR DESCRIPTION
Exposing the testdata to https://docs.rs/crate/brotli/8.0.2/source/ so that users can run the tests as part of their build system when the code is pulled from crates.io instead of github.