### PR TITLE
Handle NULL returns from custom encoder allocators

### DIFF
--- a/src/ffi/compressor.rs
+++ b/src/ffi/compressor.rs
@@ -94,6 +94,9 @@ pub unsafe extern "C" fn BrotliEncoderCreateInstance(
                 allocators.opaque,
                 core::mem::size_of::<BrotliEncoderState>(),
             );
+            if ptr.is_null() {
+                return core::ptr::null_mut();
+            }
             let brotli_decoder_state_ptr =
                 core::mem::transmute::<*mut c_void, *mut BrotliEncoderState>(ptr);
             core::ptr::write(brotli_decoder_state_ptr, to_box);
@@ -445,3 +448,26 @@ fn catch_panic_cstate<F: FnOnce() -> *mut BrotliEncoderState>(
 
 #[cfg(any(not(feature = "std"), feature = "pass-through-ffi-panics"))]
 fn error_print<Err>(_err: Err) {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    extern "C" fn failing_alloc(_opaque: *mut c_void, _size: usize) -> *mut c_void {
+        core::ptr::null_mut()
+    }
+
+    extern "C" fn failing_free(_opaque: *mut c_void, _address: *mut c_void) {}
+
+    #[test]
+    fn test_create_instance_returns_null_on_allocator_failure() {
+        let state = unsafe {
+            BrotliEncoderCreateInstance(
+                Some(failing_alloc),
+                Some(failing_free),
+                core::ptr::null_mut(),
+            )
+        };
+        assert!(state.is_null());
+    }
+}

--- a/src/ffi/multicompress/mod.rs
+++ b/src/ffi/multicompress/mod.rs
@@ -261,6 +261,9 @@ pub unsafe extern "C" fn BrotliEncoderCreateWorkPool(
                 allocators.opaque,
                 core::mem::size_of::<BrotliEncoderWorkPool>(),
             );
+            if ptr.is_null() {
+                return core::ptr::null_mut();
+            }
             let brotli_work_pool_ptr =
                 core::mem::transmute::<*mut c_void, *mut BrotliEncoderWorkPool>(ptr);
             core::ptr::write(brotli_work_pool_ptr, to_box);

--- a/src/ffi/multicompress/test.rs
+++ b/src/ffi/multicompress/test.rs
@@ -6,6 +6,25 @@ use core;
 use super::*;
 use crate::enc::encode::BrotliEncoderParameter;
 
+extern "C" fn failing_alloc(_opaque: *mut c_void, _size: usize) -> *mut c_void {
+    core::ptr::null_mut()
+}
+
+extern "C" fn failing_free(_opaque: *mut c_void, _address: *mut c_void) {}
+
+#[test]
+fn test_create_work_pool_returns_null_on_allocator_failure() {
+    let wp = unsafe {
+        BrotliEncoderCreateWorkPool(
+            8,
+            Some(failing_alloc),
+            Some(failing_free),
+            core::ptr::null_mut(),
+        )
+    };
+    assert!(wp.is_null());
+}
+
 #[test]
 fn test_compress_workpool() {
     let input = [


### PR DESCRIPTION
Fixes #249.

`BrotliEncoderCreateInstance` and `BrotliEncoderCreateWorkPool` accept caller-provided allocator callbacks. If a custom `alloc_func` returned `NULL`, both constructors transmuted that pointer and wrote the encoder state into it with `core::ptr::write`, causing a null-pointer write instead of reporting allocation failure to the caller.

This change checks the allocator result before writing the constructed state:

- `BrotliEncoderCreateInstance` now returns `NULL` if the custom allocator returns `NULL`.
- `BrotliEncoderCreateWorkPool` now returns `NULL` if the custom allocator returns `NULL`.

The public C ABI is unchanged. Returning `NULL` from these constructors is consistent with the expected C-style allocation failure behavior and with the existing destroy paths accepting null state pointers.

Focused FFI tests cover failing custom allocators for both constructor paths.