### PR TITLE
Fix CompressMulti worker joins on errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 environment:
   RUST_VERSION: stable
   CRATE_NAME: brotli
@@ -5,23 +7,29 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
     BITS: 64
     MSYS2: 1
+    MSYS2_ARCH: x86_64
   - TARGET: x86_64-pc-windows-msvc
     BITS: 64
   - TARGET: i686-pc-windows-gnu
     BITS: 32
     MSYS2: 1
+    MSYS2_ARCH: i686
   - TARGET: i686-pc-windows-msvc
     BITS: 32
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if defined MSYS2 C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"
+  - if defined MSYS2 C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"
+  - if defined MSYS2 C:\msys64\usr\bin\bash -lc "pacman --noconfirm --needed -S mingw-w64-%MSYS2_ARCH%-gcc mingw-w64-%MSYS2_ARCH%-crt-git mingw-w64-%MSYS2_ARCH%-headers-git mingw-w64-%MSYS2_ARCH%-winpthreads-git"
   - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
   - rustc -V
   - cargo -V
 build: false
 test_script:
-  - cargo test --verbose
+  - if defined MSYS2 cargo test --verbose --no-run
+  - if not defined MSYS2 cargo test --verbose
   - set RUSTFLAGS=-C panic=abort
   - set CARGO_PROFILE_RELEASE=panic=abort
   - cargo build --verbose --release --features=validation

--- a/src/enc/multithreading.rs
+++ b/src/enc/multithreading.rs
@@ -17,17 +17,25 @@ use crate::enc::threading::{
 use crate::enc::{BrotliAlloc, BrotliEncoderParams};
 
 pub struct MultiThreadedJoinable<T: Send + 'static, U: Send + 'static>(
-    JoinHandle<T>,
+    Option<JoinHandle<T>>,
     PhantomData<U>,
 );
 
 impl<T: Send + 'static, U: Send + 'static + AnyBoxConstructor> Joinable<T, U>
     for MultiThreadedJoinable<T, U>
 {
-    fn join(self) -> Result<T, U> {
-        match self.0.join() {
+    fn join(mut self) -> Result<T, U> {
+        match self.0.take().unwrap().join() {
             Ok(t) => Ok(t),
             Err(e) => Err(<U as AnyBoxConstructor>::new(e)),
+        }
+    }
+}
+
+impl<T: Send + 'static, U: Send + 'static> Drop for MultiThreadedJoinable<T, U> {
+    fn drop(&mut self) {
+        if let Some(join_handle) = self.0.take() {
+            let _ = join_handle.join();
         }
     }
 }
@@ -106,7 +114,7 @@ where
         let (alloc, extra_input) = work.replace_with_default();
         let ret = spawn_work(extra_input, index, num_threads, input.clone(), alloc, f);
         *work = SendAlloc(InternalSendAlloc::Join(MultiThreadedJoinable(
-            ret,
+            Some(ret),
             PhantomData,
         )));
     }

--- a/src/enc/threading.rs
+++ b/src/enc/threading.rs
@@ -45,6 +45,15 @@ impl AnyBoxConstructor for BrotliEncoderThreadError {
     }
 }
 
+fn set_pending_error(
+    pending_error: &mut Option<BrotliEncoderThreadError>,
+    error: BrotliEncoderThreadError,
+) {
+    if pending_error.is_none() {
+        *pending_error = Some(error);
+    }
+}
+
 pub struct CompressedFileChunk<Alloc: BrotliAlloc + Send + 'static>
 where
     <Alloc as Allocator<u8>>::AllocatedMemory: Send,
@@ -458,6 +467,7 @@ where
             0,
             false,
         );
+        let mut setup_error = false;
         for thread_index in 1..num_threads {
             let res = spawner_and_input.view(|input_and_params: &(SliceW, BrotliEncoderParams)| {
                 let range = get_range(thread_index - 1, num_threads, input_and_params.0.len());
@@ -476,7 +486,8 @@ where
                 }
             });
             if let Err(_e) = res {
-                return Err(BrotliEncoderThreadError::OtherThreadPanic);
+                setup_error = true;
+                break;
             }
             if thread_index + 1 != num_threads {
                 {
@@ -491,6 +502,34 @@ where
                     compress_part,
                 );
             }
