### PR TITLE
Catch panics in Broccoli FFI exports

### DIFF
--- a/src/ffi/broccoli.rs
+++ b/src/ffi/broccoli.rs
@@ -1,4 +1,8 @@
 use core;
+#[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
+use std::io::Write;
+#[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
+use std::{io, panic, thread};
 
 pub use brotli_decompressor::ffi::interface::c_void;
 use brotli_decompressor::ffi::{slice_from_raw_parts_or_nil, slice_from_raw_parts_or_nil_mut};
@@ -64,9 +68,14 @@ pub extern "C" fn BroccoliDestroyInstance(_state: BroccoliState) {}
 
 #[no_mangle]
 pub unsafe extern "C" fn BroccoliNewBrotliFile(state: *mut BroccoliState) {
-    let mut bro_catli: BroCatli = (*state).into();
-    bro_catli.new_brotli_file();
-    *state = BroccoliState::from(bro_catli);
+    if let Err(panic_err) = catch_panic(|| {
+        let mut bro_catli: BroCatli = (*state).into();
+        bro_catli.new_brotli_file();
+        *state = BroccoliState::from(bro_catli);
+        BroCatliResult::Success
+    }) {
+        error_print(panic_err);
+    }
 }
 
 #[no_mangle]
@@ -77,18 +86,24 @@ pub unsafe extern "C" fn BroccoliConcatStream(
     available_out: *mut usize,
     output_buf_ptr: *mut *mut u8,
 ) -> BroccoliResult {
-    let input_buf = slice_from_raw_parts_or_nil(*input_buf_ptr, *available_in);
-    let output_buf = slice_from_raw_parts_or_nil_mut(*output_buf_ptr, *available_out);
-    let mut input_offset = 0usize;
-    let mut output_offset = 0usize;
-    let mut bro_catli: BroCatli = (*state).into();
-    let ret = bro_catli.stream(input_buf, &mut input_offset, output_buf, &mut output_offset);
-    *input_buf_ptr = (*input_buf_ptr).add(input_offset);
-    *output_buf_ptr = (*output_buf_ptr).add(output_offset);
-    *available_in -= input_offset;
-    *available_out -= output_offset;
-    *state = BroccoliState::from(bro_catli);
-    ret
+    catch_panic(|| {
+        let input_buf = slice_from_raw_parts_or_nil(*input_buf_ptr, *available_in);
+        let output_buf = slice_from_raw_parts_or_nil_mut(*output_buf_ptr, *available_out);
+        let mut input_offset = 0usize;
+        let mut output_offset = 0usize;
+        let mut bro_catli: BroCatli = (*state).into();
+        let ret = bro_catli.stream(input_buf, &mut input_offset, output_buf, &mut output_offset);
+        *input_buf_ptr = (*input_buf_ptr).add(input_offset);
+        *output_buf_ptr = (*output_buf_ptr).add(output_offset);
+        *available_in -= input_offset;
+        *available_out -= output_offset;
+        *state = BroccoliState::from(bro_catli);
+        ret
+    })
+    .unwrap_or_else(|panic_err| {
+        error_print(panic_err);
+        BroCatliResult::BrotliFileNotCraftedForConcatenation
+    })
 }
 
 #[no_mangle]
@@ -99,13 +114,19 @@ pub unsafe extern "C" fn BroccoliConcatStreaming(
     available_out: *mut usize,
     mut output_buf: *mut u8,
 ) -> BroccoliResult {
-    BroccoliConcatStream(
-        state,
-        available_in,
-        &mut input_buf,
-        available_out,
-        &mut output_buf,
-    )
+    catch_panic(|| {
+        BroccoliConcatStream(
+            state,
+            available_in,
+            &mut input_buf,
+            available_out,
+            &mut output_buf,
+        )
+    })
+    .unwrap_or_else(|panic_err| {
+        error_print(panic_err);
+        BroCatliResult::BrotliFileNotCraftedForConcatenation
+    })
 }
 
 #[no_mangle]
@@ -114,14 +135,20 @@ pub unsafe extern "C" fn BroccoliConcatFinish(
     available_out: *mut usize,
     output_buf_ptr: *mut *mut u8,
 ) -> BroCatliResult {
-    let output_buf = slice_from_raw_parts_or_nil_mut(*output_buf_ptr, *available_out);
-    let mut output_offset = 0usize;
-    let mut bro_catli: BroCatli = (*state).into();
-    let ret = bro_catli.finish(output_buf, &mut output_offset);
-    *output_buf_ptr = (*output_buf_ptr).add(output_offset);
-    *available_out -= output_offset;
-    *state = BroccoliState::from(bro_catli);
-    ret
+    catch_panic(|| {
+        let output_buf = slice_from_raw_parts_or_nil_mut(*output_buf_ptr, *available_out);
+        let mut output_offset = 0usize;
+        let mut bro_catli: BroCatli = (*state).into();
+        let ret = bro_catli.finish(output_buf, &mut output_offset);
+        *output_buf_ptr = (*output_buf_ptr).add(output_offset);
+        *available_out -= output_offset;
+        *state = BroccoliState::from(bro_catli);
+        ret
+    })
+    .unwrap_or_else(|panic_err| {
+        error_print(panic_err);
+        BroCatliResult::BrotliFileNotCraftedForConcatenation
+    })
 }
 
 // exactly the same as BrotliConcatFinish but without the indirect
