### PR TITLE
Fix index out of bounds under the disallow_large_window_size feature

### DIFF
--- a/src/enc/constants.rs
+++ b/src/enc/constants.rs
@@ -104,7 +104,10 @@ static kContextLookup: [u8; 2048] = [
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7,
 ];
+#[cfg(not(feature = "disallow_large_window_size"))]
 pub const BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS: usize = 544;
+#[cfg(feature = "disallow_large_window_size")]
+pub const BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS: usize = 520;
 pub const BROTLI_NUM_LITERAL_SYMBOLS: usize = 256;
 pub const BROTLI_NUM_COMMAND_SYMBOLS: usize = 704;
 pub const BROTLI_WINDOW_GAP: usize = 16;

--- a/src/enc/histogram.rs
+++ b/src/enc/histogram.rs
@@ -5,7 +5,9 @@ use super::super::alloc;
 use super::super::alloc::{SliceWrapper, SliceWrapperMut};
 use super::block_split::BlockSplit;
 use super::command::Command;
-use super::constants::{kSigned3BitContextLookup, kUTF8ContextLookup};
+use super::constants::{
+    kSigned3BitContextLookup, kUTF8ContextLookup, BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS,
+};
 use super::util::floatX;
 use super::vectorization::Mem256i;
 
@@ -62,11 +64,6 @@ impl Default for HistogramCommand {
     }
 }
 //#[derive(Clone)] // #derive is broken for arrays > 32
-
-#[cfg(not(feature = "disallow_large_window_size"))]
-const BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS: usize = 544;
-#[cfg(feature = "disallow_large_window_size")]
-const BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS: usize = 520;
 
 pub struct HistogramDistance {
     pub data_: [u32; BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS],


### PR DESCRIPTION
`cargo test --features disallow_large_window_size` panics in `BrotliOptimizeHuffmanCountsForRle` with `index out of bounds: the len is 520 but the index is 520` (`integration_tests::test_ukkonooa`), and so does compressing ordinary text with that feature on.

`BROTLI_NUM_HISTOGRAM_DISTANCE_SYMBOLS` was defined twice: `pub` and unconditionally 544 in `enc/constants.rs`, and privately in `enc/histogram.rs`, where only that copy shrank to 520 under the feature. `HistogramDistance::data_` took the private value while every bound took the public one.

This keeps one feature-aware definition in `constants.rs` and imports it from `histogram.rs`. The default build still reads 544.

Tests: `cargo test --features disallow_large_window_size` now passes (42 + 101). `cargo fmt --check`, `cargo test`, `cargo test --doc` and `cargo test --features portable-float` pass as before.