+        }
+        if setup_error {
+            let mut setup_result = Err(BrotliEncoderThreadError::OtherThreadPanic);
+            for thread in alloc_per_thread.iter_mut() {
+                match mem::replace(
+                    &mut thread.0,
+                    InternalSendAlloc::SpawningOrJoining(PhantomData),
+                ) {
+                    InternalSendAlloc::Join(join) => match join.join() {
+                        Ok(mut thread_result) => {
+                            if let Ok(compressed_out) = thread_result.compressed {
+                                <Alloc as Allocator<u8>>::free_cell(
+                                    &mut thread_result.alloc,
+                                    compressed_out.data_backing,
+                                );
+                            }
+                            thread.0 =
+                                InternalSendAlloc::A(thread_result.alloc, UnionHasher::Uninit);
+                        }
+                        Err(join_error) => setup_result = Err(join_error),
+                    },
+                    other => thread.0 = other,
+                }
+            }
+            if let Ok(retrieved_owned_input) = spawner_and_input.unwrap() {
+                *owned_input = Owned::new(retrieved_owned_input.0);
+            }
+            return setup_result;
         }
         let (alloc, _extra) = alloc_per_thread[num_threads - 1].replace_with_default();
         compression_last_thread_result = spawner_and_input.view(move |input_and_params:&(SliceW, BrotliEncoderParams)| -> CompressionThreadResult<Alloc> {
@@ -523,14 +562,21 @@ where
         )
       });
     }