@@ -131,13 +158,79 @@ pub unsafe extern "C" fn BroccoliConcatFinished(
     available_out: *mut usize,
     mut output_buf: *mut u8,
 ) -> BroCatliResult {
-    BroccoliConcatFinish(state, available_out, &mut output_buf)
+    catch_panic(|| BroccoliConcatFinish(state, available_out, &mut output_buf)).unwrap_or_else(
+        |panic_err| {
+            error_print(panic_err);
+            BroCatliResult::BrotliFileNotCraftedForConcatenation
+        },
+    )
 }
+
+#[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
+fn catch_panic<F: FnOnce() -> BroccoliResult>(f: F) -> thread::Result<BroccoliResult> {
+    panic::catch_unwind(panic::AssertUnwindSafe(f))
+}
+
+// can't catch panics in a reliable way without std:: configure with panic=abort. These shouldn't happen
+#[cfg(any(not(feature = "std"), feature = "pass-through-ffi-panics"))]
+fn catch_panic<F: FnOnce() -> BroccoliResult>(f: F) -> Result<BroccoliResult, ()> {
+    Ok(f())
+}
+
+#[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
+fn error_print<Err: core::fmt::Debug>(err: Err) {
+    let _ign = writeln!(&mut io::stderr(), "Internal Error {:?}", err);
+}
+
+#[cfg(any(not(feature = "std"), feature = "pass-through-ffi-panics"))]
+fn error_print<Err>(_err: Err) {}
 
 #[cfg(test)]
 mod test {
     #[test]
     fn test_create_instance_with_invalid_window_size_does_not_panic() {
         let _ = super::BroccoliCreateInstanceWithWindowSize(5);
+    }
+
+    #[cfg(all(feature = "std", not(feature = "pass-through-ffi-panics")))]
+    #[test]
+    fn test_concat_stream_panic_returns_error() {
+        let mut state: super::BroccoliState = super::BroccoliCreateInstanceWithWindowSize(22);
+        let empty_catable = [b';'];
+        let mut input_buf = empty_catable.as_ptr();
+        let mut available_in = empty_catable.len();
+        let mut output = [0u8; 32];
+        let mut output_buf = output.as_mut_ptr();
+        let mut available_out = output.len();
+        let mut result = unsafe {
+            super::BroccoliConcatStream(
+                &mut state,
+                &mut available_in,
+                &mut input_buf,
+                &mut available_out,
+                &mut output_buf,
+            )
+        };
+        assert_eq!(result, super::BroccoliResult::NeedsMoreInput);
+
+        unsafe { super::BroccoliNewBrotliFile(&mut state) };
+        let truncated_metadata = [0x71, 0x1b, 0, 0];
+        input_buf = truncated_metadata.as_ptr();
+        available_in = truncated_metadata.len();
+        output_buf = output.as_mut_ptr();
+        available_out = output.len();
+        result = unsafe {
+            super::BroccoliConcatStream(
+                &mut state,
+                &mut available_in,
+                &mut input_buf,
+                &mut available_out,
+                &mut output_buf,
+            )
+        };
+        assert_eq!(
+            result,
+            super::BroccoliResult::BrotliFileNotCraftedForConcatenation
+        );
     }
 }


### PR DESCRIPTION
Fixes #248.

The Broccoli concat FFI exports called directly into Rust concat code without the panic-catching wrapper pattern used by the encoder FFI exports. If a panic occurred while processing caller-provided state or stream bytes, it could unwind across the `extern "C"` boundary.

This change adds a local Broccoli panic-catching helper and wraps the mutable Broccoli FFI entry points:

- `BroccoliNewBrotliFile`
- `BroccoliConcatStream`
- `BroccoliConcatStreaming`
- `BroccoliConcatFinish`
- `BroccoliConcatFinished`

When `std` panic catching is available and `pass-through-ffi-panics` is not enabled, caught panics are converted into the existing `BroCatliResult::BrotliFileNotCraftedForConcatenation` error for result-returning APIs. `BroccoliNewBrotliFile` has no return value, so it catches and logs consistently with the other wrappers.

For `no_std` and `pass-through-ffi-panics` builds, behavior remains pass-through, matching the existing encoder FFI helper pattern.

This does not change the public C ABI or add new result variants. It also does not replace the parser-side fix for malformed stream headers; it only ensures unexpected Rust panics do not cross the C ABI boundary when panic catching is available.

A regression test covers a crafted Broccoli stream input that previously panicked through `BroccoliConcatStream` and now returns `BrotliFileNotCraftedForConcatenation`.