### PR TITLE
Fix BroCatli deserialized last_bytes_len validation

### DIFF
--- a/src/concat/mod.rs
+++ b/src/concat/mod.rs
@@ -169,7 +169,7 @@ impl BroCatli {
             window_size: buffer[11],
             new_stream_pending,
         };
-        if ret.last_bytes.len() > 8 {
+        if usize::from(ret.last_bytes_len) > ret.last_bytes.len() {
             return Err(());
         }
         let xlen = ret.last_bytes.len();
@@ -668,6 +668,7 @@ mod test {
         for (index, item) in buffer.iter_mut().enumerate() {
             *item = index as u8;
         }
+        buffer[8] = 2;
         broccoli = BroCatli::deserialize_from_buffer(&buffer).unwrap();
         broccoli.serialize_to_buffer(&mut buffer2[..]).unwrap();
         broccoli = BroCatli::deserialize_from_buffer(&buffer2).unwrap();
@@ -679,6 +680,7 @@ mod test {
         for (index, item) in buffer.iter_mut().enumerate() {
             *item = 0xff ^ index as u8;
         }
+        buffer[8] = 2;
         broccoli = BroCatli::deserialize_from_buffer(&buffer).unwrap();
         broccoli.serialize_to_buffer(&mut buffer2[..]).unwrap();
         broccoli = BroCatli::deserialize_from_buffer(&buffer2).unwrap();
@@ -687,6 +689,12 @@ mod test {
         }
         broccoli.serialize_to_buffer(&mut buffer[..]).unwrap();
         assert_eq!(&buffer[..], &buffer2[..]);
+    }
+    #[test]
+    fn test_deserialization_rejects_invalid_last_bytes_len() {
+        let mut buffer = [0u8; 248];
+        buffer[8] = 3;
+        assert!(BroCatli::deserialize_from_buffer(&buffer[..]).is_err());
     }
     #[test]
     fn test_cat_empty_stream() {


### PR DESCRIPTION
Fixes #246.

`BroCatli::deserialize_from_buffer` checked `ret.last_bytes.len() > 8`, but `last_bytes` is a fixed `[u8; 2]`, so the check was constant-false. This PR validates the deserialized `last_bytes_len` field instead and returns the existing `Err(())` for invalid serialized state.

The public API is unchanged. A regression test covers `last_bytes_len > last_bytes.len()`.