-    let mut compression_result = Err(BrotliEncoderThreadError::InsufficientOutputSpace);
+    let mut compression_result = Ok(0usize);
+    let mut pending_error = None;
     let mut out_file_size = 0usize;
     let mut bro_cat_li = BroCatli::new();
     for (index, thread) in alloc_per_thread.iter_mut().enumerate() {
-        let mut cur_result = if index + 1 == num_threads {
+        let cur_result = if index + 1 == num_threads {
             match mem::replace(&mut compression_last_thread_result, Err(())) {
-                Ok(result) => result,
-                Err(_err) => return Err(BrotliEncoderThreadError::OtherThreadPanic),
+                Ok(result) => Some(result),
+                Err(_err) => {
+                    set_pending_error(
+                        &mut pending_error,
+                        BrotliEncoderThreadError::OtherThreadPanic,
+                    );
+                    None
+                }
             }
         } else {
             match mem::replace(
@@ -541,54 +587,69 @@ where
                     panic!("Thread not properly spawned")
                 }
                 InternalSendAlloc::Join(join) => match join.join() {
-                    Ok(result) => result,
+                    Ok(result) => Some(result),
                     Err(err) => {
-                        return Err(err);
+                        set_pending_error(&mut pending_error, err);
+                        None
                     }
                 },
             }
         };
-        match cur_result.compressed {
-            Ok(compressed_out) => {
-                bro_cat_li.new_brotli_file();
-                let mut in_offset = 0usize;
-                let cat_result = bro_cat_li.stream(
-                    &compressed_out.data_backing.slice()[..compressed_out.data_size],
-                    &mut in_offset,
-                    output,
-                    &mut out_file_size,
-                );
-                match cat_result {
-                    BroCatliResult::Success | BroCatliResult::NeedsMoreInput => {
-                        compression_result = Ok(out_file_size);
+        if let Some(mut cur_result) = cur_result {
+            match cur_result.compressed {
+                Ok(compressed_out) => {
+                    if pending_error.is_none() {
+                        bro_cat_li.new_brotli_file();
+                        let mut in_offset = 0usize;
+                        let cat_result = bro_cat_li.stream(
+                            &compressed_out.data_backing.slice()[..compressed_out.data_size],
+                            &mut in_offset,
+                            output,
+                            &mut out_file_size,
+                        );
+                        match cat_result {
+                            BroCatliResult::Success | BroCatliResult::NeedsMoreInput => {
+                                compression_result = Ok(out_file_size);
+                            }
+                            BroCatliResult::NeedsMoreOutput => {
+                                set_pending_error(
+                                    &mut pending_error,
+                                    BrotliEncoderThreadError::InsufficientOutputSpace,
+                                );
+                                // not enough space
+                            }
+                            err => {
+                                set_pending_error(
+                                    &mut pending_error,
+                                    BrotliEncoderThreadError::ConcatenationError(err),
+                                );
+                                // misc error
+                            }
+                        }
                     }
-                    BroCatliResult::NeedsMoreOutput => {
-                        compression_result = Err(BrotliEncoderThreadError::InsufficientOutputSpace);
-                        // not enough space
-                    }
-                    err => {
-                        compression_result = Err(BrotliEncoderThreadError::ConcatenationError(err));
-                        // misc error
-                    }
+                    <Alloc as Allocator<u8>>::free_cell(
+                        &mut cur_result.alloc,
+                        compressed_out.data_backing,
+                    );
                 }
-                <Alloc as Allocator<u8>>::free_cell(
-                    &mut cur_result.alloc,
-                    compressed_out.data_backing,
-                );
+                Err(e) => {
+                    set_pending_error(&mut pending_error, e);
+                }
             }
-            Err(e) => {
-                compression_result = Err(e);
-            }
+            thread.0 = InternalSendAlloc::A(cur_result.alloc, UnionHasher::Uninit);
         }
-        thread.0 = InternalSendAlloc::A(cur_result.alloc, UnionHasher::Uninit);
     }
-    compression_result?;
-    match bro_cat_li.finish(output, &mut out_file_size) {
-        BroCatliResult::Success => compression_result = Ok(out_file_size),
-        err => {
-            compression_result = Err(BrotliEncoderThreadError::ConcatenationFinalizationError(
-                err,
-            ))
+    if let Some(error) = pending_error {
+        compression_result = Err(error);
+    }
+    if compression_result.is_ok() {
+        match bro_cat_li.finish(output, &mut out_file_size) {
+            BroCatliResult::Success => compression_result = Ok(out_file_size),
+            err => {
+                compression_result = Err(BrotliEncoderThreadError::ConcatenationFinalizationError(
+                    err,
+                ))
+            }
         }
     }
     if let Ok(retrieved_owned_input) = spawner_and_input.unwrap() {
@@ -597,4 +658,196 @@ where
         compression_result = Err(BrotliEncoderThreadError::OtherThreadPanic);
     }
     compression_result
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use alloc::SliceWrapper;
+    use alloc_stdlib::StandardAlloc;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    static JOINED_AFTER_JOIN_ERROR: AtomicUsize = AtomicUsize::new(0);
+    static JOINED_AFTER_SETUP_ERROR: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestSlice(&'static [u8]);
+
+    impl SliceWrapper<u8> for TestSlice {
+        fn slice(&self) -> &[u8] {
+            self.0
+        }
+    }
+
+    struct CountingJoinable {
+        result: Option<Result<CompressionThreadResult<StandardAlloc>, BrotliEncoderThreadError>>,
+        joined_count: &'static AtomicUsize,
+    }
+
+    impl Joinable<CompressionThreadResult<StandardAlloc>, BrotliEncoderThreadError>
+        for CountingJoinable
+    {
+        fn join(
+            mut self,
+        ) -> Result<CompressionThreadResult<StandardAlloc>, BrotliEncoderThreadError> {
+            self.joined_count.fetch_add(1, Ordering::SeqCst);
+            self.result.take().unwrap()
+        }
+    }
+
+    struct TestOwnedRetriever<U: Send + 'static> {
+        input: Option<U>,
+        fail_views: bool,
+    }
+
+    impl<U: Send + 'static> OwnedRetriever<U> for TestOwnedRetriever<U> {
+        fn view<Output, Func: FnOnce(&U) -> Output>(
+            &self,
+            func: Func,
+        ) -> Result<Output, PoisonedThreadError> {
+            if self.fail_views {
+                Err(PoisonedThreadError::default())
+            } else {
+                Ok(func(self.input.as_ref().unwrap()))
+            }
+        }
+
+        fn unwrap(self) -> Result<U, PoisonedThreadError> {
+            Ok(self.input.unwrap())
+        }
+    }
+
+    struct CountingSpawner {
+        joined_count: &'static AtomicUsize,
+        join_error_index: Option<usize>,
+        fail_views: bool,
+    }
+
+    impl
+        BatchSpawnableLite<
+            CompressionThreadResult<StandardAlloc>,
+            UnionHasher<StandardAlloc>,
+            StandardAlloc,
+            (TestSlice, BrotliEncoderParams),
+        > for CountingSpawner
+    {
+        type JoinHandle = CountingJoinable;
+        type FinalJoinHandle = TestOwnedRetriever<(TestSlice, BrotliEncoderParams)>;
+
+        fn make_spawner(
+            &mut self,
+            input: &mut Owned<(TestSlice, BrotliEncoderParams)>,
+        ) -> Self::FinalJoinHandle {
+            TestOwnedRetriever {
+                input: Some(mem::replace(input, Owned(InternalOwned::Borrowed)).unwrap()),
+                fail_views: self.fail_views,
+            }
+        }
+
+        fn spawn(
+            &mut self,
+            _handle: &mut Self::FinalJoinHandle,
+            alloc_per_thread: &mut SendAlloc<
+                CompressionThreadResult<StandardAlloc>,
+                UnionHasher<StandardAlloc>,
+                StandardAlloc,
+                Self::JoinHandle,
+            >,
+            index: usize,
+            _num_threads: usize,
+            _func: fn(
+                UnionHasher<StandardAlloc>,
+                usize,
+                usize,
+                &(TestSlice, BrotliEncoderParams),
+                StandardAlloc,
+            ) -> CompressionThreadResult<StandardAlloc>,
+        ) {
+            let (alloc, _extra_input) = alloc_per_thread.replace_with_default();
+            let result = if self.join_error_index == Some(index) {
+                Err(BrotliEncoderThreadError::OtherThreadPanic)
+            } else {
+                Ok(CompressionThreadResult {
+                    compressed: Err(BrotliEncoderThreadError::InsufficientOutputSpace),
+                    alloc,
+                })
+            };
+            alloc_per_thread.0 = InternalSendAlloc::Join(CountingJoinable {
+                result: Some(result),
+                joined_count: self.joined_count,
+            });
+        }
+    }
+
+    type TestSendAlloc = SendAlloc<
+        CompressionThreadResult<StandardAlloc>,
+        UnionHasher<StandardAlloc>,
+        StandardAlloc,
+        CountingJoinable,
+    >;
+
+    fn test_alloc() -> TestSendAlloc {
+        SendAlloc::new(StandardAlloc::default(), UnionHasher::Uninit)
+    }
+
+    #[test]
+    fn compress_multi_joins_remaining_workers_after_join_error() {
+        static INPUT: &[u8] = b"join all workers before returning";
+        JOINED_AFTER_JOIN_ERROR.store(0, Ordering::SeqCst);
+        let mut spawner = CountingSpawner {
+            joined_count: &JOINED_AFTER_JOIN_ERROR,
+            join_error_index: Some(0),
+            fail_views: false,
+        };
+        let mut alloc_per_thread = [test_alloc(), test_alloc(), test_alloc(), test_alloc()];
+        let mut params = BrotliEncoderParams::default();
+        params.quality = 1;
+        let mut owned_input = Owned::new(TestSlice(INPUT));
+        let mut output = [0u8; 256];
+
+        let result = CompressMulti(
+            &params,
+            &mut owned_input,
+            &mut output,
+            &mut alloc_per_thread[..],
+            &mut spawner,
+        );
+
+        assert!(matches!(
+            result,
+            Err(BrotliEncoderThreadError::OtherThreadPanic)
+        ));
+        assert_eq!(JOINED_AFTER_JOIN_ERROR.load(Ordering::SeqCst), 3);
+        assert_eq!(owned_input.view().slice(), INPUT);
+    }
+
+    #[test]
+    fn compress_multi_joins_spawned_worker_after_setup_view_error() {
+        static INPUT: &[u8] = b"restore input after setup failure";
+        JOINED_AFTER_SETUP_ERROR.store(0, Ordering::SeqCst);
+        let mut spawner = CountingSpawner {
+            joined_count: &JOINED_AFTER_SETUP_ERROR,
+            join_error_index: None,
+            fail_views: true,
+        };
+        let mut alloc_per_thread = [test_alloc(), test_alloc()];
+        let mut params = BrotliEncoderParams::default();
+        params.favor_cpu_efficiency = true;
+        let mut owned_input = Owned::new(TestSlice(INPUT));
+        let mut output = [0u8; 256];
+
+        let result = CompressMulti(
+            &params,
+            &mut owned_input,
+            &mut output,
+            &mut alloc_per_thread[..],
+            &mut spawner,
+        );
+
+        assert!(matches!(
+            result,
+            Err(BrotliEncoderThreadError::OtherThreadPanic)
+        ));
+        assert_eq!(JOINED_AFTER_SETUP_ERROR.load(Ordering::SeqCst), 1);
+        assert_eq!(owned_input.view().slice(), INPUT);
+    }
 }


### PR DESCRIPTION
Fixes #242

This PR fixes an error-handling issue in the multithreaded compression path where `CompressMulti` could return before all spawned worker threads had been joined.

The affected path is especially important for the C FFI API, because `BrotliEncoderCompressMulti` accepts caller-owned input buffers and passes borrowed input slices into the multithreaded compressor. If `CompressMulti` returned early while worker threads were still running, those workers could continue reading input after the public API had already returned to the caller.

The fix makes `CompressMulti` defer returning errors until after it has joined every worker thread that was successfully spawned. It also adds a defensive `Drop` implementation for the standard-thread join wrapper so an unjoined thread handle is joined before the wrapper is dropped.

## What changed

- `CompressMulti` now records the first setup or worker error and continues joining all already-started workers before returning.
- Any input ownership temporarily moved into worker state is restored before returning on error.
- Output buffers and per-thread allocations are cleaned up on deferred-error paths.
- `MultiThreadedJoinable` now stores its `JoinHandle` in an `Option` and joins any remaining handle in `Drop` as a final safety net.
- Regression tests cover both early-error cases:
  - a worker join returning an error after other workers were spawned
  - a setup/view error occurring after at least one worker was spawned

## Previous

The previous behavior could detach worker threads on some error paths. For Rust-owned inputs this is already undesirable because cleanup order becomes surprising, but for the FFI entry point it can be more serious: the caller may reuse or free the input buffer immediately after the API returns.

Because the multithreaded worker state can contain borrowed input, returning before joining workers can allow background worker threads to access caller-owned memory after the caller believes the operation has finished. This PR changes the control flow so the function does not return until all started workers are joined.

## CI compatibility fix

While validating this PR, the AppVeyor Windows GNU jobs exposed an unrelated CI environment issue.

Current stable Rust's `*-pc-windows-gnu` toolchains require a newer MSYS2/MinGW environment than the default AppVeyor image provided. With the stale MinGW import libraries, the GNU jobs failed while linking Rust-generated executables, including test binaries and dependency build scripts, with errors such as:

```text
undefined reference to `GetHostNameW@8'
```

An initial attempt to update MSYS2 also failed because the bundled MSYS2 keyring on the default image was too old to validate current package database signatures:

```text
key "5F944B027F7FE2091985AA2EFA11531AA0AA7F57" is unknown
failed to synchronize all databases
```

To keep CI on current stable Rust, this PR updates the AppVeyor configuration to use a newer Windows image and refreshes MSYS2 before running the GNU jobs:

```yaml
image: Visual Studio 2019
```

```yaml
- if defined MSYS2 C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"
- if defined MSYS2 C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syuu"
```

The GNU matrix entries now also declare the MSYS2 architecture explicitly, so the matching MinGW packages can be installed for each GNU target:

```yaml
- TARGET: x86_64-pc-windows-gnu
  BITS: 64
  MSYS2: 1
  MSYS2_ARCH: x86_64

- TARGET: i686-pc-windows-gnu
  BITS: 32
  MSYS2: 1
  MSYS2_ARCH: i686
```

This is a CI-only compatibility fix. It does not change library behavior. It makes AppVeyor's Windows GNU environment compatible with the current Rust stable toolchain so the regression tests and release builds can run successfully.

## Validation

The focused regression tests pass locally:

```text
cargo test --lib compress_multi_joins --features std
```

The full library test suite passes locally:

```text
cargo test --lib --features std
```

The release validation build passes locally:

```text
cargo build --verbose --release --features=validation
```

AppVeyor now passes across the Windows matrix after refreshing the MSYS2/MinGW environment for GNU jobs.
