### PR TITLE
brotli CLI: accept -bare and -bytealign with -catable, exit 1 when rejected

### DIFF
--- a/src/bin/brotli.rs
+++ b/src/bin/brotli.rs
@@ -852,13 +852,15 @@ fn main() {
             }
             panic!("Unknown Argument {:}", argument);
         }
-        if params.bare_stream && !params.appendable {
+        // -catable implies -appendable, but SanitizeParams only derives that later
+        let concatenable = params.appendable || params.catable;
+        if params.bare_stream && !concatenable {
             println_stderr!("bare streams only supported when catable or appendable!");
-            return;
+            std::process::exit(1);
         }
-        if params.byte_align && !params.appendable {
+        if params.byte_align && !concatenable {
             println_stderr!("byte aligned streams only supported when catable or appendable!");
-            return;
+            std::process::exit(1);
         }
         if filenames[0] != "" {
             let mut input = match File::open(Path::new(&filenames[0])) {


### PR DESCRIPTION
The README's concatenation recipe is `brotli -c -bare -catable -w22 file`, but the CLI rejected it: the `-bare` and `-bytealign` guards test `appendable` alone, and `-catable` only implies `appendable` once `SanitizeParams` runs, after the guards. The rejection also `return`ed from `main`, so the process printed "bare streams only supported when catable or appendable!", wrote nothing and exited 0. A shell pipeline collected an empty part and the combined stream decoded to the first input alone.

`-bare -catable` and `-bytealign -catable` are now accepted, matching the message and the README, and the rejection exits 1. `-bare` or `-bytealign` without either prerequisite is still refused.

Tests: `cargo fmt --check`, `cargo test`, `cargo test --doc` and `cargo test --features portable-float` pass. On `testdata/ukkonooa`, `-bare -catable`, `-bare -appendable` and `-bytealign -catable` now emit 85, 82 and 86 bytes; `-bare` alone exits 1.
